### PR TITLE
Add ClusterFuzzLite fuzzing harness (#8)

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder:v1
+RUN apt-get update && apt-get install -y cmake ninja-build
+COPY . $SRC/clearCore
+COPY .clusterfuzzlite/build.sh $SRC/
+WORKDIR $SRC/clearCore

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -euo pipefail
+
+cmake -S "$SRC/clearCore" -B build -G Ninja \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DBUILD_NYXSTONE=OFF \
+    -DBUILD_QT6_UI=OFF \
+    -DBUILD_QT6_QUICK_UI=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DSPDLOG_USE_STD_FORMAT=ON \
+    -DFUZZING_ENGINE="$LIB_FUZZING_ENGINE"
+
+cmake --build build --target fuzz_hex_loader -j"$(nproc)"
+
+cp build/fuzz_hex_loader "$OUT/"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://github.com/khenderson20/clearCore"
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,27 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  pull_request:
+    branches: [main, develop]
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+  security-events: write
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build Fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: c++
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 120
+          mode: 'code-change'
+          output-sarif: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,13 @@ FetchContent_Declare(GSL
 
 # spdlog — fast structured logging (MIT), https://github.com/gabime/spdlog
 # Used for instruction tracing, pipeline/hazard events, and memory access logs.
+# Uses spdlog's bundled fmt copy to avoid cross-version API mismatches.
+# The ClusterFuzzLite fuzz build overrides this with SPDLOG_USE_STD_FORMAT=ON
+# so Clang 22+ uses C++20 <format> instead, sidestepping fmt entirely.
+set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+
 FetchContent_Declare(spdlog
         GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
         GIT_TAG "v1.14.1"
@@ -523,6 +530,22 @@ if (GOLDEN_TESTS)
     else ()
         message(STATUS "GOLDEN_TESTS: Java runtime or Python3 not found — skipping")
     endif ()
+endif ()
+
+# ============================================================================
+# FUZZ TARGETS  (ClusterFuzzLite / libFuzzer)
+# ============================================================================
+#
+# Pass -DFUZZING_ENGINE=<engine> at configure time to build fuzz harnesses.
+# The ClusterFuzzLite build.sh sets this from the $LIB_FUZZING_ENGINE env var
+# injected by the base-builder image (e.g. /usr/lib/libFuzzer.a or
+# -fsanitize=fuzzer). Not built in normal developer or CI builds.
+#
+if (FUZZING_ENGINE)
+    add_executable(fuzz_hex_loader tests/fuzz/fuzz_hex_loader.cpp)
+    target_link_libraries(fuzz_hex_loader PRIVATE mips_core clearcore_warnings ${FUZZING_ENGINE})
+    target_compile_features(fuzz_hex_loader PUBLIC cxx_std_20)
+    message(STATUS "Fuzz targets enabled (engine: ${FUZZING_ENGINE})")
 endif ()
 
 # ============================================================================

--- a/tests/fuzz/fuzz_hex_loader.cpp
+++ b/tests/fuzz/fuzz_hex_loader.cpp
@@ -1,0 +1,13 @@
+#include "mips/program_loader.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    std::istringstream in(std::string(reinterpret_cast<const char*>(data), size));
+    auto               result = mips::parse_hex_program(in);
+    (void)result;
+    return 0;
+}


### PR DESCRIPTION
* Add ClusterFuzzLite harness for parse_hex_program

Addresses Scorecard fuzzing signal (security/code-scanning/22). Sets up:
- tests/fuzz/fuzz_hex_loader.cpp: LLVMFuzzerTestOneInput target
- .clusterfuzzlite/: project.yaml, Dockerfile, build.sh
- .github/workflows/cflite_pr.yml: 120s code-change fuzzing on PRs
- CMakeLists.txt: fuzz_hex_loader target gated on -DFUZZING_ENGINE=<engine>

Normal developer and CI builds are unaffected.



* Potential fix for pull request finding



* Update .clusterfuzzlite/build.sh



* Potential fix for pull request finding



* Fix spdlog compilation under Clang 22 in ClusterFuzzLite

Fetch fmt 11.0.2 as an external dependency and set SPDLOG_FMT_EXTERNAL=ON so spdlog uses it instead of its bundled copy. Eliminates consteval failures in spdlog/details/fmt_helper.h and spdlog/logger-inl.h under Clang 22+, which is the toolchain in the ClusterFuzzLite base-builder image.



* updated fmtlib/fmt.git version to 12.2.0

* Fix spdlog/fmt incompatibility in ClusterFuzzLite build

spdlog v1.14.1 with SPDLOG_FMT_EXTERNAL includes <fmt/core.h> expecting fmt::basic_format_string there, but fmt 11+ moved it to <fmt/format.h>, causing a compile error under Clang 22 in the base-builder image.

Remove the external fmt dependency entirely — spdlog uses its bundled copy for all normal and CI builds. For the ClusterFuzzLite fuzz build, pass -DSPDLOG_USE_STD_FORMAT=ON in build.sh so spdlog uses C++20 <format> via Clang 22 instead, bypassing fmt compatibility altogether.



---------

## Summary by Sourcery

Add a ClusterFuzzLite-based fuzzing setup for the hex program loader and integrate it into CI while keeping normal builds unchanged.

New Features:
- Introduce a fuzzing harness for mips::parse_hex_program via an LLVMFuzzerTestOneInput target.
- Add ClusterFuzzLite configuration, Dockerfile, and build script to build and run fuzzers against the project.

Enhancements:
- Extend CMake configuration with an optional fuzz_hex_loader target gated on a FUZZING_ENGINE parameter and using C++20.
- Configure spdlog to avoid external fmt dependencies and support using C++20 std::format in the ClusterFuzzLite fuzz build.

CI:
- Add a GitHub Actions workflow to build and run ClusterFuzzLite fuzzers on pull requests with short code-change fuzzing runs.