### PR TITLE
Add ClusterFuzzLite fuzzing harness

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder:v1
+RUN apt-get update && apt-get install -y cmake ninja-build
+COPY . $SRC/clearCore
+COPY .clusterfuzzlite/build.sh $SRC/
+WORKDIR $SRC/clearCore

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -euo pipefail
 
 cmake -S "$SRC/clearCore" -B build -G Ninja \
     -DCMAKE_C_COMPILER="$CC" \

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -9,6 +9,7 @@ cmake -S "$SRC/clearCore" -B build -G Ninja \
     -DBUILD_QT6_UI=OFF \
     -DBUILD_QT6_QUICK_UI=OFF \
     -DCMAKE_BUILD_TYPE=Release \
+    -DSPDLOG_USE_STD_FORMAT=ON \
     -DFUZZING_ENGINE="$LIB_FUZZING_ENGINE"
 
 cmake --build build --target fuzz_hex_loader -j"$(nproc)"

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eu
+
+cmake -S "$SRC/clearCore" -B build -G Ninja \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DBUILD_NYXSTONE=OFF \
+    -DBUILD_QT6_UI=OFF \
+    -DBUILD_QT6_QUICK_UI=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DFUZZING_ENGINE="$LIB_FUZZING_ENGINE"
+
+cmake --build build --target fuzz_hex_loader -j"$(nproc)"
+
+cp build/fuzz_hex_loader "$OUT/"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://github.com/khenderson20/clearCore"
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,11 @@ name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
     branches: [main, develop]
-permissions: read-all
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+  security-events: write
 jobs:
   PR:
     runs-on: ubuntu-latest

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,23 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  pull_request:
+    branches: [main, develop]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build Fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: c++
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 120
+          mode: 'code-change'
+          output-sarif: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,25 @@ FetchContent_Declare(GSL
         GIT_SHALLOW ON
 )
 
+# fmt — formatting library (MIT); fetched first so spdlog uses it instead of
+# its bundled copy. This avoids consteval failures in spdlog's fmt_helper.h
+# under Clang 22+ (seen in the ClusterFuzzLite base-builder image).
+FetchContent_Declare(fmt
+        GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
+        GIT_TAG "11.0.2"
+        GIT_SHALLOW ON
+)
+FetchContent_MakeAvailable(fmt)
+
 # spdlog — fast structured logging (MIT), https://github.com/gabime/spdlog
 # Used for instruction tracing, pipeline/hazard events, and memory access logs.
+# SPDLOG_FMT_EXTERNAL makes it use the fmt target above instead of its bundled
+# copy, which is required for Clang 22+ compatibility.
+set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
+set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+
 FetchContent_Declare(spdlog
         GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
         GIT_TAG "v1.14.1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,22 @@ if (GOLDEN_TESTS)
 endif ()
 
 # ============================================================================
+# FUZZ TARGETS  (ClusterFuzzLite / libFuzzer)
+# ============================================================================
+#
+# Pass -DFUZZING_ENGINE=<engine> at configure time to build fuzz harnesses.
+# The ClusterFuzzLite build.sh sets this from the $LIB_FUZZING_ENGINE env var
+# injected by the base-builder image (e.g. /usr/lib/libFuzzer.a or
+# -fsanitize=fuzzer). Not built in normal developer or CI builds.
+#
+if (FUZZING_ENGINE)
+    add_executable(fuzz_hex_loader tests/fuzz/fuzz_hex_loader.cpp)
+    target_link_libraries(fuzz_hex_loader PRIVATE mips_core ${FUZZING_ENGINE})
+    target_compile_features(fuzz_hex_loader PUBLIC cxx_std_20)
+    message(STATUS "Fuzz targets enabled (engine: ${FUZZING_ENGINE})")
+endif ()
+
+# ============================================================================
 # BUILD SUMMARY
 # ============================================================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,21 +83,11 @@ FetchContent_Declare(GSL
         GIT_SHALLOW ON
 )
 
-# fmt — formatting library (MIT); fetched first so spdlog uses it instead of
-# its bundled copy. This avoids consteval failures in spdlog's fmt_helper.h
-# under Clang 22+ (seen in the ClusterFuzzLite base-builder image).
-FetchContent_Declare(fmt
-        GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
-        GIT_TAG "12.2.0"
-        GIT_SHALLOW ON
-)
-FetchContent_MakeAvailable(fmt)
-
 # spdlog — fast structured logging (MIT), https://github.com/gabime/spdlog
 # Used for instruction tracing, pipeline/hazard events, and memory access logs.
-# SPDLOG_FMT_EXTERNAL makes it use the fmt target above instead of its bundled
-# copy, which is required for Clang 22+ compatibility.
-set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
+# Uses spdlog's bundled fmt copy to avoid cross-version API mismatches.
+# The ClusterFuzzLite fuzz build overrides this with SPDLOG_USE_STD_FORMAT=ON
+# so Clang 22+ uses C++20 <format> instead, sidestepping fmt entirely.
 set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ FetchContent_Declare(GSL
 # under Clang 22+ (seen in the ClusterFuzzLite base-builder image).
 FetchContent_Declare(fmt
         GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
-        GIT_TAG "11.0.2"
+        GIT_TAG "12.2.0"
         GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(fmt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,7 +536,7 @@ endif ()
 #
 if (FUZZING_ENGINE)
     add_executable(fuzz_hex_loader tests/fuzz/fuzz_hex_loader.cpp)
-    target_link_libraries(fuzz_hex_loader PRIVATE mips_core ${FUZZING_ENGINE})
+    target_link_libraries(fuzz_hex_loader PRIVATE mips_core clearcore_warnings ${FUZZING_ENGINE})
     target_compile_features(fuzz_hex_loader PUBLIC cxx_std_20)
     message(STATUS "Fuzz targets enabled (engine: ${FUZZING_ENGINE})")
 endif ()

--- a/tests/fuzz/fuzz_hex_loader.cpp
+++ b/tests/fuzz/fuzz_hex_loader.cpp
@@ -1,0 +1,13 @@
+#include "mips/program_loader.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    std::istringstream in(std::string(reinterpret_cast<const char*>(data), size));
+    auto               result = mips::parse_hex_program(in);
+    (void)result;
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Adds `tests/fuzz/fuzz_hex_loader.cpp` — a libFuzzer harness targeting `mips::parse_hex_program`, the hand-rolled hex text parser that takes untrusted input
- Adds `.clusterfuzzlite/` (project.yaml, Dockerfile, build.sh) so ClusterFuzzLite can build and run the harness in CI
- Adds `.github/workflows/cflite_pr.yml` — runs 120 seconds of code-change fuzzing on every PR to `main`/`develop`
- Gates the `fuzz_hex_loader` CMake target on `-DFUZZING_ENGINE=<engine>` so normal developer and CI builds are completely unaffected

Closes security/code-scanning/22 (Scorecard: no fuzzing detected).

## Test plan

- [ ] Existing `ctest --preset core-only` still passes (19/19 — no fuzz target built)
- [ ] ClusterFuzzLite PR workflow triggers and builds the harness successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a libFuzzer-based fuzzing harness for the MIPS hex program loader and wire it into ClusterFuzzLite-driven CI fuzzing on pull requests.

New Features:
- Add a fuzzing harness targeting mips::parse_hex_program via a new fuzz_hex_loader executable.
- Enable ClusterFuzzLite PR fuzzing workflow that runs code-change fuzzing for C++ targets on main and develop branches.

Enhancements:
- Gate fuzz target builds behind a FUZZING_ENGINE CMake option to keep standard builds unaffected.
- Provide ClusterFuzzLite configuration, Dockerfile, and build script to build and run the fuzz harness in the OSS-Fuzz environment.

CI:
- Add a GitHub Actions workflow to build and run ClusterFuzzLite fuzzers for 120 seconds on each pull request to main and develop.