### PR TITLE
Prepare v0.0.1 stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 project(clearCore
-        VERSION 0.1.0
+        VERSION 0.0.1
         LANGUAGES CXX C  # C may be needed by some dependencies
         DESCRIPTION "Educational MIPS CPU emulator with pipeline visualization"
 )

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -36,6 +36,8 @@
 #include <QToolBar>
 #include <QVBoxLayout>
 #include <array>
+#include <string>
+#include <utility>
 
 #include <DockAreaWidget.h>
 #include <DockManager.h>
@@ -141,7 +143,7 @@ void MainWindow::setupCentralWidget() {
 
     ads::CDockAreaWidget* area      = nullptr;
     const auto            add_panel = [&](const QString& title, QWidget* contents) {
-        auto* dock = new ads::CDockWidget(title);  // objectName = title (saveState key)
+        auto* dock = new ads::CDockWidget(dock_manager_, title);
         dock->setWidget(contents);
         if (area == nullptr)
             area = dock_manager_->addDockWidget(ads::CenterDockWidgetArea, dock);

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -144,7 +144,7 @@ void MainWindow::setupCentralWidget() {
     ads::CDockAreaWidget* area      = nullptr;
     const auto            add_panel = [&](const QString& title, QWidget* contents) {
         auto* dock = new ads::CDockWidget(dock_manager_, title);
-        dock->setWidget(contents);
+        dock->setObjectName(title);
         if (area == nullptr)
             area = dock_manager_->addDockWidget(ads::CenterDockWidgetArea, dock);
         else


### PR DESCRIPTION
- Bump project version to 0.0.1
- Fix deprecated CDockWidget constructor (pass manager as first arg)
- Add missing <string> and <utility> includes to main_window.cpp
- Extend CI triggers to include the develop branch

## Summary by Sourcery

Prepare the codebase and workflows for the 0.0.1 stable release.

Bug Fixes:
- Update dock widget construction to use the non-deprecated constructor signature.

Enhancements:
- Add missing standard library includes to the Qt main window implementation for cleaner builds.

Build:
- Set the project version to 0.0.1 in CMake for the upcoming stable release.

CI:
- Extend CI workflow triggers to run on both main and develop branches.