### PR TITLE
Add MIPS syntax highlighting to the Code Editor via KSyntaxHighlighting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,11 @@ jobs:
           ninja-build qt6-base-dev qt6-base-private-dev qt6-declarative-dev
           llvm-dev zlib1g-dev
 
+      # Only packaged from Ubuntu 25.10 on; the Code Editor falls back to
+      # plain text when the CMake find_package comes up empty.
+      - name: Install KSyntaxHighlighting (optional)
+        run: sudo apt-get install -y libkf6syntaxhighlighting-dev || true
+
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,20 @@ if(BUILD_QT6_UI)
             QHexView
             clearcore_warnings
     )
+
+    # Optional: KSyntaxHighlighting (MIT since KF 5.50) gives the Code Editor
+    # real MIPS assembly highlighting using Kate's syntax definitions.
+    # System package: kf6-syntax-highlighting-devel (Fedora) or
+    # libkf6syntaxhighlighting-dev (Ubuntu >= 25.10). Without it the editor
+    # is plain text, exactly as before.
+    find_package(KF6SyntaxHighlighting QUIET)
+    if(KF6SyntaxHighlighting_FOUND)
+        message(STATUS "KSyntaxHighlighting found: Code Editor gets MIPS syntax highlighting")
+        target_link_libraries(clearCore-gui PRIVATE KF6::SyntaxHighlighting)
+        target_compile_definitions(clearCore-gui PRIVATE HAVE_KSYNTAXHIGHLIGHTING)
+    else()
+        message(STATUS "KSyntaxHighlighting not found: Code Editor stays plain text")
+    endif()
 else()
     message(STATUS "Qt6 GUI disabled (set -DBUILD_QT6_UI=ON to enable)")
 endif()

--- a/include/nsc_qt/widgets/code_editor.h
+++ b/include/nsc_qt/widgets/code_editor.h
@@ -5,6 +5,12 @@
 class QPaintEvent;
 class QResizeEvent;
 
+#ifdef HAVE_KSYNTAXHIGHLIGHTING
+namespace KSyntaxHighlighting {
+class SyntaxHighlighter;
+}
+#endif
+
 namespace nsc::qt {
 
 class LineNumberArea;
@@ -36,6 +42,12 @@ private slots:
 private:
     QWidget* line_number_area_ = nullptr;
     bool     dark_mode_        = false;
+
+#ifdef HAVE_KSYNTAXHIGHLIGHTING
+    // MIPS assembly highlighting via KSyntaxHighlighting (optional dependency;
+    // without it the editor is plain text). Owned by the document.
+    KSyntaxHighlighting::SyntaxHighlighter* highlighter_ = nullptr;
+#endif
 };
 
 // The gutter widget itself. All painting is delegated back to CodeEditor,

--- a/src/nsc_qt/widgets/code_editor.cpp
+++ b/src/nsc_qt/widgets/code_editor.cpp
@@ -4,7 +4,23 @@
 #include <QPainter>
 #include <QTextBlock>
 
+#ifdef HAVE_KSYNTAXHIGHLIGHTING
+#include <KSyntaxHighlighting/Definition>
+#include <KSyntaxHighlighting/Repository>
+#include <KSyntaxHighlighting/SyntaxHighlighter>
+#include <KSyntaxHighlighting/Theme>
+#endif
+
 namespace nsc::qt {
+
+#ifdef HAVE_KSYNTAXHIGHLIGHTING
+// One repository for the whole app: loading the syntax definitions is not
+// free, and Definition handles stay valid as long as the repository lives.
+static KSyntaxHighlighting::Repository& syntaxRepository() {
+    static KSyntaxHighlighting::Repository repo;
+    return repo;
+}
+#endif
 
 CodeEditor::CodeEditor(QWidget* parent) : QPlainTextEdit(parent) {
     line_number_area_ = new LineNumberArea(this);
@@ -12,6 +28,15 @@ CodeEditor::CodeEditor(QWidget* parent) : QPlainTextEdit(parent) {
     connect(this, &QPlainTextEdit::blockCountChanged, this, &CodeEditor::updateLineNumberAreaWidth);
     connect(this, &QPlainTextEdit::updateRequest, this, &CodeEditor::updateLineNumberArea);
     connect(this, &QPlainTextEdit::cursorPositionChanged, this, &CodeEditor::highlightCurrentLine);
+
+#ifdef HAVE_KSYNTAXHIGHLIGHTING
+    auto& repo   = syntaxRepository();
+    highlighter_ = new KSyntaxHighlighting::SyntaxHighlighter(document());
+    auto def     = repo.definitionForName(QStringLiteral("MIPS Assembler"));
+    if (!def.isValid()) def = repo.definitionForName(QStringLiteral("GNU Assembler"));
+    highlighter_->setDefinition(def);
+    highlighter_->setTheme(repo.defaultTheme(KSyntaxHighlighting::Repository::LightTheme));
+#endif
 
     updateLineNumberAreaWidth(0);
     highlightCurrentLine();
@@ -95,6 +120,12 @@ void CodeEditor::lineNumberAreaPaintEvent(QPaintEvent* event) {
 
 void CodeEditor::setDarkMode(bool dark) {
     dark_mode_ = dark;
+#ifdef HAVE_KSYNTAXHIGHLIGHTING
+    auto& repo = syntaxRepository();
+    highlighter_->setTheme(repo.defaultTheme(dark ? KSyntaxHighlighting::Repository::DarkTheme
+                                                  : KSyntaxHighlighting::Repository::LightTheme));
+    highlighter_->rehighlight();
+#endif
     highlightCurrentLine();
     line_number_area_->update();
 }


### PR DESCRIPTION
KSyntaxHighlighting (KDE framework, MIT since KF 5.50) is an optional system dependency: when CMake finds KF6SyntaxHighlighting, the editor attaches Kate's 'MIPS Assembler' definition (GNU Assembler fallback) with light/dark themes tracking the app preference. Without the package the editor compiles to exactly the previous plain-text behaviour, so no platform is broken.

Packages: kf6-syntax-highlighting-devel (Fedora),
libkf6syntaxhighlighting-dev (Ubuntu >= 25.10 — CI installs it tolerantly since ubuntu-latest may predate it).

## Summary by Sourcery

Add optional MIPS assembly syntax highlighting to the Qt code editor using KSyntaxHighlighting when available, while preserving plain-text behavior otherwise.

New Features:
- Enable MIPS (with GNU Assembler fallback) syntax highlighting in the Qt code editor via KSyntaxHighlighting when the optional dependency is present.

Enhancements:
- Make the editor’s syntax highlighting theme follow the application’s light/dark mode setting.
- Introduce a shared KSyntaxHighlighting repository instance for efficient reuse across the application.

Build:
- Add optional CMake integration with KF6SyntaxHighlighting, wiring it into the Qt GUI target only when found.

CI:
- Update GitHub Actions workflow to install the KSyntaxHighlighting development package on Ubuntu when available.