### PR TITLE
Add CHANGELOG.md and release-drafter automation; update README and wi…

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,58 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Derive the next version from labels on merged PRs.
+# PR with the highest-priority label wins; default bump is patch.
+version-resolver:
+  major:
+    labels:
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'feature'
+  patch:
+    labels:
+      - 'enhancement'
+      - 'bug'
+      - 'security'
+      - 'documentation'
+      - 'dependencies'
+      - 'ci'
+  default: patch
+
+categories:
+  - title: '🚀 Added'
+    labels:
+      - 'feature'
+  - title: '🔄 Changed'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Fixed'
+    labels:
+      - 'bug'
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+  - title: '📖 Documentation'
+    labels:
+      - 'documentation'
+  - title: '⬆️ Dependencies'
+    labels:
+      - 'dependencies'
+  - title: '⚙️ CI / Internal'
+    labels:
+      - 'ci'
+
+# PRs with these labels are excluded from release notes entirely.
+exclude-labels:
+  - 'skip-changelog'
+
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog:** https://github.com/khenderson20/clearCore/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,28 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  # NOTE: release-drafter needs write permissions; running on fork PRs will fail due to read-only tokens.
+  # The push-to-main trigger below updates the draft release after merge, so a PR trigger is unnecessary.
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,92 @@
+name: Update CHANGELOG on release
+
+# Triggers when a GitHub Release is published (not a draft).
+# Converts the [Unreleased] section in CHANGELOG.md to the released version,
+# inserts a fresh [Unreleased] header, and commits back to develop.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09e4fc2bb41ae8fb3f8a3c5f2e5e3 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Promote [Unreleased] to versioned entry
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_DATE: ${{ github.event.release.published_at }}
+        run: |
+          python3 - <<'EOF'
+          import os, re
+
+          tag_raw = os.environ["RELEASE_TAG"]
+          tag     = tag_raw[1:] if tag_raw.startswith("v") else tag_raw
+          date    = os.environ["RELEASE_DATE"][:10]   # YYYY-MM-DD
+
+          with open("CHANGELOG.md", "r") as f:
+              content = f.read()
+
+          # Insert a fresh empty [Unreleased] section, then the released version heading.
+          # The existing Unreleased contents remain in-place and therefore become the body
+          # of the released entry.
+          new_section = (
+              "## [Unreleased]\n\n"
+              "---\n\n"
+              f"## [{tag}] - {date}\n\n"
+          )
+          python3 - <<'EOF'
+          import os, re, textwrap
+
+          tag   = os.environ["RELEASE_TAG"]
+          date  = os.environ["RELEASE_DATE"][:10]   # YYYY-MM-DD
+          body  = os.environ["RELEASE_BODY"].strip()
+
+          with open("CHANGELOG.md", "r") as f:
+              content = f.read()
+
+          # Replace the [Unreleased] heading with the new versioned heading.
+          # Also insert a blank [Unreleased] section above it for the next cycle.
+          new_section = (
+              "## [Unreleased]\n\n"
+              "---\n\n"
+              f"## [{tag}] - {date}\n\n"
+              f"{body}\n"
+          )
+
+          updated = re.sub(
+              r"## \[Unreleased\]",
+              new_section,
+              content,
+              count=1,
+          )
+
+          with open("CHANGELOG.md", "w") as f:
+              f.write(updated)
+
+          print(f"CHANGELOG.md promoted [Unreleased] → [{tag}] - {date}")
+          EOF
+
+      - name: Commit and push to develop
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: promote [Unreleased] to ${{ github.event.release.tag_name }} in CHANGELOG"
+          git push origin develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to clearCore are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **How this file stays current:** [release-drafter](https://github.com/release-drafter/release-drafter) collects
+> merged PR titles into a draft GitHub Release on every push to `main`. When a release is published, the
+> `update-changelog.yml` workflow promotes the `[Unreleased]` section to a versioned entry and commits back to
+> `develop` automatically. Label PRs with the categories below so they land in the right section.
+>
+> | Label            | CHANGELOG section  |
+> |------------------|--------------------|
+> | `feature`        | Added              |
+> | `enhancement`    | Changed            |
+> | `bug`            | Fixed              |
+> | `security`       | Security           |
+> | `documentation`  | Documentation      |
+> | `dependencies`   | Dependencies       |
+> | `ci`             | CI / Internal      |
+
+---
+
+## [Unreleased]
+
+### Added
+- ClusterFuzzLite libFuzzer harness (`tests/fuzz/fuzz_hex_loader.cpp`) targeting `mips::parse_hex_program`;
+  runs 120 s on every PR via `.github/workflows/cflite_pr.yml`. Addresses OpenSSF Scorecard fuzzing signal.
+  `fuzz_hex_loader` CMake target is gated on `-DFUZZING_ENGINE=<engine>` — normal builds are unaffected.
+  ClusterFuzzLite config lives in `.clusterfuzzlite/` (project.yaml, Dockerfile, build.sh). (#8, #9)
+
+### Fixed
+- Qt GUI: set each dock widget's `objectName` to its title for improved panel identification and debugging. (#7)
+
+### Documentation
+- Full README and wiki pass covering all changes introduced in PRs #2–#9: KSyntaxHighlighting, ClusterFuzzLite,
+  security hardening, v0.0.1 release, and CI workflow table. Added release badge, CHANGELOG, and
+  release-drafter automation.
+
+---
+
+## [0.0.1] - 2026-07-02
+
+First stable release. Establishes the full Qt6 desktop GUI alongside the FTXUI terminal UI, the dual-backend
+simulator core, MARS differential testing, coverage CI, and supply-chain hardening.
+
+### Added
+- Optional MIPS assembly syntax highlighting in the Qt6 Code Editor via
+  [KSyntaxHighlighting](https://invent.kde.org/frameworks/syntax-highlighting) (KDE framework, MIT since KF 5.50).
+  Attaches Kate's MIPS Assembler definition (GNU Assembler fallback) when the system package is found at configure
+  time; tracks the application light/dark theme preference. No impact on builds without the package. (#4)
+- `.github/CODEOWNERS` file defining default code ownership. (#5)
+
+### Changed
+- Bumped project version to `0.0.1` in `CMakeLists.txt`. (#6)
+- Extended CI workflow triggers to include the `develop` branch alongside `main`. (#6)
+
+### Fixed
+- `CDockWidget` construction updated to pass the dock manager as the first argument (deprecated signature removed). (#6)
+- Added missing `<string>` and `<utility>` includes to `src/nsc_qt/main_window.cpp` for cleaner builds. (#6)
+
+### Security
+- Pinned all third-party GitHub Actions to full-length commit SHAs across `ci.yml`, `codeql.yml`, and
+  `scorecard.yml`. (#3)
+- Added `step-security/harden-runner` to all CI jobs to audit outbound network calls and prevent credential
+  exfiltration. (#3)
+- Set default `GITHUB_TOKEN` permissions to `read-only` at repository level; per-job write overrides only where
+  required. (#3)
+- Added `dependency-review.yml` workflow: blocks PRs that introduce dependencies with known CVEs. (#3)
+- Extended `.pre-commit-config.yaml` with whitespace, YAML, secret-scanning, C++ linting, and Python linting
+  hooks. (#3)
+
+### Dependencies
+- Bumped `actions/checkout` v4 → v7. (#2)
+- Bumped `github/codeql-action` v3 → v4. (#2)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   <a href="https://scorecard.dev/viewer/?uri=github.com/khenderson20/clearCore">
     <img src="https://api.scorecard.dev/projects/github.com/khenderson20/clearCore/badge" alt="OpenSSF Scorecard">
   </a>
+  <a href="https://github.com/khenderson20/clearCore/releases/latest">
+    <img src="https://img.shields.io/github/v/release/khenderson20/clearCore?style=flat-square&label=release&color=268BD2" alt="Latest Release">
+  </a>
 </p>
 
 <p align="center">
@@ -96,7 +99,8 @@ program's execution trace.
 <td width="50%">
 
 **Code Editor** — accepts MIPS assembly source with labels, branches, and loops; assembles and loads directly into the
-simulator. No external toolchain required.
+simulator. No external toolchain required. Optional MIPS syntax highlighting (light/dark theme aware) when
+KSyntaxHighlighting is installed (`kf6-syntax-highlighting-devel` on Fedora, `libkf6syntaxhighlighting-dev` on Ubuntu).
 
 <img src="assets/screenshots/tab-05-codeEditor.png" alt="Code Editor tab showing a MIPS sum-loop program assembled and loaded">
 
@@ -255,7 +259,10 @@ ctest --preset asan     # same suites under AddressSanitizer + UBSan
 ```
 
 CI (GitHub Actions) runs core suites in Debug and ASan/UBSan configurations on every push and pull request.
-Static-analysis config lives in `.clang-tidy`; code style in `.clang-format`.
+Static-analysis config lives in `.clang-tidy`; code style in `.clang-format`. Additional workflows run on every PR:
+`dependency-review.yml` blocks vulnerable dependency introductions; `codeql.yml` runs CodeQL static analysis;
+`scorecard.yml` tracks supply-chain posture; and `cflite_pr.yml` runs 120 seconds of libFuzzer fuzzing via
+ClusterFuzzLite, targeting `mips::parse_hex_program` with the `fuzz_hex_loader` harness (`tests/fuzz/`).
 
 ---
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -110,6 +110,8 @@ Widget code never touches the CPU directly and never needs a mutex. `nsc_qt` als
 
 Beyond the five core CTest suites and the Qt smoke-test suite (see [Getting Started](Getting-Started)), `tests/golden/` runs **differential tests**: each `.asm` program in that directory is assembled and executed independently by MARS (a Java-based reference MIPS simulator) and by both clearCore CPU models via `golden_runner`, and the resulting register files are compared for an exact match. This is separate from — and a stronger correctness signal than — the polymorphic `IProcessor` contract tests, which only check the two clearCore backends against each other rather than against an external reference. Golden tests are skipped automatically if no JRE or Python 3 is available.
 
+**Fuzz testing**: `tests/fuzz/fuzz_hex_loader.cpp` is a libFuzzer harness targeting `mips::parse_hex_program`. It is not part of the normal CTest runs; it is built and exercised by the ClusterFuzzLite CI workflow (`.github/workflows/cflite_pr.yml`) on every PR. See [Contributing § Fuzzing](Contributing#fuzzing) for how to add new harnesses.
+
 ---
 
 ## Academic foundations

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -9,7 +9,17 @@
 5. Run `ctest --preset debug` (or `ctest --preset asan`) to verify all tests pass
 6. Open a pull request targeting the `develop` branch
 
-CI (`.github/workflows/ci.yml`) runs four jobs on every push and PR to `main`: a `clang-format` check, a coverage build uploaded to Codecov, a fast core-only test matrix (Debug and Debug+ASan/UBSan), and a full build exercising both Qt6 GUIs and Nyxstone. `codeql.yml`, `dependency-review.yml`, and `scorecard.yml` run supply-chain and static-analysis checks separately.
+CI (`.github/workflows/ci.yml`) runs four jobs on every push and PR to `main` or `develop`: a `clang-format` check, a coverage build uploaded to Codecov, a fast core-only test matrix (Debug and Debug+ASan/UBSan), and a full build exercising both Qt6 GUIs and Nyxstone. Additional workflows run on every PR:
+
+| Workflow                    | Purpose                                                                                  |
+|-----------------------------|-------------------------------------------------------------------------------------------|
+| `codeql.yml`                | CodeQL static analysis for C++                                                            |
+| `dependency-review.yml`     | Blocks PRs that introduce dependencies with known vulnerabilities                         |
+| `scorecard.yml`             | Tracks OpenSSF supply-chain posture (token permissions, pinned actions, etc.)             |
+| `cflite_pr.yml`             | Runs 120 seconds of libFuzzer fuzzing via ClusterFuzzLite on `fuzz_hex_loader` (see below) |
+| `wiki-sync.yml`             | Pushes `wiki/` to the GitHub wiki on merge to `main`                                     |
+
+All third-party GitHub Actions in these workflows are pinned to full-length commit SHAs. Each job uses `step-security/harden-runner` to audit outbound network calls. Default `GITHUB_TOKEN` permissions are set to `read-only` at the repository level, with per-job overrides only where write access is needed.
 
 ---
 
@@ -86,6 +96,16 @@ When adding a new instruction to the ISA:
 ### Golden tests
 
 `tests/golden/*.asm` programs are cross-checked against MARS (the classroom-standard reference MIPS simulator) via `golden_runner` and `run_golden.py`, for both CPU models. These require a JRE and Python 3 and are skipped automatically otherwise — don't assume they ran locally just because `ctest` reported success.
+
+---
+
+## Fuzzing
+
+A libFuzzer harness lives at `tests/fuzz/fuzz_hex_loader.cpp`. It feeds arbitrary byte sequences to `mips::parse_hex_program`, which is the one function that accepts raw untrusted input (hex words from a file or the Program Loader tab). The harness is gated on `-DFUZZING_ENGINE=<engine>` at configure time and is never built by normal developer or CI builds.
+
+ClusterFuzzLite (`.clusterfuzzlite/`) provides the OSS-Fuzz-compatible project config, Dockerfile, and `build.sh`. The `cflite_pr.yml` workflow builds and runs `fuzz_hex_loader` for 120 seconds on every PR. Crashes or hangs are reported as CI failures.
+
+If you add a new function that parses untrusted text or binary input, consider adding a parallel harness in `tests/fuzz/` following the same pattern.
 
 ---
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -2,31 +2,34 @@
 
 ## Dependencies
 
-| Dependency   | Version | Notes                                                                 |
-|--------------|---------|------------------------------------------------------------------------|
-| C++ compiler | C++20   | GCC 13+ or Clang 16+                                                    |
-| CMake        | 3.20+   | 3.25+ recommended — the preset workflow below is the recommended path  |
-| FTXUI        | v7.0.0  | Auto-fetched via `FetchContent` — no manual install needed             |
-| Qt6          | 6.x     | Optional — powers both `clearCore-gui` (Widgets) and `clearCore-quick` (QML); disable with `-DBUILD_QT6_UI=OFF -DBUILD_QT6_QUICK_UI=OFF` |
-| LLVM         | 15+     | Optional — powers the Nyxstone assembler/disassembler bridge; disable with `-DBUILD_NYXSTONE=OFF` |
-| Java + Python 3 | any  | Optional — needed only for the MARS differential ("golden") test suite; skipped automatically if missing |
+| Dependency           | Version | Notes                                                                 |
+|----------------------|---------|------------------------------------------------------------------------|
+| C++ compiler         | C++20   | GCC 13+ or Clang 16+                                                    |
+| CMake                | 3.20+   | 3.25+ recommended — the preset workflow below is the recommended path  |
+| FTXUI                | v7.0.0  | Auto-fetched via `FetchContent` — no manual install needed             |
+| Qt6                  | 6.x     | Optional — powers both `clearCore-gui` (Widgets) and `clearCore-quick` (QML); disable with `-DBUILD_QT6_UI=OFF -DBUILD_QT6_QUICK_UI=OFF` |
+| KSyntaxHighlighting  | KF6     | Optional — adds MIPS syntax highlighting to the Qt6 Code Editor; auto-detected at configure time (`kf6-syntax-highlighting-devel` / `libkf6syntaxhighlighting-dev`) |
+| LLVM                 | 15+     | Optional — powers the Nyxstone assembler/disassembler bridge; disable with `-DBUILD_NYXSTONE=OFF` |
+| Java + Python 3      | any     | Optional — needed only for the MARS differential ("golden") test suite; skipped automatically if missing |
 
 GSL and spdlog are also auto-fetched via `FetchContent` and need no manual install.
 
-### Installing Qt6 and LLVM
+### Installing Qt6, LLVM, and KSyntaxHighlighting
 
-Only needed if you want the desktop GUIs or the Nyxstone assembler bridge — skip this if you only want the terminal UI.
+Only needed if you want the desktop GUIs, the Nyxstone assembler bridge, or MIPS syntax highlighting — skip this if you only want the terminal UI.
 
 ```bash
 # Fedora / RHEL
-sudo dnf install qt6-qtbase-devel qt6-qtdeclarative-devel llvm-devel
+sudo dnf install qt6-qtbase-devel qt6-qtdeclarative-devel llvm-devel kf6-syntax-highlighting-devel
 
-# Ubuntu / Debian
-sudo apt install qt6-base-dev qt6-declarative-dev llvm-dev
+# Ubuntu / Debian (KSyntaxHighlighting requires Ubuntu 25.10+)
+sudo apt install qt6-base-dev qt6-declarative-dev llvm-dev libkf6syntaxhighlighting-dev
 
 # macOS
 brew install qt@6 llvm@15
 ```
+
+KSyntaxHighlighting is auto-detected — omitting it is fine, the Code Editor just stays plain text.
 
 ---
 
@@ -126,6 +129,10 @@ The suite covers:
 **MARS golden tests** (`golden_arith_single`, `golden_fib_pipelined`, etc.) run each program in `tests/golden/` through MARS — the classroom-standard reference MIPS simulator — and both clearCore CPU models, and assert the register files match exactly. These require a JRE and Python 3; CMake downloads MARS automatically and verifies its checksum, and quietly skips the suite if the runtime isn't available or the download fails.
 
 This project uses a lightweight, dependency-free `CHECK()`-macro test harness throughout — not GoogleTest or Catch2.
+
+### ClusterFuzzLite fuzzing (CI only)
+
+A libFuzzer harness (`tests/fuzz/fuzz_hex_loader.cpp`) targets `mips::parse_hex_program` — the hex text parser that accepts untrusted input. It is **not** built by normal `cmake --preset debug` or `ctest` invocations. The `.github/workflows/cflite_pr.yml` workflow builds and runs it for 120 seconds on every PR to `main` or `develop` via ClusterFuzzLite's base-builder image (Clang 22 + libFuzzer). To build it manually, pass `-DFUZZING_ENGINE=/path/to/libFuzzer.a` at configure time.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -15,7 +15,9 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 - **Live hazard visualization** — stall, forward, and flush badges inline in the pipeline strip
 - **Telemetry** — running cycle count, CPI, stall/forward/flush tallies
 - **In-app MIPS assembler** — the Qt6 Code Editor assembles labeled assembly source directly into loadable instruction words (no external toolchain)
+- **MIPS syntax highlighting** — optional KSyntaxHighlighting integration gives the Code Editor Kate-quality MIPS highlighting with automatic light/dark theme tracking (no-op when the package is absent)
 - **Differential testing** — the `tests/golden/` suite cross-checks both CPU models against MARS, the classroom-standard MIPS simulator
+- **Continuous fuzzing** — a libFuzzer harness (`fuzz_hex_loader`) runs on every PR via ClusterFuzzLite, exercising `mips::parse_hex_program` against arbitrary input
 
 ---
 
@@ -36,9 +38,9 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 ## At a glance
 
 ```
-C++20 · CMake 3.20+ · MIT license
-FTXUI v7.0.0 (auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM (optional)
-Five core CTest suites + a Qt smoke-test suite + MARS differential tests
+C++20 · CMake 3.20+ · MIT license · v0.0.1
+FTXUI v7.0.0 (auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM (optional) · KSyntaxHighlighting (optional)
+Five core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
 ```
 
 Build presets: `debug`, `release`, `asan`, `core-only` (TUI-only, no Qt/LLVM). See [Getting Started](Getting-Started).

--- a/wiki/Qt6-GUI.md
+++ b/wiki/Qt6-GUI.md
@@ -45,6 +45,7 @@ An inline MIPS assembler. Write assembly text in the left pane; the right pane s
 - Forward and backward branch resolution
 - Line-numbered syntax error reporting
 - **Assemble & Load** — assembles and transfers the program to the CPU in one click
+- **Optional MIPS syntax highlighting** via [KSyntaxHighlighting](https://invent.kde.org/frameworks/syntax-highlighting) (KDE framework, MIT since KF 5.50) — when the system package is found at configure time, the editor attaches Kate's MIPS Assembler definition (GNU Assembler fallback) and tracks the application light/dark theme preference automatically. Without the package, the editor behaves as before (plain text, no change to any other behavior).
 
 The supported instruction set matches the decoder's ISA subset (see [MIPS CPU Simulator](MIPS-CPU-Emulator#supported-isa-subset)). Pseudo-instructions (`li`, `move`, `la`) and assembler directives (`.data`/`.text`/`.word`) are **not** supported yet — that's the remaining Stage 3 scope; see [Roadmap](Roadmap).
 
@@ -89,6 +90,20 @@ cmake --build cmake-build-debug --target clearCore-gui
 ```
 
 New `.cpp` or `.h` files added to `nsc_qt/` must be registered in `CMakeLists.txt` — Qt's MOC (meta-object compiler) will not pick them up automatically and you will get a linker error, not a compile error.
+
+### KSyntaxHighlighting (optional)
+
+KSyntaxHighlighting is detected automatically at configure time — no CMake flag is needed. To install it:
+
+```bash
+# Fedora / RHEL
+sudo dnf install kf6-syntax-highlighting-devel
+
+# Ubuntu 25.10+
+sudo apt install libkf6syntaxhighlighting-dev
+```
+
+If the package is absent, CMake prints `KSyntaxHighlighting not found: Code Editor stays plain text` and the build proceeds unaffected.
 
 ---
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -130,6 +130,7 @@ The Qt6 GUI's Pipeline Trace and Statistics tabs already deliver most of this fo
 
 ### Regression / quality
 
+- [x] ClusterFuzzLite fuzzing harness (`tests/fuzz/fuzz_hex_loader.cpp`) — libFuzzer targets `mips::parse_hex_program`; runs 120 s on every PR via `cflite_pr.yml` (addresses OpenSSF Scorecard fuzzing signal)
 - [ ] UI smoke test guarding `Container::Tab` child count against `tab_labels.size()` (prevents reintroduction of the tab/focus aliasing bug)
 - [ ] Regression test for per-instruction-type telemetry breakout
 


### PR DESCRIPTION
…ki for PRs #2–#9 (#10)

* Add CHANGELOG.md and release-drafter automation; update README and wiki for PRs #2–#9

- CHANGELOG.md: initial file in Keep-a-Changelog format covering v0.0.1 and Unreleased (ClusterFuzzLite, dock widget fix). Includes instructions on the label→section mapping for future contributors.
- .github/release-drafter.yml: categorises merged PRs by label (feature, enhancement, bug, security, documentation, dependencies, ci) and resolves semver bump automatically.
- .github/workflows/release-drafter.yml: updates the draft GitHub Release on every push to main or PR event.
- .github/workflows/update-changelog.yml: on release publish, promotes the [Unreleased] section to the versioned entry and commits back to develop.
- README.md: release badge, Code Editor syntax-highlighting note, expanded CI paragraph listing all five workflows and the ClusterFuzzLite harness.
- wiki/Home.md: added MIPS syntax highlighting and continuous fuzzing to the feature list; updated the at-a-glance block with v0.0.1 and new deps.
- wiki/Qt6-GUI.md: Code Editor section now describes KSyntaxHighlighting integration; Build notes section adds install commands.
- wiki/Getting-Started.md: KSyntaxHighlighting row in deps table, updated install commands, ClusterFuzzLite note in the test section.
- wiki/Contributing.md: CI section replaced with a full workflow table plus notes on pinned SHAs and harden-runner; new Fuzzing section.
- wiki/Architecture.md: testing section now mentions the fuzz harness.
- wiki/Roadmap.md: ClusterFuzzLite marked completed under Regression/quality.



* Use tag-based action versions in release-drafter.yml



* Potential fix for pull request finding



* Potential fix for pull request finding



---------

## Summary by Sourcery

Add automated release-note and changelog management plus document new syntax highlighting, fuzzing, and CI workflows.

Enhancements:
- Document the libFuzzer hex loader fuzz harness and its integration with ClusterFuzzLite as part of the project’s quality and security story.

CI:
- Configure release-drafter to generate draft GitHub Releases from labeled pull requests and auto-resolve semantic version bumps.
- Add a Release Drafter workflow to update the draft release on pushes to main with hardened runner settings.
- Add an update-changelog workflow that promotes the Unreleased section to a versioned entry in CHANGELOG.md when a GitHub Release is published and commits the change back to develop.

Documentation:
- Introduce a Keep-a-Changelog formatted CHANGELOG.md describing v0.0.1 and unreleased changes, and explaining label-to-section mapping for contributors.
- Update README and wiki pages to cover optional KSyntaxHighlighting-based MIPS syntax highlighting, ClusterFuzzLite fuzzing, expanded CI workflows, and the v0.0.1 release details.