### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# All files
+* @khenderson20
+
+# Qt GUI specifically
+nsc_qt/** @khenderson20
+src/emulator/** @khenderson20
+
+# CI workflows
+.github/workflows/** @khenderson20


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Introduce a CODEOWNERS file under .github to define default code ownership for the repository.