### PR TITLE
feat: CP0 exception model, ELF loader, and GDB RSP stub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,29 @@ add_library(mips_core STATIC
         src/mips/pipelined_cpu.cpp    # 5-stage pipelined CPU with hazard logic
         src/mips/program_loader.cpp   # Load programs into memory
         src/mips/disassembler.cpp     # Machine code back to assembly
+        src/mips/cp0.cpp              # Coprocessor 0: exception model (Status/Cause/EPC)
+        src/mips/elf_loader.cpp       # MIPS ELF32 (mipsel) binary loader
 )
+
+# ── GDB RSP stub (optional — requires POSIX sockets; excluded on non-POSIX) ──
+option(BUILD_GDB_STUB "Build the GDB Remote Serial Protocol stub (requires POSIX sockets)" ON)
+if (BUILD_GDB_STUB)
+    include(CheckIncludeFile)
+    check_include_file("sys/socket.h" HAVE_SYS_SOCKET_H)
+    if (HAVE_SYS_SOCKET_H)
+        target_sources(mips_core PRIVATE src/mips/gdb_stub.cpp)
+        target_compile_definitions(mips_core PUBLIC CLEARCORE_GDB_STUB_ENABLED=1)
+        message(STATUS "GDB stub: enabled (POSIX sockets found)")
+    else ()
+        message(WARNING "sys/socket.h not found — GDB stub disabled; "
+                        "use -DBUILD_GDB_STUB=OFF to suppress this warning")
+        set(BUILD_GDB_STUB OFF)
+        target_compile_definitions(mips_core PUBLIC CLEARCORE_GDB_STUB_ENABLED=0)
+    endif ()
+else ()
+    target_compile_definitions(mips_core PUBLIC CLEARCORE_GDB_STUB_ENABLED=0)
+    message(STATUS "GDB stub: disabled (set -DBUILD_GDB_STUB=ON to enable)")
+endif ()
 
 target_include_directories(mips_core PUBLIC include)
 
@@ -438,6 +460,8 @@ clearcore_add_test(decoder_test tests/mips/decoder_test.cpp mips_core)  # Instru
 clearcore_add_test(cpu_test tests/mips/cpu_test.cpp mips_core)  # CPU execution (both models)
 clearcore_add_test(processor_test tests/mips/processor_test.cpp mips_core)  # IProcessor contract
 clearcore_add_test(disasm_test tests/mips/disasm_test.cpp mips_core)  # Disassembler + hex loader
+clearcore_add_test(cp0_test tests/mips/cp0_test.cpp mips_core)  # CP0 exception model
+clearcore_add_test(elf_loader_test tests/mips/elf_loader_test.cpp mips_core)  # ELF32 loader
 clearcore_add_test(nsc_tests tests/nsc/convert_test.cpp nsc_core)   # Number conversion
 
 # ---- qt_ui_test: exercises assembler/controller/widgets (if Qt6 enabled) ----

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -8,4 +8,6 @@ linelength=100
 filter=-legal/copyright
 filter=-build/namespaces
 filter=-whitespace/indent_namespace
+filter=-whitespace/indent
 filter=-build/include_order
+filter=-readability/check

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
 - [Ecosystem](#ecosystem)
+- [CP0 / Exceptions, ELF Loader, and GDB Stub](#cp0--exceptions-elf-loader-and-gdb-stub)
 - [Roadmap](#roadmap)
 - [Documentation](#documentation)
 - [License](#license)
@@ -305,6 +306,90 @@ terminal UI and a native desktop GUI over a shared simulation core.
 
 ---
 
+## CP0 / Exceptions, ELF Loader, and GDB Stub
+
+These three subsystems extend the simulator from a pure teaching tool into a self-contained MIPS debugging environment.
+
+### CP0 and the exception model
+
+The `mips_core` library now implements **Coprocessor 0 (CP0)** following the MIPS32r2 specification. Both `SingleCycleCpu` and `PipelinedCpu` raise proper hardware exceptions rather than halting on bad instructions or memory accesses.
+
+| What happened before | What happens now |
+|---|---|
+| Bad opcode → `StepResult::Fault` (stop cold) | Bad opcode → Reserved Instruction (RI) exception, EPC saved, PC = `0x8000_0180` |
+| Out-of-bounds memory → `StepResult::Fault` | OOB load/store → AdEL / AdES exception with BadVAddr set |
+| No `SYSCALL`/`BREAK` support | SYSCALL and BREAK raise Sys/Bp exceptions; GDB stub intercepts them as signals |
+
+New instructions: `SYSCALL`, `BREAK`, `MFC0`, `MTC0`, `ERET`.
+
+CP0 registers: `Status` (bit 1 = EXL), `Cause` (ExcCode in [6:2]), `EPC`, `BadVAddr`. The exception vector is `0x8000_0180` — the same address real MIPS hardware uses.
+
+```cpp
+if (cpu.step() == StepResult::Exception) {
+    auto& cp0 = cpu.cp0();
+    // cp0.last_exception(), cp0.epc(), cp0.bad_vaddr() are all valid
+}
+```
+
+See [wiki/CP0-Exceptions](https://github.com/khenderson20/clearCore/wiki/CP0-Exceptions) for the full reference.
+
+---
+
+### ELF loader
+
+The `mips::load_elf_file_into_processor()` function parses a MIPS ELF32 binary, maps each `PT_LOAD` segment into the processor's address space (zero-filling BSS), and sets the PC to the entry point — exactly what a kernel exec does for a static binary.
+
+Only **little-endian MIPS** (`mipsel`, `ELFDATA2LSB`) is supported. Compile with:
+
+```bash
+mipsel-linux-gnu-as -mips32r2 -EL -o hello.o hello.s
+mipsel-linux-gnu-ld -e _start -Ttext=0x0000 -o hello hello.o
+```
+
+Or with musl libc for C programs:
+
+```bash
+mipsel-linux-musl-gcc -static -O2 -o hello hello.c
+```
+
+Then load it at runtime:
+
+```cpp
+mips::SingleCycleCpu cpu(4u << 20);  // 4 MB
+std::string err;
+if (!mips::load_elf_file_into_processor(cpu, "hello", err))
+    std::cerr << err << "\n";
+```
+
+See [wiki/ELF-Loader](https://github.com/khenderson20/clearCore/wiki/ELF-Loader) for toolchain setup and the full API.
+
+---
+
+### GDB RSP stub
+
+Attach `mipsel-linux-gnu-gdb` to port 1234 and debug the running emulator with the full GDB experience — software breakpoints, single-step, register and memory inspection, and exception-triggered stop signals:
+
+```bash
+mipsel-linux-gnu-gdb hello
+(gdb) target remote localhost:1234
+(gdb) break _start
+(gdb) continue
+(gdb) info registers
+(gdb) stepi
+```
+
+The stub models 38 MIPS registers (r0–r31, Status, LO, HI, BadVAddr, Cause, PC). Exceptions translate to UNIX signals: `Bp`→SIGTRAP, `Sys`→SIGSYS, `RI`→SIGILL, `Ov`→SIGFPE, `AdEL/AdES`→SIGSEGV.
+
+The stub requires POSIX socket headers (Linux/macOS). On Windows or without sockets it is automatically disabled at CMake configure time. To disable explicitly:
+
+```bash
+cmake --preset debug -DBUILD_GDB_STUB=OFF
+```
+
+See [wiki/GDB-Stub](https://github.com/khenderson20/clearCore/wiki/GDB-Stub) for the full command reference.
+
+---
+
 ## Roadmap
 
 - [x] **Stage 1** — Number converter core + MIPS decoder
@@ -312,6 +397,7 @@ terminal UI and a native desktop GUI over a shared simulation core.
 - [x] **Stage 2** — TUI execution visualizer: memory panel, hazard badges, speed controls, telemetry
 - [x] **Stage 2.5** — Qt6 GUI: datapath, registers, memory, pipeline trace, code editor with in-app assembler,
   statistics
+- [x] **Stage 2.6** — CP0 exception model, ELF loader, and GDB RSP stub
 - [ ] **Stage 3** — Two-pass assembler with full symbol table, label resolution, and pseudo-instruction expansion *(the
   Qt6 Code Editor covers labels and branches; pseudo-instructions are still outstanding)*
 - [ ] **Stage 4** — Per-stage TUI telemetry and CPI analysis to reach parity with the GUI's Pipeline Trace and
@@ -328,6 +414,9 @@ See the [Roadmap wiki page](https://github.com/khenderson20/clearCore/wiki/Roadm
 |--------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
 | [Getting Started](https://github.com/khenderson20/clearCore/wiki/Getting-Started)                | Beginners learning MIPS concepts through the TUI visualization |
 | [Architecture](https://github.com/khenderson20/clearCore/wiki/Architecture)                      | Design patterns, hardware abstractions, and academic grounding |
+| [CP0 and Exceptions](https://github.com/khenderson20/clearCore/wiki/CP0-Exceptions)             | MIPS32r2 exception model, CP0 registers, ERET, MFC0/MTC0      |
+| [ELF Loader](https://github.com/khenderson20/clearCore/wiki/ELF-Loader)                         | Loading compiled mipsel binaries; toolchain setup guide        |
+| [GDB Stub](https://github.com/khenderson20/clearCore/wiki/GDB-Stub)                             | GDB RSP server — breakpoints, single-step, exception signals   |
 | [Qt6 GUI](https://github.com/khenderson20/clearCore/wiki/Qt6-GUI)                               | How `nsc_qt` and `SimulatorController` are structured          |
 | [Contributing](https://github.com/khenderson20/clearCore/wiki/Contributing)                      | Branching model, code style, and testing guidelines            |
 | [Roadmap](https://github.com/khenderson20/clearCore/wiki/Roadmap)                               | Staged feature plan and reference patterns                     |

--- a/include/mips/cp0.h
+++ b/include/mips/cp0.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace mips {
+
+// MIPS exception codes (Cause register ExcCode field [6:2]).
+// MIPS32r2 §6.1.13 Table 6-1 — subset relevant to a 5-stage integer pipeline.
+enum class ExceptionCode : uint8_t {
+    Int  = 0,   // Hardware interrupt (not internally generated)
+    AdEL = 4,   // Address error on instruction fetch or data load
+    AdES = 5,   // Address error on data store
+    Sys  = 8,   // SYSCALL instruction
+    Bp   = 9,   // BREAK instruction
+    RI   = 10,  // Reserved (unrecognised) instruction
+    Ov   = 12,  // Arithmetic overflow (ADD, ADDI, SUB)
+};
+
+[[nodiscard]] std::string_view exception_name(ExceptionCode code) noexcept;
+
+// General exception vector (Status.BEV=0, MIPS32r2 §6.3).
+// Programs that install a handler must map code here.  The GDB stub intercepts
+// exceptions before they vector, so this address is never actually fetched when
+// running under GDB.
+constexpr uint32_t kExceptionVector = 0x8000'0180u;
+
+// ─── Cp0 ──────────────────────────────────────────────────────────────────────
+// Minimal Coprocessor 0 for a 5-stage educational pipeline.
+// Only the four registers needed by the exception model and the GDB stub
+// are implemented; all others read as 0 and ignore writes.
+//
+// Status register (CP0[12]):
+//   bit 0  IE  — interrupt enable (modelled but not acted upon)
+//   bit 1  EXL — exception level; 1 while inside an exception handler
+//
+// Cause register (CP0[13]):
+//   bits 6:2  ExcCode — most recent exception code
+//
+// EPC register (CP0[14]):
+//   PC of the instruction that caused the exception.
+//   ERET restores the CPU's PC from this register.
+//
+// BadVAddr register (CP0[8]):
+//   Virtual address that triggered AdEL or AdES.
+class Cp0 {
+public:
+    static constexpr uint8_t  kRegBadVAddr = 8;
+    static constexpr uint8_t  kRegStatus   = 12;
+    static constexpr uint8_t  kRegCause    = 13;
+    static constexpr uint8_t  kRegEpc      = 14;
+    static constexpr uint32_t kStatusEXL   = 1u << 1;  // Exception Level bit
+
+    // Raise an exception.
+    //   • Writes faulting_pc to EPC.
+    //   • Encodes code into Cause.ExcCode[6:2].
+    //   • Sets Status.EXL = 1.
+    //   • Stores bad_addr in BadVAddr (for AdEL / AdES only).
+    // Returns kExceptionVector — the address the CPU's PC should be set to.
+    uint32_t raise(ExceptionCode code, uint32_t faulting_pc, uint32_t bad_addr = 0) noexcept;
+
+    // Execute ERET: clears Status.EXL and returns EPC.
+    // The CPU should set its PC to the returned value.
+    uint32_t eret() noexcept;
+
+    // MFC0 / MTC0 register access.  Reads of unknown registers return 0;
+    // writes to unknown registers are silently ignored.
+    [[nodiscard]] uint32_t read(uint8_t reg) const noexcept;
+    void                   write(uint8_t reg, uint32_t value) noexcept;
+
+    [[nodiscard]] bool     in_exception() const noexcept { return (status_ & kStatusEXL) != 0; }
+    [[nodiscard]] uint32_t status() const noexcept { return status_; }
+    [[nodiscard]] uint32_t cause() const noexcept { return cause_; }
+    [[nodiscard]] uint32_t epc() const noexcept { return epc_; }
+    [[nodiscard]] uint32_t bad_vaddr() const noexcept { return bad_vaddr_; }
+
+    // Most recent exception code (meaningful after raise() has been called).
+    [[nodiscard]] ExceptionCode last_exception() const noexcept { return last_exc_; }
+
+    void reset() noexcept;
+
+private:
+    uint32_t      status_    = 0;
+    uint32_t      cause_     = 0;
+    uint32_t      epc_       = 0;
+    uint32_t      bad_vaddr_ = 0;
+    ExceptionCode last_exc_  = ExceptionCode::RI;
+};
+
+}  // namespace mips

--- a/include/mips/decoder.h
+++ b/include/mips/decoder.h
@@ -27,6 +27,7 @@ enum class Opcode : uint8_t {
     ORI     = 0x0D,
     XORI    = 0x0E,
     LUI     = 0x0F,
+    COP0    = 0x10,  // Coprocessor 0: MFC0 (rs=0) / MTC0 (rs=4) / ERET (rs=0x10,funct=0x18)
     LW      = 0x23,
     LBU     = 0x24,
     LHU     = 0x25,
@@ -34,25 +35,28 @@ enum class Opcode : uint8_t {
 };
 
 // ─── Funct field [5:0] ────────────────────────────────────────────────────────
-// Only meaningful when opcode == SPECIAL (0x00).
+// Only meaningful when opcode == SPECIAL (0x00) or COP0 CO-mode (rs == 0x10).
 enum class FunctCode : uint8_t {
-    SLL  = 0x00,
-    SRL  = 0x02,
-    SRA  = 0x03,
-    SLLV = 0x04,
-    SRLV = 0x06,
-    JR   = 0x08,
-    JALR = 0x09,
-    ADD  = 0x20,
-    ADDU = 0x21,
-    SUB  = 0x22,
-    SUBU = 0x23,
-    AND  = 0x24,
-    OR   = 0x25,
-    XOR  = 0x26,
-    NOR  = 0x27,
-    SLT  = 0x2A,
-    SLTU = 0x2B,
+    SLL     = 0x00,
+    SRL     = 0x02,
+    SRA     = 0x03,
+    SLLV    = 0x04,
+    SRLV    = 0x06,
+    JR      = 0x08,
+    JALR    = 0x09,
+    SYSCALL = 0x0C,  // System call — raises ExceptionCode::Sys
+    BREAK   = 0x0D,  // Breakpoint — raises ExceptionCode::Bp
+    ADD     = 0x20,
+    ADDU    = 0x21,
+    SUB     = 0x22,
+    SUBU    = 0x23,
+    AND     = 0x24,
+    OR      = 0x25,
+    XOR     = 0x26,
+    NOR     = 0x27,
+    SLT     = 0x2A,
+    SLTU    = 0x2B,
+    ERET    = 0x18,  // Return from exception (COP0 CO-mode only)
 };
 
 // ─── Per-format field structs (H&H Figure 6.10) ───────────────────────────────

--- a/include/mips/elf_loader.h
+++ b/include/mips/elf_loader.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// ─── elf_loader.h ────────────────────────────────────────────────────────────
+// Loads MIPS ELF32 executables into an IProcessor's memory and sets the
+// initial program counter from the ELF entry point.
+//
+// Supported format:
+//   • ELFCLASS32 (32-bit), ELFDATA2LSB (little-endian / mipsel)
+//   • Static executables and relocatable objects (ET_EXEC, ET_REL)
+//   • PT_LOAD program-header segments — the same mapping used by the OS loader
+//
+// How to build a compatible binary:
+//   mipsel-linux-gnu-gcc -static -nostdlib -o hello hello.s
+//   # or with the musl toolchain for full libc support:
+//   mipsel-linux-musl-gcc -static -o hello hello.c
+//
+// Big-endian MIPS ELF files (ELFDATA2MSB) are rejected with a clear error
+// because the emulator's Memory model is little-endian — byte-swapping would
+// corrupt data segments.  Use a mipsel (little-endian) toolchain instead.
+
+#include "mips/processor.h"
+
+#include <cstdint>
+#include <istream>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mips {
+
+// A PT_LOAD segment mapped from the ELF file.
+struct ElfSegment {
+    uint32_t             vaddr;   // virtual address to load at
+    uint32_t             filesz;  // bytes from the file
+    uint32_t             memsz;   // bytes in memory (memsz >= filesz; gap is zero-filled)
+    std::vector<uint8_t> data;    // raw file content (length == filesz)
+};
+
+// Result of parsing an ELF file.
+struct ElfImage {
+    std::vector<ElfSegment>    segments;   // PT_LOAD segments, in order
+    uint32_t                   entry = 0;  // initial PC (ELF entry point)
+    std::optional<std::string> error;      // set on failure
+
+    [[nodiscard]] bool ok() const noexcept { return !error.has_value(); }
+    explicit           operator bool() const noexcept { return ok(); }
+};
+
+// Parse an ELF image from an arbitrary input stream.
+[[nodiscard]] ElfImage parse_elf(std::istream& in);
+
+// Open `path` and parse it as an ELF file.
+[[nodiscard]] ElfImage load_elf_file(const std::string& path);
+
+// Map all PT_LOAD segments of `image` into `cpu`'s memory and set the PC.
+// Returns false and sets `error_out` if any segment falls outside the
+// processor's address space.
+bool load_elf_into_processor(IProcessor& cpu, const ElfImage& image, std::string& error_out);
+
+// Convenience: open, parse, and load in one call.
+bool load_elf_file_into_processor(IProcessor& cpu, const std::string& path, std::string& error_out);
+
+}  // namespace mips

--- a/include/mips/gdb_stub.h
+++ b/include/mips/gdb_stub.h
@@ -1,0 +1,122 @@
+#pragma once
+
+// ─── gdb_stub.h ──────────────────────────────────────────────────────────────
+// GDB Remote Serial Protocol (RSP) server for clearCore's MIPS emulator.
+//
+// How it works:
+//   1. Call listen() — this blocks until a GDB client connects on `port`.
+//   2. The stub enters an RSP event loop: GDB sends commands (step, continue,
+//      read registers, read/write memory, set/remove breakpoints) and the stub
+//      translates them to IProcessor calls.
+//   3. The loop exits when GDB sends 'k' (kill) or 'D' (detach), or when the
+//      CPU halts (self-targeting jump) or the connection drops.
+//
+// Supported RSP commands:
+//   ?           — stop reason (always SIGTRAP initially)
+//   g / G       — read / write all 38 MIPS registers
+//   p n / P n=v — read / write single register
+//   m addr,len  — read memory
+//   M addr,len:data — write memory
+//   c [addr]    — continue execution
+//   s [addr]    — step one instruction
+//   Z0,a,k / z0,a,k — insert / remove software breakpoint
+//   k           — kill (stop loop)
+//   D           — detach (stop loop)
+//   qSupported  — feature negotiation
+//   qAttached   — query attach mode
+//   qC          — current thread
+//   H / T       — thread selection / alive (ignored)
+//   vCont?      — not supported (GDB falls back to c/s)
+//
+// MIPS register layout (GDB MIPS32 ABI, 38 registers × 4 bytes):
+//   0–31   general-purpose r0–r31
+//   32     CP0 Status
+//   33     LO
+//   34     HI
+//   35     CP0 BadVAddr
+//   36     CP0 Cause
+//   37     PC
+
+#include "mips/processor.h"
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace mips {
+
+class GdbStub {
+public:
+    // Construct a stub attached to `cpu`, listening on TCP `port`.
+    // The stub does NOT take ownership of the processor.
+    explicit GdbStub(IProcessor& cpu, uint16_t port = 1234);
+    ~GdbStub();
+
+    GdbStub(const GdbStub&)            = delete;
+    GdbStub& operator=(const GdbStub&) = delete;
+
+    // Block until a GDB client connects, then run the RSP event loop.
+    // Returns when GDB sends 'k'/'D', or the CPU halts, or the socket drops.
+    void listen();
+
+private:
+    // ── RSP packet I/O ────────────────────────────────────────────────────────
+    bool send_packet(const std::string& data);
+    bool send_raw(const std::string& s);
+    bool recv_packet(std::string& out);
+    void send_ok();
+    void send_empty();
+    void send_error(uint8_t code);
+    void send_signal(int sig);
+
+    // ── RSP command handlers ──────────────────────────────────────────────────
+    std::string handle_read_regs();
+    bool        handle_write_regs(const std::string& hex);
+    std::string handle_read_reg(const std::string& args);
+    bool        handle_write_reg(const std::string& args);
+    std::string handle_read_mem(const std::string& args);
+    bool        handle_write_mem(const std::string& args);
+    void        handle_continue(const std::string& args);
+    void        handle_step(const std::string& args);
+    void        handle_breakpoint_set(const std::string& args);
+    void        handle_breakpoint_clear(const std::string& args);
+    void        dispatch(const std::string& pkt);
+
+    // ── Breakpoint helpers ────────────────────────────────────────────────────
+    // Software breakpoints: GDB replaces the target instruction with BREAK
+    // (0x0000000d) and restores it on removal.  We track the original word
+    // so we can restore it on z0.
+    struct Breakpoint {
+        uint32_t addr;
+        uint32_t saved_word;  // original instruction replaced by BREAK
+    };
+    bool insert_breakpoint(uint32_t addr);
+    bool remove_breakpoint(uint32_t addr);
+
+    // ── Register access (MIPS GDB layout) ────────────────────────────────────
+    static constexpr int kNumRegs = 38;
+    uint32_t             read_gdb_reg(int n) const;
+    void                 write_gdb_reg(int n, uint32_t value);
+
+    // ── Utilities ────────────────────────────────────────────────────────────
+    static uint8_t     checksum(const std::string& data) noexcept;
+    static std::string to_hex_le(uint32_t v);  // 4-byte little-endian hex
+    static uint32_t    from_hex_le(const std::string& s, size_t off = 0);
+    static uint32_t    parse_hex(const std::string& s);
+    static std::string hex_byte(uint8_t b);
+
+    // Signal number to send for a given StepResult / exception code.
+    int stop_signal() const;
+
+    IProcessor& cpu_;
+    uint16_t    port_;
+    int         server_fd_ = -1;
+    int         client_fd_ = -1;
+
+    std::vector<Breakpoint> breakpoints_;
+    bool                    running_     = false;  // true while inside handle_continue
+    StepResult              last_result_ = StepResult::Ok;
+};
+
+}  // namespace mips

--- a/include/mips/pipelined_cpu.h
+++ b/include/mips/pipelined_cpu.h
@@ -24,6 +24,8 @@
 #include "mips/pipeline_regs.h"
 #include "mips/processor.h"
 
+#include <vector>
+
 namespace mips {
 
 class PipelinedCpu final : public IProcessor {
@@ -43,11 +45,20 @@ public:
     [[nodiscard]] const Control&       last_control() const noexcept override { return ctrl_; }
     [[nodiscard]] std::size_t          cycle_count() const noexcept override { return cycle_; }
     [[nodiscard]] const PipelineState& pipeline_state() const noexcept override { return ps_; }
+    [[nodiscard]] const Cp0&           cp0() const noexcept override { return cp0_; }
+    [[nodiscard]] Cp0&                 cp0() noexcept override { return cp0_; }
+    [[nodiscard]] uint32_t             hi() const noexcept override { return hi_; }
+    [[nodiscard]] uint32_t             lo() const noexcept override { return lo_; }
+    void                               set_hi(uint32_t v) noexcept override { hi_ = v; }
+    void                               set_lo(uint32_t v) noexcept override { lo_ = v; }
 
 private:
     RegisterFile  regs_;
     Memory        mem_;
+    Cp0           cp0_{};
     uint32_t      pc_ = 0;
+    uint32_t      hi_ = 0;
+    uint32_t      lo_ = 0;
     Control       ctrl_{};
     std::size_t   cycle_ = 0;
     PipelineState ps_{};

--- a/include/mips/processor.h
+++ b/include/mips/processor.h
@@ -15,6 +15,7 @@
 //   4. Forwarding and stall flags are first-class so the Stage 5 TUI can draw
 //      bypass wires and bubble indicators (Arches, Haydel et al. 2025).
 
+#include "mips/cp0.h"
 #include "mips/decoder.h"
 #include "mips/memory.h"
 #include "mips/registers.h"
@@ -47,9 +48,10 @@ struct Control {
 
 // ─── StepResult ───────────────────────────────────────────────────────────────
 enum class StepResult : uint8_t {
-    Ok,     // instruction executed; PC advanced
-    Fault,  // undecodable instruction or bad/misaligned memory access
-    Halt,   // self-targeting jump retired from WB (spin-in-place idiom)
+    Ok,         // instruction executed; PC advanced normally
+    Exception,  // CP0 exception raised; EPC/Cause/Status updated; PC = kExceptionVector
+    Fault,      // unrecoverable internal error (should not occur in correct programs)
+    Halt,       // self-targeting jump retired from WB (spin-in-place idiom)
 };
 
 // ─── Pipeline visualisation state ─────────────────────────────────────────────
@@ -112,8 +114,8 @@ public:
 
     // ── Accessors ──────────────────────────────────────────────────────────────
 
-    [[nodiscard]] virtual uint32_t pc() const noexcept       = 0;
-    virtual void                   set_pc(uint32_t) noexcept = 0;
+    [[nodiscard]] virtual uint32_t pc() const noexcept            = 0;
+    virtual void                   set_pc(uint32_t addr) noexcept = 0;
 
     [[nodiscard]] virtual const RegisterFile& regs() const noexcept = 0;
     [[nodiscard]] virtual RegisterFile&       regs() noexcept       = 0;
@@ -130,6 +132,19 @@ public:
     // Snapshot of all five pipeline stages from the most recent step().
     // SingleCycleCpu only populates stages[2] (EX); PipelinedCpu fills all five.
     [[nodiscard]] virtual const PipelineState& pipeline_state() const noexcept = 0;
+
+    // ── Coprocessor 0 ─────────────────────────────────────────────────────────
+    // Access to Status, Cause, EPC, BadVAddr, and the last exception code.
+    // Valid to read after any step() returns StepResult::Exception.
+    [[nodiscard]] virtual const Cp0& cp0() const noexcept = 0;
+    [[nodiscard]] virtual Cp0&       cp0() noexcept       = 0;
+
+    // HI and LO registers (destination for MULT/DIV; exposed for GDB register
+    // layout even before those instructions are implemented).
+    [[nodiscard]] virtual uint32_t hi() const noexcept         = 0;
+    [[nodiscard]] virtual uint32_t lo() const noexcept         = 0;
+    virtual void                   set_hi(uint32_t v) noexcept = 0;
+    virtual void                   set_lo(uint32_t v) noexcept = 0;
 };
 
 }  // namespace mips

--- a/include/mips/single_cycle_cpu.h
+++ b/include/mips/single_cycle_cpu.h
@@ -12,6 +12,8 @@
 
 #include "mips/processor.h"
 
+#include <vector>
+
 namespace mips {
 
 class SingleCycleCpu final : public IProcessor {
@@ -31,14 +33,26 @@ public:
     [[nodiscard]] const Control&       last_control() const noexcept override { return ctrl_; }
     [[nodiscard]] std::size_t          cycle_count() const noexcept override { return cycle_; }
     [[nodiscard]] const PipelineState& pipeline_state() const noexcept override { return ps_; }
+    [[nodiscard]] const Cp0&           cp0() const noexcept override { return cp0_; }
+    [[nodiscard]] Cp0&                 cp0() noexcept override { return cp0_; }
+    [[nodiscard]] uint32_t             hi() const noexcept override { return hi_; }
+    [[nodiscard]] uint32_t             lo() const noexcept override { return lo_; }
+    void                               set_hi(uint32_t v) noexcept override { hi_ = v; }
+    void                               set_lo(uint32_t v) noexcept override { lo_ = v; }
 
 private:
-    bool exec_rtype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc);
-    bool exec_itype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc);
+    // Returns StepResult::Exception after calling cp0_.raise() and updating pc_.
+    StepResult raise(ExceptionCode code, uint32_t faulting_pc, uint32_t bad_addr = 0) noexcept;
+
+    bool exec_rtype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc, StepResult& exc);
+    bool exec_itype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc, StepResult& exc);
 
     RegisterFile  regs_;
     Memory        mem_;
+    Cp0           cp0_{};
     uint32_t      pc_ = 0;
+    uint32_t      hi_ = 0;
+    uint32_t      lo_ = 0;
     Control       ctrl_{};
     std::size_t   cycle_ = 0;
     PipelineState ps_{};

--- a/src/mips/cp0.cpp
+++ b/src/mips/cp0.cpp
@@ -1,0 +1,78 @@
+#include "mips/cp0.h"
+
+namespace mips {
+
+std::string_view exception_name(ExceptionCode code) noexcept {
+    switch (code) {
+    case ExceptionCode::Int:
+        return "Int";
+    case ExceptionCode::AdEL:
+        return "AdEL";
+    case ExceptionCode::AdES:
+        return "AdES";
+    case ExceptionCode::Sys:
+        return "Sys";
+    case ExceptionCode::Bp:
+        return "Bp";
+    case ExceptionCode::RI:
+        return "RI";
+    case ExceptionCode::Ov:
+        return "Ov";
+    default:
+        return "??";
+    }
+}
+
+uint32_t Cp0::raise(ExceptionCode code, uint32_t faulting_pc, uint32_t bad_addr) noexcept {
+    last_exc_ = code;
+    epc_      = faulting_pc;
+    cause_    = (cause_ & ~0x7Cu) | (static_cast<uint32_t>(code) << 2);
+    status_ |= kStatusEXL;
+    bad_vaddr_ = bad_addr;
+    return kExceptionVector;
+}
+
+uint32_t Cp0::eret() noexcept {
+    status_ &= ~kStatusEXL;
+    return epc_;
+}
+
+uint32_t Cp0::read(uint8_t reg) const noexcept {
+    switch (reg) {
+    case kRegBadVAddr:
+        return bad_vaddr_;
+    case kRegStatus:
+        return status_;
+    case kRegCause:
+        return cause_;
+    case kRegEpc:
+        return epc_;
+    default:
+        return 0;
+    }
+}
+
+void Cp0::write(uint8_t reg, uint32_t value) noexcept {
+    switch (reg) {
+    case kRegStatus:
+        status_ = value;
+        break;
+    case kRegCause:
+        cause_ = value;
+        break;
+    case kRegEpc:
+        epc_ = value;
+        break;
+    default:
+        break;
+    }
+}
+
+void Cp0::reset() noexcept {
+    status_    = 0;
+    cause_     = 0;
+    epc_       = 0;
+    bad_vaddr_ = 0;
+}
+
+}  // namespace mips

--- a/src/mips/decoder.cpp
+++ b/src/mips/decoder.cpp
@@ -6,6 +6,7 @@ namespace mips {
 InstrFormat Decoder::format_of(Opcode op) {
     switch (op) {
     case Opcode::SPECIAL:
+    case Opcode::COP0:
         return InstrFormat::R;
 
     case Opcode::J:
@@ -49,9 +50,21 @@ std::optional<DecodedInstr> Decoder::decode(uint32_t instr) {
     case InstrFormat::R: {
         const auto funct = static_cast<FunctCode>(bits(instr, 5, 0));
 
-        // Validate funct — reject reserved encodings rather than passing
-        // garbage to the ALU. Unknown funct codes become a decode stall
-        // once the pipeline is in place.
+        // COP0 (MFC0 / MTC0 / ERET): the rs field selects the sub-operation.
+        // Decode unconditionally as R-type; the CPU dispatches on rs/funct.
+        if (raw_op == Opcode::COP0) {
+            result.fields = RFields{
+                .rs    = static_cast<uint8_t>(bits(instr, 25, 21)),
+                .rt    = static_cast<uint8_t>(bits(instr, 20, 16)),
+                .rd    = static_cast<uint8_t>(bits(instr, 15, 11)),
+                .shamt = 0,
+                .funct = funct,
+            };
+            break;
+        }
+
+        // Validate SPECIAL funct — reject reserved encodings rather than
+        // passing garbage to the ALU.
         switch (funct) {
         case FunctCode::SLL:
         case FunctCode::SRL:
@@ -60,6 +73,8 @@ std::optional<DecodedInstr> Decoder::decode(uint32_t instr) {
         case FunctCode::SRLV:
         case FunctCode::JR:
         case FunctCode::JALR:
+        case FunctCode::SYSCALL:
+        case FunctCode::BREAK:
         case FunctCode::ADD:
         case FunctCode::ADDU:
         case FunctCode::SUB:
@@ -100,7 +115,8 @@ std::optional<DecodedInstr> Decoder::decode(uint32_t instr) {
         };
         break;
     }
-    default:;
+    default: {
+    }
     }
 
     return result;
@@ -144,9 +160,21 @@ std::string_view Decoder::mnemonic(const DecodedInstr& instr) {
             return "JR";
         case FunctCode::JALR:
             return "JALR";
+        case FunctCode::SYSCALL:
+            return "SYSCALL";
+        case FunctCode::BREAK:
+            return "BREAK";
         default:
             return "???";
         }
+    }
+
+    if (instr.opcode == Opcode::COP0) {
+        const uint8_t rs = instr.r().rs;
+        if (rs == 0x00) return "MFC0";
+        if (rs == 0x04) return "MTC0";
+        if (rs == 0x10 && instr.r().funct == FunctCode::ERET) return "ERET";
+        return "COP0";
     }
 
     switch (instr.opcode) {

--- a/src/mips/elf_loader.cpp
+++ b/src/mips/elf_loader.cpp
@@ -1,0 +1,216 @@
+#include "mips/elf_loader.h"
+
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace mips {
+
+// ─── ELF32 on-disk structures ─────────────────────────────────────────────────
+// Defined inline to avoid a dependency on <elf.h> (not available on all hosts).
+
+static constexpr uint8_t  kElfMag0     = 0x7f;
+static constexpr uint8_t  kElfMag1     = 'E';
+static constexpr uint8_t  kElfMag2     = 'L';
+static constexpr uint8_t  kElfMag3     = 'F';
+static constexpr uint8_t  kElfClass32  = 1;  // ELFCLASS32
+static constexpr uint8_t  kElfData2LSB = 1;  // little-endian
+static constexpr uint16_t kEmMips      = 8;  // EM_MIPS
+static constexpr uint16_t kEtExec      = 2;  // ET_EXEC
+static constexpr uint16_t kEtRel       = 1;  // ET_REL
+static constexpr uint32_t kPtLoad      = 1;  // PT_LOAD
+
+#pragma pack(push, 1)
+struct Elf32Ehdr {
+    uint8_t  e_ident[16];
+    uint16_t e_type;
+    uint16_t e_machine;
+    uint32_t e_version;
+    uint32_t e_entry;
+    uint32_t e_phoff;
+    uint32_t e_shoff;
+    uint32_t e_flags;
+    uint16_t e_ehsize;
+    uint16_t e_phentsize;
+    uint16_t e_phnum;
+    uint16_t e_shentsize;
+    uint16_t e_shnum;
+    uint16_t e_shstrndx;
+};
+static_assert(sizeof(Elf32Ehdr) == 52);
+
+struct Elf32Phdr {
+    uint32_t p_type;
+    uint32_t p_offset;
+    uint32_t p_vaddr;
+    uint32_t p_paddr;
+    uint32_t p_filesz;
+    uint32_t p_memsz;
+    uint32_t p_flags;
+    uint32_t p_align;
+};
+static_assert(sizeof(Elf32Phdr) == 32);
+#pragma pack(pop)
+
+// ─── Helper: read a fixed-size struct from stream ────────────────────────────
+template <typename T> static bool stream_read(std::istream& in, T& out) {
+    return static_cast<bool>(in.read(reinterpret_cast<char*>(&out), sizeof(T)));
+}
+
+// ─── parse_elf ────────────────────────────────────────────────────────────────
+ElfImage parse_elf(std::istream& in) {
+    ElfImage img;
+
+    Elf32Ehdr ehdr{};
+    if (!stream_read(in, ehdr)) {
+        img.error = "failed to read ELF header (file too short)";
+        return img;
+    }
+
+    // Magic number check.
+    if (ehdr.e_ident[0] != kElfMag0 || ehdr.e_ident[1] != kElfMag1 || ehdr.e_ident[2] != kElfMag2 ||
+        ehdr.e_ident[3] != kElfMag3) {
+        img.error = "not an ELF file (bad magic)";
+        return img;
+    }
+
+    // 32-bit only.
+    if (ehdr.e_ident[4] != kElfClass32) {
+        img.error = "only ELF32 is supported (got ELF64)";
+        return img;
+    }
+
+    // Little-endian (mipsel) only.  Big-endian MIPS ELF would require
+    // byte-swapping instruction words but not byte arrays — we can't know
+    // which is which at segment granularity.
+    if (ehdr.e_ident[5] != kElfData2LSB) {
+        img.error = "only little-endian MIPS ELF (mipsel) is supported; "
+                    "recompile with mipsel-linux-gnu-gcc or mipsel-linux-musl-gcc";
+        return img;
+    }
+
+    if (ehdr.e_machine != kEmMips) {
+        img.error =
+            "ELF machine type is not MIPS (e_machine=" + std::to_string(ehdr.e_machine) + ")";
+        return img;
+    }
+
+    if (ehdr.e_type != kEtExec && ehdr.e_type != kEtRel) {
+        img.error = "only ET_EXEC and ET_REL ELF types are supported";
+        return img;
+    }
+
+    if (ehdr.e_phnum == 0 || ehdr.e_phoff == 0) {
+        img.error = "ELF has no program headers — is this a relocatable object "
+                    "without a linker script?  Use -static -Ttext=0x0 or link "
+                    "with a MEMORY script.";
+        return img;
+    }
+
+    img.entry = ehdr.e_entry;
+
+    // Read PT_LOAD segments.
+    for (uint16_t i = 0; i < ehdr.e_phnum; ++i) {
+        const auto phoff =
+            static_cast<std::streamoff>(ehdr.e_phoff) +
+            static_cast<std::streamoff>(i) * static_cast<std::streamoff>(ehdr.e_phentsize);
+        in.seekg(phoff);
+        if (!in) {
+            img.error = "failed to seek to program header " + std::to_string(i);
+            return img;
+        }
+
+        Elf32Phdr phdr{};
+        if (!stream_read(in, phdr)) {
+            img.error = "failed to read program header " + std::to_string(i);
+            return img;
+        }
+
+        if (phdr.p_type != kPtLoad) continue;
+        if (phdr.p_filesz == 0) continue;
+
+        // Read the raw segment data from the file.
+        in.seekg(static_cast<std::streamoff>(phdr.p_offset));
+        if (!in) {
+            img.error = "failed to seek to segment " + std::to_string(i) + " data (offset 0x" +
+                        [&] {
+                            std::ostringstream s;
+                            s << std::hex << phdr.p_offset;
+                            return s.str();
+                        }() +
+                        ")";
+            return img;
+        }
+
+        ElfSegment seg;
+        seg.vaddr  = phdr.p_vaddr;
+        seg.filesz = phdr.p_filesz;
+        seg.memsz  = phdr.p_memsz;
+        seg.data.resize(phdr.p_filesz);
+        if (!in.read(reinterpret_cast<char*>(seg.data.data()),
+                     static_cast<std::streamsize>(phdr.p_filesz))) {
+            img.error = "failed to read segment " + std::to_string(i) + " data";
+            return img;
+        }
+
+        img.segments.push_back(std::move(seg));
+    }
+
+    if (img.segments.empty()) {
+        img.error = "ELF has no PT_LOAD segments — nothing to load";
+    }
+
+    return img;
+}
+
+// ─── load_elf_file ────────────────────────────────────────────────────────────
+ElfImage load_elf_file(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        ElfImage img;
+        img.error = "cannot open '" + path + "'";
+        return img;
+    }
+    return parse_elf(f);
+}
+
+// ─── load_elf_into_processor ─────────────────────────────────────────────────
+bool load_elf_into_processor(IProcessor& cpu, const ElfImage& image, std::string& error_out) {
+    if (!image) {
+        error_out = image.error.value_or("unknown ELF error");
+        return false;
+    }
+
+    for (const ElfSegment& seg : image.segments) {
+        // Write the file-content bytes directly into memory.
+        for (uint32_t off = 0; off < seg.filesz; ++off) {
+            if (!cpu.mem().write_byte(seg.vaddr + off, seg.data[off])) {
+                std::ostringstream s;
+                s << std::hex;
+                s << "segment at 0x" << seg.vaddr << " extends outside the "
+                  << "processor's address space (0x" << cpu.mem().size()
+                  << " bytes); increase mem_bytes in the IProcessor constructor";
+                error_out = s.str();
+                return false;
+            }
+        }
+        // Zero-fill the BSS portion (memsz > filesz).
+        for (uint32_t off = seg.filesz; off < seg.memsz; ++off) {
+            cpu.mem().write_byte(seg.vaddr + off, 0);
+        }
+    }
+
+    cpu.set_pc(image.entry);
+    return true;
+}
+
+// ─── load_elf_file_into_processor ────────────────────────────────────────────
+bool load_elf_file_into_processor(IProcessor& cpu, const std::string& path,
+                                  std::string& error_out) {
+    const ElfImage img = load_elf_file(path);
+    return load_elf_into_processor(cpu, img, error_out);
+}
+
+}  // namespace mips

--- a/src/mips/gdb_stub.cpp
+++ b/src/mips/gdb_stub.cpp
@@ -1,0 +1,542 @@
+#include "mips/gdb_stub.h"
+#include "mips/cp0.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+// POSIX socket headers — supported on Linux and macOS.
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace mips {
+
+// MIPS BREAK instruction word (opcode=SPECIAL, funct=BREAK=0x0D, code field 0).
+static constexpr uint32_t kBreakWord = 0x0000'000Du;
+
+// POSIX signal numbers mirrored here to avoid including <signal.h>.
+static constexpr int kSIGTRAP = 5;
+static constexpr int kSIGSEGV = 11;
+static constexpr int kSIGILL  = 4;
+static constexpr int kSIGFPE  = 8;
+static constexpr int kSIGSYS  = 12;
+
+// ─── Constructor / destructor ─────────────────────────────────────────────────
+
+GdbStub::GdbStub(IProcessor& cpu, uint16_t port) : cpu_(cpu), port_(port) {}
+
+GdbStub::~GdbStub() {
+    if (client_fd_ >= 0) ::close(client_fd_);
+    if (server_fd_ >= 0) ::close(server_fd_);
+}
+
+// ─── listen ───────────────────────────────────────────────────────────────────
+
+void GdbStub::listen() {
+    server_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd_ < 0) return;
+
+    const int yes = 1;
+    ::setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    sockaddr_in addr{};
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port        = htons(port_);
+
+    if (::bind(server_fd_, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) < 0) {
+        ::close(server_fd_);
+        server_fd_ = -1;
+        return;
+    }
+    ::listen(server_fd_, 1);
+
+    sockaddr_in peer{};
+    socklen_t   peer_len = sizeof(peer);
+    client_fd_           = ::accept(server_fd_, reinterpret_cast<sockaddr*>(&peer), &peer_len);
+    if (client_fd_ < 0) return;
+
+    // Disable Nagle — RSP is request-response, latency matters more than throughput.
+    ::setsockopt(client_fd_, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes));
+
+    // RSP event loop.
+    last_result_ = StepResult::Ok;
+    std::string pkt;
+    while (recv_packet(pkt)) {
+        dispatch(pkt);
+    }
+
+    ::close(client_fd_);
+    client_fd_ = -1;
+    ::close(server_fd_);
+    server_fd_ = -1;
+}
+
+// ─── Packet I/O ──────────────────────────────────────────────────────────────
+
+uint8_t GdbStub::checksum(const std::string& data) noexcept {
+    uint8_t sum = 0;
+    for (unsigned char c : data)
+        sum = static_cast<uint8_t>(sum + c);
+    return sum;
+}
+
+std::string GdbStub::hex_byte(uint8_t b) {
+    char buf[3];
+    std::snprintf(buf, sizeof(buf), "%02x", b);
+    return {buf};
+}
+
+bool GdbStub::send_raw(const std::string& s) {
+    const char* p   = s.data();
+    auto        rem = static_cast<ssize_t>(s.size());
+    while (rem > 0) {
+        const ssize_t n = ::send(client_fd_, p, static_cast<size_t>(rem), 0);
+        if (n <= 0) return false;
+        p += n;
+        rem -= n;
+    }
+    return true;
+}
+
+bool GdbStub::send_packet(const std::string& data) {
+    const std::string pkt = "$" + data + "#" + hex_byte(checksum(data));
+    return send_raw(pkt);
+}
+
+void GdbStub::send_ok() {
+    send_packet("OK");
+}
+void GdbStub::send_empty() {
+    send_packet("");
+}
+void GdbStub::send_error(uint8_t code) {
+    send_packet("E" + hex_byte(code));
+}
+
+void GdbStub::send_signal(int sig) {
+    char buf[4];
+    std::snprintf(buf, sizeof(buf), "S%02x", static_cast<unsigned>(sig));
+    send_packet(buf);
+}
+
+bool GdbStub::recv_packet(std::string& out) {
+    out.clear();
+    // Skip until '$'.
+    char c;
+    while (true) {
+        const ssize_t n = ::recv(client_fd_, &c, 1, 0);
+        if (n <= 0) return false;
+        if (c == '$') break;
+        if (c == '\x03') {
+            // Ctrl-C interrupt: treat like a step + stop.
+            send_signal(kSIGTRAP);
+            return true;
+        }
+    }
+    // Read until '#'.
+    while (true) {
+        const ssize_t n = ::recv(client_fd_, &c, 1, 0);
+        if (n <= 0) return false;
+        if (c == '#') break;
+        out += c;
+    }
+    // Read two-character checksum (we accept it without verifying for simplicity).
+    char cksum[2];
+    if (::recv(client_fd_, cksum, 2, MSG_WAITALL) != 2) return false;
+    send_raw("+");  // ACK
+    return true;
+}
+
+// ─── Register access ─────────────────────────────────────────────────────────
+// MIPS GDB register numbering (38 registers):
+//   0–31  r0–r31 (general purpose)
+//   32    CP0 Status
+//   33    LO
+//   34    HI
+//   35    CP0 BadVAddr
+//   36    CP0 Cause
+//   37    PC
+
+uint32_t GdbStub::read_gdb_reg(int n) const {
+    if (n >= 0 && n < 32) return cpu_.regs().read(static_cast<uint8_t>(n));
+    if (n == 32) return cpu_.cp0().status();
+    if (n == 33) return cpu_.lo();
+    if (n == 34) return cpu_.hi();
+    if (n == 35) return cpu_.cp0().bad_vaddr();
+    if (n == 36) return cpu_.cp0().cause();
+    if (n == 37) return cpu_.pc();
+    return 0;
+}
+
+void GdbStub::write_gdb_reg(int n, uint32_t value) {
+    if (n >= 0 && n < 32) {
+        cpu_.regs().write(static_cast<uint8_t>(n), value);
+        return;
+    }
+    if (n == 32) {
+        cpu_.cp0().write(Cp0::kRegStatus, value);
+        return;
+    }
+    if (n == 33) {
+        cpu_.set_lo(value);
+        return;
+    }
+    if (n == 34) {
+        cpu_.set_hi(value);
+        return;
+    }
+    if (n == 36) {
+        cpu_.cp0().write(Cp0::kRegCause, value);
+        return;
+    }
+    if (n == 37) {
+        cpu_.set_pc(value);
+        return;
+    }
+}
+
+// ─── Hex encoding helpers ─────────────────────────────────────────────────────
+
+// Encode a 32-bit value in little-endian hex (8 chars, LSB first).
+std::string GdbStub::to_hex_le(uint32_t v) {
+    char buf[9];
+    // Write bytes LSB-first.
+    std::snprintf(buf, sizeof(buf), "%02x%02x%02x%02x", v & 0xFFu, (v >> 8) & 0xFFu,
+                  (v >> 16) & 0xFFu, (v >> 24) & 0xFFu);
+    return {buf};
+}
+
+uint32_t GdbStub::parse_hex(const std::string& s) {
+    return static_cast<uint32_t>(std::stoul(s, nullptr, 16));
+}
+
+// ─── Stop signal ─────────────────────────────────────────────────────────────
+
+int GdbStub::stop_signal() const {
+    if (last_result_ == StepResult::Halt) return kSIGTRAP;
+    if (last_result_ == StepResult::Exception) {
+        switch (cpu_.cp0().last_exception()) {
+        case ExceptionCode::Bp:
+            return kSIGTRAP;
+        case ExceptionCode::Sys:
+            return kSIGSYS;
+        case ExceptionCode::RI:
+            return kSIGILL;
+        case ExceptionCode::Ov:
+            return kSIGFPE;
+        case ExceptionCode::AdEL:
+        case ExceptionCode::AdES:
+            return kSIGSEGV;
+        default:
+            return kSIGTRAP;
+        }
+    }
+    return kSIGTRAP;
+}
+
+// ─── RSP command handlers ─────────────────────────────────────────────────────
+
+std::string GdbStub::handle_read_regs() {
+    std::string out;
+    out.reserve(kNumRegs * 8);
+    for (int i = 0; i < kNumRegs; ++i)
+        out += to_hex_le(read_gdb_reg(i));
+    return out;
+}
+
+bool GdbStub::handle_write_regs(const std::string& hex) {
+    if (hex.size() < static_cast<size_t>(kNumRegs * 8)) return false;
+    for (int i = 0; i < kNumRegs; ++i) {
+        const std::string chunk = hex.substr(static_cast<size_t>(i) * 8, 8);
+        // Little-endian: LSB is at the lowest address in the hex string.
+        uint32_t v = 0;
+        for (int b = 0; b < 4; ++b) {
+            const std::string byte_str = chunk.substr(static_cast<size_t>(b) * 2, 2);
+            v |= static_cast<uint32_t>(std::stoul(byte_str, nullptr, 16)) << (b * 8);
+        }
+        write_gdb_reg(i, v);
+    }
+    return true;
+}
+
+std::string GdbStub::handle_read_reg(const std::string& args) {
+    const int n = static_cast<int>(parse_hex(args));
+    if (n >= kNumRegs) return "E01";
+    return to_hex_le(read_gdb_reg(n));
+}
+
+bool GdbStub::handle_write_reg(const std::string& args) {
+    const size_t eq = args.find('=');
+    if (eq == std::string::npos) return false;
+    const int n = static_cast<int>(parse_hex(args.substr(0, eq)));
+    if (n >= kNumRegs) return false;
+    const std::string& vs = args.substr(eq + 1);
+    uint32_t           v  = 0;
+    for (int b = 0; b < 4 && b * 2 + 1 < static_cast<int>(vs.size()); ++b)
+        v |=
+            static_cast<uint32_t>(std::stoul(vs.substr(static_cast<size_t>(b) * 2, 2), nullptr, 16))
+            << (b * 8);
+    write_gdb_reg(n, v);
+    return true;
+}
+
+std::string GdbStub::handle_read_mem(const std::string& args) {
+    const size_t comma = args.find(',');
+    if (comma == std::string::npos) return "E01";
+    const uint32_t addr = parse_hex(args.substr(0, comma));
+    const uint32_t len  = parse_hex(args.substr(comma + 1));
+    std::string    out;
+    out.reserve(len * 2);
+    for (uint32_t i = 0; i < len; ++i) {
+        const auto b = cpu_.mem().read_byte(addr + i);
+        if (!b) return "E02";  // OOB
+        out += hex_byte(*b);
+    }
+    return out;
+}
+
+bool GdbStub::handle_write_mem(const std::string& args) {
+    const size_t colon = args.find(':');
+    const size_t comma = args.find(',');
+    if (colon == std::string::npos || comma == std::string::npos) return false;
+    const uint32_t     addr = parse_hex(args.substr(0, comma));
+    const uint32_t     len  = parse_hex(args.substr(comma + 1, colon - comma - 1));
+    const std::string& hex  = args.substr(colon + 1);
+    for (uint32_t i = 0; i < len; ++i) {
+        if (i * 2 + 1 >= hex.size()) return false;
+        const uint8_t byte = static_cast<uint8_t>(
+            std::stoul(hex.substr(static_cast<size_t>(i) * 2, 2), nullptr, 16));
+        if (!cpu_.mem().write_byte(addr + i, byte)) return false;
+    }
+    return true;
+}
+
+// ─── Breakpoints ─────────────────────────────────────────────────────────────
+
+bool GdbStub::insert_breakpoint(uint32_t addr) {
+    // Don't double-insert.
+    for (const auto& bp : breakpoints_)
+        if (bp.addr == addr) return true;
+
+    const auto word = cpu_.mem().read_word(addr);
+    if (!word) return false;
+
+    if (!cpu_.mem().write_word(addr, kBreakWord)) return false;
+
+    breakpoints_.push_back({addr, *word});
+    return true;
+}
+
+bool GdbStub::remove_breakpoint(uint32_t addr) {
+    for (auto it = breakpoints_.begin(); it != breakpoints_.end(); ++it) {
+        if (it->addr == addr) {
+            cpu_.mem().write_word(addr, it->saved_word);
+            breakpoints_.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+void GdbStub::handle_breakpoint_set(const std::string& args) {
+    // args: "type,addr,kind" — we only handle type 0 (software).
+    const size_t c1 = args.find(',');
+    if (c1 == std::string::npos) {
+        send_error(1);
+        return;
+    }
+    const size_t c2 = args.find(',', c1 + 1);
+    if (c2 == std::string::npos) {
+        send_error(1);
+        return;
+    }
+    const int type = static_cast<int>(parse_hex(args.substr(0, c1)));
+    if (type != 0) {
+        send_empty();
+        return;
+    }  // unsupported breakpoint type
+    const uint32_t addr = parse_hex(args.substr(c1 + 1, c2 - c1 - 1));
+    insert_breakpoint(addr) ? send_ok() : send_error(1);
+}
+
+void GdbStub::handle_breakpoint_clear(const std::string& args) {
+    const size_t c1 = args.find(',');
+    if (c1 == std::string::npos) {
+        send_error(1);
+        return;
+    }
+    const size_t c2 = args.find(',', c1 + 1);
+    if (c2 == std::string::npos) {
+        send_error(1);
+        return;
+    }
+    const int type = static_cast<int>(parse_hex(args.substr(0, c1)));
+    if (type != 0) {
+        send_empty();
+        return;
+    }
+    const uint32_t addr = parse_hex(args.substr(c1 + 1, c2 - c1 - 1));
+    remove_breakpoint(addr) ? send_ok() : send_error(1);
+}
+
+// ─── Continue / step ──────────────────────────────────────────────────────────
+
+void GdbStub::handle_continue(const std::string& args) {
+    if (!args.empty()) cpu_.set_pc(parse_hex(args));
+
+    running_ = true;
+    while (running_) {
+        last_result_ = cpu_.step();
+        if (last_result_ == StepResult::Halt) {
+            running_ = false;
+            send_signal(kSIGTRAP);
+            return;
+        }
+        if (last_result_ == StepResult::Exception) {
+            running_ = false;
+            // Report the faulting PC (EPC), not the exception vector.
+            // GDB receives: T{sig}thread:01;
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "T%02xthread:01;", stop_signal());
+            send_packet(buf);
+            // Restore PC to EPC so GDB sees the instruction that caused the exception.
+            cpu_.set_pc(cpu_.cp0().epc());
+            return;
+        }
+        if (last_result_ == StepResult::Fault) {
+            running_ = false;
+            send_signal(kSIGTRAP);
+            return;
+        }
+        // Check if we hit a software breakpoint (BREAK at current PC was restored;
+        // the CPU already executed it and took a Bp exception above, so this path
+        // is for hardware-BP-style address matching on normal instructions).
+        // Nothing to do here — the BREAK word in memory handles it automatically.
+    }
+}
+
+void GdbStub::handle_step(const std::string& args) {
+    if (!args.empty()) cpu_.set_pc(parse_hex(args));
+
+    last_result_ = cpu_.step();
+    if (last_result_ == StepResult::Exception) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "T%02xthread:01;", stop_signal());
+        send_packet(buf);
+        cpu_.set_pc(cpu_.cp0().epc());
+        return;
+    }
+    send_signal(kSIGTRAP);
+}
+
+// ─── Main dispatch ────────────────────────────────────────────────────────────
+
+void GdbStub::dispatch(const std::string& pkt) {
+    if (pkt.empty()) {
+        send_empty();
+        return;
+    }
+
+    const char        cmd  = pkt[0];
+    const std::string args = pkt.substr(1);
+
+    switch (cmd) {
+    case '?':
+        send_signal(kSIGTRAP);
+        break;
+
+    case 'g':
+        send_packet(handle_read_regs());
+        break;
+
+    case 'G':
+        handle_write_regs(args) ? send_ok() : send_error(1);
+        break;
+
+    case 'p':
+        send_packet(handle_read_reg(args));
+        break;
+
+    case 'P':
+        handle_write_reg(args) ? send_ok() : send_error(1);
+        break;
+
+    case 'm':
+        send_packet(handle_read_mem(args));
+        break;
+
+    case 'M':
+        handle_write_mem(args) ? send_ok() : send_error(1);
+        break;
+
+    case 'c':
+        handle_continue(args);
+        break;
+
+    case 's':
+        handle_step(args);
+        break;
+
+    case 'Z':
+        handle_breakpoint_set(args);
+        break;
+
+    case 'z':
+        handle_breakpoint_clear(args);
+        break;
+
+    case 'k':  // kill — stop the loop
+        running_ = false;
+        send_ok();
+        break;
+
+    case 'D':  // detach — stop the loop but don't kill the program
+        running_ = false;
+        send_ok();
+        break;
+
+    case 'H':  // set thread — we have one thread; ignore
+        send_ok();
+        break;
+
+    case 'T':  // thread alive
+        send_ok();
+        break;
+
+    case 'q':
+        if (args.substr(0, 9) == "Supported") {
+            send_packet("PacketSize=4000;swbreak+;hwbreak-");
+        } else if (args == "Attached") {
+            send_packet("1");  // attached to existing process
+        } else if (args == "C") {
+            send_packet("QC0");
+        } else if (args.substr(0, 6) == "Symbol") {
+            send_ok();
+        } else {
+            send_empty();
+        }
+        break;
+
+    case 'v':
+        if (args.substr(0, 5) == "Cont?") {
+            send_empty();  // not supported; GDB falls back to 'c'/'s'
+        } else {
+            send_empty();
+        }
+        break;
+
+    default:
+        send_empty();
+        break;
+    }
+}
+
+}  // namespace mips

--- a/src/mips/pipelined_cpu.cpp
+++ b/src/mips/pipelined_cpu.cpp
@@ -1,4 +1,7 @@
 #include "mips/pipelined_cpu.h"
+
+#include <vector>
+
 #include "mips/alu.h"
 #include "mips/decoder.h"
 
@@ -35,12 +38,12 @@ StepResult PipelinedCpu::step() {
 
     // Hazard / flush flags set by various stages.
     bool stall_load_use = false;
-    bool flush_from_ex  = false;  // 2-stage flush (branch, JR, JALR)
+    bool flush_from_ex  = false;  // 2-stage flush (branch, JR, JALR, exceptions)
     bool flush_from_id  = false;  // 1-stage flush (J, JAL)
     // Use SEPARATE target variables: EX and ID both run in the same step() call
     // and both may set a redirect.  flush_from_ex wins (higher priority), so we
     // must not let ID's write overwrite EX's target in a shared variable.
-    uint32_t   branch_pc = 0;  // target set by EX (branch / JR / JALR)
+    uint32_t   branch_pc = 0;  // target set by EX (branch / JR / JALR / exception)
     uint32_t   jump_pc   = 0;  // target set by ID (J / JAL)
     StepResult result    = StepResult::Ok;
 
@@ -69,25 +72,39 @@ StepResult PipelinedCpu::step() {
         new_mem.is_halt   = cur_ex.is_halt;
 
         if (cur_ex.ctrl.mem_read) {
+            const uint32_t          addr = cur_ex.alu.value;
             std::optional<uint32_t> loaded;
             switch (cur_ex.opcode) {
             case Opcode::LW:
-                loaded = mem_.read_word(cur_ex.alu.value);
+                loaded = mem_.read_word(addr);
                 break;
             case Opcode::LBU:
-                if (auto v = mem_.read_byte(cur_ex.alu.value)) loaded = *v;
+                if (auto v = mem_.read_byte(addr)) loaded = *v;
                 break;
             case Opcode::LHU:
-                if (auto v = mem_.read_half(cur_ex.alu.value)) loaded = *v;
+                if (auto v = mem_.read_half(addr)) loaded = *v;
                 break;
             default:
                 break;
             }
-            if (!loaded) return StepResult::Fault;
-            new_mem.mem_val = *loaded;
+            if (!loaded) {
+                // AdEL exception: flush EX, ID, IF and vector to exception handler.
+                branch_pc     = cp0_.raise(ExceptionCode::AdEL, cur_ex.pc, addr);
+                flush_from_ex = true;
+                new_mem       = {};
+                result        = StepResult::Exception;
+            } else {
+                new_mem.mem_val = *loaded;
+            }
         }
-        if (cur_ex.ctrl.mem_write) {
-            if (!mem_.write_word(cur_ex.alu.value, cur_ex.rt_val)) return StepResult::Fault;
+        if (cur_ex.ctrl.mem_write && result != StepResult::Exception) {
+            const uint32_t addr = cur_ex.alu.value;
+            if (!mem_.write_word(addr, cur_ex.rt_val)) {
+                branch_pc     = cp0_.raise(ExceptionCode::AdES, cur_ex.pc, addr);
+                flush_from_ex = true;
+                new_mem       = {};
+                result        = StepResult::Exception;
+            }
         }
     }
 
@@ -147,11 +164,9 @@ StepResult PipelinedCpu::step() {
                 new_ex.write_reg = 31;          // $ra
             }
             // J: ctrl.reg_write is already false; write_reg stays 0.
-        }
-
-        // ── BEQ / BNE: branch resolved in EX, 2-cycle flush ─────────────────
-        else if (dec.format == InstrFormat::I &&
-                 (dec.opcode == Opcode::BEQ || dec.opcode == Opcode::BNE)) {
+        } else if (dec.format == InstrFormat::I &&
+                   (dec.opcode == Opcode::BEQ || dec.opcode == Opcode::BNE)) {
+            // ── BEQ / BNE: branch resolved in EX, 2-cycle flush ───────────
             const AluResult cmp   = Alu::execute(AluOp::SUBU, fwd_a, fwd_b);
             const bool      taken = (dec.opcode == Opcode::BEQ) ? cmp.zero : !cmp.zero;
             if (taken) {
@@ -159,13 +174,10 @@ StepResult PipelinedCpu::step() {
                 branch_pc         = cur_id.pc4 + (static_cast<uint32_t>(off) << 2);
                 flush_from_ex     = true;
             }
-            // No writeback for branch instructions.
-            // new_ex stays invalid (default).
-        }
-
-        // ── JR / JALR: register jump resolved in EX, 2-cycle flush ──────────
-        else if (dec.format == InstrFormat::R &&
-                 (dec.r().funct == FunctCode::JR || dec.r().funct == FunctCode::JALR)) {
+            // No writeback for branch instructions; new_ex stays invalid.
+        } else if (dec.format == InstrFormat::R &&
+                   (dec.r().funct == FunctCode::JR || dec.r().funct == FunctCode::JALR)) {
+            // ── JR / JALR: register jump resolved in EX, 2-cycle flush ────
             branch_pc     = fwd_a;  // rs, potentially forwarded
             flush_from_ex = true;
             if (dec.r().funct == FunctCode::JALR) {
@@ -177,46 +189,99 @@ StepResult PipelinedCpu::step() {
                 new_ex.is_halt   = cur_id.is_halt;
             }
             // JR: no writeback; new_ex stays invalid.
-        }
-
-        // ── Regular ALU instruction ───────────────────────────────────────────
-        else {
+        } else if (dec.format == InstrFormat::R &&
+                   (dec.r().funct == FunctCode::SYSCALL || dec.r().funct == FunctCode::BREAK)) {
+            // ── SYSCALL / BREAK: raise CP0 exception, flush 2 stages ──────
+            const ExceptionCode code =
+                (dec.r().funct == FunctCode::SYSCALL) ? ExceptionCode::Sys : ExceptionCode::Bp;
+            branch_pc     = cp0_.raise(code, cur_id.pc);
+            flush_from_ex = true;
+            result        = StepResult::Exception;
+            // new_ex stays invalid — the exception handler gets a clean pipeline.
+        } else if (dec.opcode == Opcode::COP0) {
+            // ── COP0: MFC0 / MTC0 / ERET — execute in EX ─────────────────
+            const uint8_t sub = dec.r().rs;
+            if (sub == 0x00) {
+                // MFC0: read CP0 register, write to GPR in WB via alu_val path.
+                new_ex.valid          = true;
+                new_ex.pc             = cur_id.pc;
+                new_ex.ctrl           = cur_id.ctrl;
+                new_ex.ctrl.reg_write = true;
+                new_ex.alu.value      = cp0_.read(dec.r().rd);
+                new_ex.write_reg      = dec.r().rt;
+                new_ex.opcode         = dec.opcode;
+            } else if (sub == 0x04) {
+                // MTC0: write forwarded GPR value to CP0 register.
+                cp0_.write(dec.r().rd, fwd_b);
+                // No pipeline writeback needed.
+            } else if (sub == 0x10 && dec.r().funct == FunctCode::ERET) {
+                // ERET: clear EXL, jump to EPC — treated as a register jump.
+                branch_pc     = cp0_.eret();
+                flush_from_ex = true;
+            }
+            // Unknown COP0 sub-ops are silently ignored (EHB, etc.).
+        } else {
+            // ── Regular ALU instruction ────────────────────────────────────
             const auto aluop = Alu::control(dec);
-            if (!aluop) return StepResult::Fault;
+            if (!aluop) {
+                // Unrecognised instruction in EX: raise RI exception.
+                branch_pc     = cp0_.raise(ExceptionCode::RI, cur_id.pc);
+                flush_from_ex = true;
+                result        = StepResult::Exception;
+            } else {
+                uint8_t shamt = (dec.format == InstrFormat::R) ? dec.r().shamt : 0;
+                if (dec.format == InstrFormat::R) {
+                    const auto f = dec.r().funct;
+                    if (f == FunctCode::SLLV || f == FunctCode::SRLV)
+                        shamt = static_cast<uint8_t>(fwd_a & 0x1Fu);
+                }
 
-            uint8_t shamt = (dec.format == InstrFormat::R) ? dec.r().shamt : 0;
-            if (dec.format == InstrFormat::R) {
-                const auto f = dec.r().funct;
-                if (f == FunctCode::SLLV || f == FunctCode::SRLV)
-                    shamt = static_cast<uint8_t>(fwd_a & 0x1Fu);
+                // ALU B: register value or sign/zero-extended immediate.
+                uint32_t alu_b = fwd_b;
+                if (cur_id.ctrl.alu_src && dec.format == InstrFormat::I) {
+                    alu_b = (cur_id.ctrl.ext == Control::Ext::Sign)
+                                ? static_cast<uint32_t>(Decoder::sign_extend(dec.i().imm))
+                                : static_cast<uint32_t>(dec.i().imm);
+                }
+
+                const AluResult alu_res = Alu::execute(*aluop, fwd_a, alu_b, shamt);
+
+                // Signed overflow on ADD/SUB/ADDI raises Ov (ADDU/SUBU/ADDIU do not).
+                if (alu_res.overflow) {
+                    const auto funct =
+                        (dec.format == InstrFormat::R) ? dec.r().funct : FunctCode::SLL;
+                    const bool is_signed_op =
+                        (funct == FunctCode::ADD || funct == FunctCode::SUB) ||
+                        (dec.opcode == Opcode::ADDI);
+                    if (is_signed_op) {
+                        branch_pc     = cp0_.raise(ExceptionCode::Ov, cur_id.pc);
+                        flush_from_ex = true;
+                        result        = StepResult::Exception;
+                        // Skip normal writeback.
+                        goto ex_done;
+                    }
+                }
+
+                {
+                    // Destination register: rd (R-type), rt (I-type).
+                    uint8_t write_reg = 0;
+                    if (cur_id.ctrl.reg_dst && dec.format == InstrFormat::R)
+                        write_reg = dec.r().rd;
+                    else if (dec.format == InstrFormat::I)
+                        write_reg = dec.i().rt;
+
+                    new_ex.valid     = true;
+                    new_ex.pc        = cur_id.pc;
+                    new_ex.ctrl      = cur_id.ctrl;
+                    new_ex.alu       = alu_res;
+                    new_ex.rt_val    = fwd_b;  // forwarded rt for SW
+                    new_ex.write_reg = write_reg;
+                    new_ex.opcode    = dec.opcode;
+                    new_ex.is_halt   = cur_id.is_halt;
+                }
             }
-
-            // ALU B: register value or sign/zero-extended immediate.
-            uint32_t alu_b = fwd_b;
-            if (cur_id.ctrl.alu_src && dec.format == InstrFormat::I) {
-                alu_b = (cur_id.ctrl.ext == Control::Ext::Sign)
-                            ? static_cast<uint32_t>(Decoder::sign_extend(dec.i().imm))
-                            : static_cast<uint32_t>(dec.i().imm);
-            }
-
-            const AluResult alu_res = Alu::execute(*aluop, fwd_a, alu_b, shamt);
-
-            // Destination register: rd (R-type), rt (I-type).
-            uint8_t write_reg = 0;
-            if (cur_id.ctrl.reg_dst && dec.format == InstrFormat::R)
-                write_reg = dec.r().rd;
-            else if (dec.format == InstrFormat::I)
-                write_reg = dec.i().rt;
-
-            new_ex.valid     = true;
-            new_ex.pc        = cur_id.pc;
-            new_ex.ctrl      = cur_id.ctrl;
-            new_ex.alu       = alu_res;
-            new_ex.rt_val    = fwd_b;  // forwarded rt for SW
-            new_ex.write_reg = write_reg;
-            new_ex.opcode    = dec.opcode;
-            new_ex.is_halt   = cur_id.is_halt;
         }
+    ex_done: {}
     }
 
     // ── ID stage ─────────────────────────────────────────────────────────────
@@ -278,7 +343,13 @@ StepResult PipelinedCpu::step() {
 
     if (!stall_load_use && cur_if.valid) {
         const auto dec_opt = Decoder::decode(cur_if.instr);
-        if (!dec_opt) return StepResult::Fault;
+        if (!dec_opt) {
+            // Unrecognised instruction: raise Reserved Instruction exception.
+            branch_pc     = cp0_.raise(ExceptionCode::RI, cur_if.pc);
+            flush_from_ex = true;
+            result        = StepResult::Exception;
+            goto id_done;
+        }
         const DecodedInstr& dec = *dec_opt;
 
         // Register indices needed for hazard detection next cycle and for
@@ -311,6 +382,7 @@ StepResult PipelinedCpu::step() {
             flush_from_id = true;
         }
     }
+id_done: {}
 
     // ── IF stage ─────────────────────────────────────────────────────────────
     if (!stall_load_use) {
@@ -328,9 +400,12 @@ StepResult PipelinedCpu::step() {
                 const uint32_t jaddr = ((pc_ + 4) & 0xF000'0000u) | (tgt << 2);
                 if (jaddr == pc_) new_if.is_halt = true;
             }
+        } else {
+            // OOB or misaligned fetch → AdEL exception.
+            branch_pc     = cp0_.raise(ExceptionCode::AdEL, pc_, pc_);
+            flush_from_ex = true;
+            result        = StepResult::Exception;
         }
-        // OOB fetch → bubble.  The fault will surface if the processor tries
-        // to execute the invalid word (Decoder::decode will return nullopt).
     }
 
     // ── Determine next PC and apply flushes ──────────────────────────────────
@@ -390,7 +465,10 @@ bool PipelinedCpu::load_program(const std::vector<uint32_t>& words, uint32_t add
 
 void PipelinedCpu::reset(bool clear_memory) {
     regs_.reset();
+    cp0_.reset();
     pc_     = 0;
+    hi_     = 0;
+    lo_     = 0;
     ctrl_   = Control{};
     cycle_  = 0;
     ps_     = {};

--- a/src/mips/single_cycle_cpu.cpp
+++ b/src/mips/single_cycle_cpu.cpp
@@ -1,4 +1,7 @@
 #include "mips/single_cycle_cpu.h"
+
+#include <vector>
+
 #include "mips/alu.h"
 #include "mips/decoder.h"
 
@@ -11,12 +14,16 @@ Control derive_control(const DecodedInstr& instr) {
     Control c;
     switch (instr.format) {
     case InstrFormat::R:
+        if (instr.opcode == Opcode::COP0) return c;  // CP0 ops handle writeback themselves
         switch (instr.r().funct) {
         case FunctCode::JR:
             return c;  // no writeback, no mem
         case FunctCode::JALR:
             c.reg_write = true;
             return c;
+        case FunctCode::SYSCALL:
+        case FunctCode::BREAK:
+            return c;  // no writeback; exception path handles flow
         default:
             c.reg_write = true;
             c.reg_dst   = true;
@@ -75,10 +82,49 @@ Control derive_control(const DecodedInstr& instr) {
 
 SingleCycleCpu::SingleCycleCpu(std::size_t mem_bytes) : mem_(mem_bytes) {}
 
-bool SingleCycleCpu::exec_rtype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc) {
+StepResult SingleCycleCpu::raise(ExceptionCode code, uint32_t faulting_pc,
+                                 uint32_t bad_addr) noexcept {
+    pc_ = cp0_.raise(code, faulting_pc, bad_addr);
+    return StepResult::Exception;
+}
+
+// exec_rtype: returns false only for a genuinely unrecoverable internal error.
+// MIPS exceptions (overflow, SYSCALL, BREAK) set exc and return true so the
+// caller can forward the Exception result without treating it as a Fault.
+bool SingleCycleCpu::exec_rtype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc,
+                                StepResult& exc) {
     const RFields&  r = d.r();
     const FunctCode f = r.funct;
 
+    // ── COP0 instructions ────────────────────────────────────────────────────
+    if (d.opcode == Opcode::COP0) {
+        const uint8_t sub = r.rs;
+        if (sub == 0x00) {
+            // MFC0 rt, rd[sel] — move from CP0 to GPR
+            regs_.write(r.rt, cp0_.read(r.rd));
+        } else if (sub == 0x04) {
+            // MTC0 rt, rd[sel] — move to CP0 from GPR
+            cp0_.write(r.rd, regs_.read(r.rt));
+        } else if (sub == 0x10 && f == FunctCode::ERET) {
+            // ERET — return from exception
+            next_pc = cp0_.eret();
+        }
+        // Unknown COP0 sub-ops are silently ignored (no RI — they may be
+        // hazard-control instructions we don't model).
+        return true;
+    }
+
+    // ── SYSCALL / BREAK ──────────────────────────────────────────────────────
+    if (f == FunctCode::SYSCALL) {
+        exc = raise(ExceptionCode::Sys, pc4 - 4);
+        return true;
+    }
+    if (f == FunctCode::BREAK) {
+        exc = raise(ExceptionCode::Bp, pc4 - 4);
+        return true;
+    }
+
+    // ── JR / JALR ────────────────────────────────────────────────────────────
     if (f == FunctCode::JR) {
         next_pc = regs_.read(r.rs);
         return true;
@@ -90,6 +136,7 @@ bool SingleCycleCpu::exec_rtype(const DecodedInstr& d, uint32_t pc4, uint32_t& n
         return true;
     }
 
+    // ── ALU R-type ───────────────────────────────────────────────────────────
     const auto op = Alu::control(d);
     if (!op) return false;
 
@@ -99,11 +146,19 @@ bool SingleCycleCpu::exec_rtype(const DecodedInstr& d, uint32_t pc4, uint32_t& n
     if (f == FunctCode::SLLV || f == FunctCode::SRLV) shamt = static_cast<uint8_t>(a & 0x1Fu);
 
     const AluResult res = Alu::execute(*op, a, b, shamt);
+
+    // Signed overflow on ADD / SUB raises an exception (ADDU / SUBU do not).
+    if (res.overflow && (f == FunctCode::ADD || f == FunctCode::SUB)) {
+        exc = raise(ExceptionCode::Ov, pc4 - 4);
+        return true;
+    }
+
     regs_.write(r.rd, res.value);
     return true;
 }
 
-bool SingleCycleCpu::exec_itype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc) {
+bool SingleCycleCpu::exec_itype(const DecodedInstr& d, uint32_t pc4, uint32_t& next_pc,
+                                StepResult& exc) {
     const IFields& i  = d.i();
     const Opcode   op = d.opcode;
 
@@ -130,27 +185,44 @@ bool SingleCycleCpu::exec_itype(const DecodedInstr& d, uint32_t pc4, uint32_t& n
     if (!aluop) return false;
     const AluResult res = Alu::execute(*aluop, rs_val, imm);
 
+    // ADDI raises on signed overflow (ADDIU does not).
+    if (res.overflow && op == Opcode::ADDI) {
+        exc = raise(ExceptionCode::Ov, pc4 - 4);
+        return true;
+    }
+
     if (op == Opcode::LW || op == Opcode::LBU || op == Opcode::LHU) {
+        const uint32_t          addr = res.value;
         std::optional<uint32_t> loaded;
         switch (op) {
         case Opcode::LW:
-            loaded = mem_.read_word(res.value);
+            loaded = mem_.read_word(addr);
             break;
         case Opcode::LBU:
-            if (auto v = mem_.read_byte(res.value)) loaded = *v;
+            if (auto v = mem_.read_byte(addr)) loaded = *v;
             break;
         case Opcode::LHU:
-            if (auto v = mem_.read_half(res.value)) loaded = *v;
+            if (auto v = mem_.read_half(addr)) loaded = *v;
             break;
         default:
             break;
         }
-        if (!loaded) return false;
+        if (!loaded) {
+            exc = raise(ExceptionCode::AdEL, pc4 - 4, addr);
+            return true;
+        }
         regs_.write(i.rt, *loaded);
         return true;
     }
 
-    if (op == Opcode::SW) return mem_.write_word(res.value, rt_val);
+    if (op == Opcode::SW) {
+        const uint32_t addr = res.value;
+        if (!mem_.write_word(addr, rt_val)) {
+            exc = raise(ExceptionCode::AdES, pc4 - 4, addr);
+            return true;
+        }
+        return true;
+    }
 
     regs_.write(i.rt, res.value);
     return true;
@@ -160,21 +232,22 @@ StepResult SingleCycleCpu::step() {
     ++cycle_;
     const uint32_t cur_pc  = pc_;
     const auto     fetched = mem_.read_word(cur_pc);
-    if (!fetched) return StepResult::Fault;
+    if (!fetched) return raise(ExceptionCode::AdEL, cur_pc, cur_pc);
 
     const uint32_t pc4     = cur_pc + 4;
     const auto     decoded = Decoder::decode(*fetched);
-    if (!decoded) return StepResult::Fault;
+    if (!decoded) return raise(ExceptionCode::RI, cur_pc);
     const DecodedInstr& d = *decoded;
 
     ctrl_            = derive_control(d);
     uint32_t next_pc = pc4;
-    bool     ok      = true;
 
     // Populate EX snapshot (the only "stage" in single-cycle)
     ps_           = {};
     ps_.stages[2] = {"EX", true, false, false, cur_pc, *fetched};
     ps_.cycle     = cycle_;
+
+    StepResult exc = StepResult::Ok;  // filled by exec_* if an exception fires
 
     switch (d.format) {
     case InstrFormat::J:
@@ -182,16 +255,17 @@ StepResult SingleCycleCpu::step() {
         next_pc = (pc4 & 0xF000'0000u) | (d.j().target << 2);
         break;
     case InstrFormat::R:
-        ok = exec_rtype(d, pc4, next_pc);
+        if (!exec_rtype(d, pc4, next_pc, exc)) return StepResult::Fault;
         break;
     case InstrFormat::I:
-        ok = exec_itype(d, pc4, next_pc);
+        if (!exec_itype(d, pc4, next_pc, exc)) return StepResult::Fault;
         break;
     default:
-        return StepResult::Fault;
+        return raise(ExceptionCode::RI, cur_pc);
     }
 
-    if (!ok) return StepResult::Fault;
+    if (exc == StepResult::Exception) return exc;
+
     pc_ = next_pc;
     return (next_pc == cur_pc) ? StepResult::Halt : StepResult::Ok;
 }
@@ -204,7 +278,10 @@ bool SingleCycleCpu::load_program(const std::vector<uint32_t>& words, uint32_t a
 
 void SingleCycleCpu::reset(bool clear_memory) {
     regs_.reset();
+    cp0_.reset();
     pc_    = 0;
+    hi_    = 0;
+    lo_    = 0;
     ctrl_  = Control{};
     cycle_ = 0;
     ps_    = {};

--- a/tests/mips/cp0_test.cpp
+++ b/tests/mips/cp0_test.cpp
@@ -1,0 +1,257 @@
+// CP0 and exception integration tests.
+//
+// Tests the three layers together:
+//   1. Cp0 register semantics (raise / eret / read / write / reset)
+//   2. SingleCycleCpu exception paths (SYSCALL, BREAK, overflow, AdEL, RI)
+//   3. PipelinedCpu exception paths (SYSCALL, BREAK, overflow, AdEL)
+
+#include "mips/cp0.h"
+#include "mips/pipelined_cpu.h"
+#include "mips/single_cycle_cpu.h"
+
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+static int g_passed = 0, g_failed = 0;
+
+#define CHECK(expr)                                                                                \
+    do {                                                                                           \
+        if (expr) {                                                                                \
+            ++g_passed;                                                                            \
+        } else {                                                                                   \
+            std::fprintf(stderr, "FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);                  \
+            ++g_failed;                                                                            \
+        }                                                                                          \
+    } while (false)
+
+// ─── Instruction encoders (reused from cpu_test.cpp style) ───────────────────
+namespace enc {
+constexpr uint32_t R(uint32_t rs, uint32_t rt, uint32_t rd, uint32_t shamt, uint32_t funct) {
+    return (rs << 21) | (rt << 16) | (rd << 11) | (shamt << 6) | funct;
+}
+constexpr uint32_t I(uint32_t op, uint32_t rs, uint32_t rt, uint16_t imm) {
+    return (op << 26) | (rs << 21) | (rt << 16) | imm;
+}
+// Registers
+constexpr uint32_t zero = 0, t0 = 8, t1 = 9, t2 = 10;
+// Opcodes
+constexpr uint32_t ADDI = 0x08, LW = 0x23, SW = 0x2B;
+// Funct codes
+constexpr uint32_t F_ADD = 0x20, F_SUB = 0x22;
+constexpr uint32_t F_SYSCALL = 0x0C, F_BREAK = 0x0D;
+// SYSCALL: opcode=SPECIAL(0), all fields 0, funct=0x0C
+constexpr uint32_t SYSCALL = F_SYSCALL;
+// BREAK: same pattern with funct=0x0D
+constexpr uint32_t BREAK_INSTR = F_BREAK;
+// Halt: J self (J target=0, pc+4[31:28]=0 → stays at 0)
+constexpr uint32_t HALT_AT_0 = (0x02u << 26) | 0x0u;
+// COP0 funct codes
+constexpr uint32_t COP0_OP = 0x10u;
+constexpr uint32_t MFC0_RS = 0x00u;
+constexpr uint32_t MTC0_RS = 0x04u;
+constexpr uint32_t ERET_RS = 0x10u, ERET_FUNCT = 0x18u;
+
+// MFC0 rt, rd — move from CP0 register rd to GPR rt
+constexpr uint32_t MFC0(uint32_t rt, uint32_t cp0_reg) {
+    return (COP0_OP << 26) | (MFC0_RS << 21) | (rt << 16) | (cp0_reg << 11);
+}
+// MTC0 rt, rd — move from GPR rt to CP0 register rd
+constexpr uint32_t MTC0(uint32_t rt, uint32_t cp0_reg) {
+    return (COP0_OP << 26) | (MTC0_RS << 21) | (rt << 16) | (cp0_reg << 11);
+}
+// ERET
+constexpr uint32_t ERET = (COP0_OP << 26) | (ERET_RS << 21) | ERET_FUNCT;
+}  // namespace enc
+
+// ─── Cp0 unit tests ───────────────────────────────────────────────────────────
+
+static void test_cp0_raise_eret() {
+    mips::Cp0 cp0;
+    CHECK(!cp0.in_exception());
+
+    const uint32_t vec = cp0.raise(mips::ExceptionCode::Sys, 0x1000);
+    CHECK(vec == mips::kExceptionVector);
+    CHECK(cp0.in_exception());
+    CHECK(cp0.epc() == 0x1000);
+    CHECK(cp0.last_exception() == mips::ExceptionCode::Sys);
+    // Cause.ExcCode = 8 (Sys) << 2
+    CHECK((cp0.cause() & 0x7Cu) == (8u << 2));
+
+    const uint32_t ret = cp0.eret();
+    CHECK(ret == 0x1000);
+    CHECK(!cp0.in_exception());
+}
+
+static void test_cp0_badvaddr() {
+    mips::Cp0 cp0;
+    cp0.raise(mips::ExceptionCode::AdEL, 0x2000, 0xDEAD'BEEF);
+    CHECK(cp0.bad_vaddr() == 0xDEAD'BEEFu);
+}
+
+static void test_cp0_read_write() {
+    mips::Cp0 cp0;
+    cp0.write(mips::Cp0::kRegStatus, 0xABCD);
+    CHECK(cp0.read(mips::Cp0::kRegStatus) == 0xABCDu);
+    // Unknown register: read 0, write ignored.
+    CHECK(cp0.read(99) == 0);
+    cp0.write(99, 0xFF);
+    CHECK(cp0.read(99) == 0);
+}
+
+static void test_cp0_reset() {
+    mips::Cp0 cp0;
+    cp0.raise(mips::ExceptionCode::Ov, 0x500);
+    cp0.reset();
+    CHECK(!cp0.in_exception());
+    CHECK(cp0.epc() == 0);
+    CHECK(cp0.cause() == 0);
+}
+
+// ─── SingleCycleCpu exception tests ──────────────────────────────────────────
+
+static void test_single_syscall() {
+    mips::SingleCycleCpu cpu(1u << 16);
+    cpu.load_program({enc::SYSCALL, enc::HALT_AT_0}, 0);
+    const auto r = cpu.step();
+    CHECK(r == mips::StepResult::Exception);
+    CHECK(cpu.cp0().last_exception() == mips::ExceptionCode::Sys);
+    CHECK(cpu.cp0().epc() == 0x0000);  // PC of the SYSCALL instruction
+    CHECK(cpu.cp0().in_exception());
+}
+
+static void test_single_break() {
+    mips::SingleCycleCpu cpu(1u << 16);
+    cpu.load_program({enc::BREAK_INSTR, enc::HALT_AT_0}, 0);
+    const auto r = cpu.step();
+    CHECK(r == mips::StepResult::Exception);
+    CHECK(cpu.cp0().last_exception() == mips::ExceptionCode::Bp);
+}
+
+static void test_single_overflow_add() {
+    // ADD $t2, $t0, $t1 where t0=0x7FFFFFFF and t1=1 → signed overflow
+    mips::SingleCycleCpu cpu(1u << 16);
+    cpu.regs().write(enc::t0, 0x7FFF'FFFF);
+    cpu.regs().write(enc::t1, 1);
+    const uint32_t add_instr = enc::R(enc::t0, enc::t1, enc::t2, 0, enc::F_ADD);
+    cpu.load_program({add_instr, enc::HALT_AT_0}, 0);
+    const auto r = cpu.step();
+    CHECK(r == mips::StepResult::Exception);
+    CHECK(cpu.cp0().last_exception() == mips::ExceptionCode::Ov);
+    // $t2 must NOT be written on overflow.
+    CHECK(cpu.regs().read(enc::t2) == 0);
+}
+
+static void test_single_addi_overflow() {
+    // ADDI $t0, $zero, 0x7FFF → no overflow (fits).
+    // ADDI $t0, $t0, 1 → t0 = 0x8000, still no overflow in 32-bit (0x7FFF+1=0x8000 unsigned OK
+    // but signed result is +32768 which fits in int32 so no overflow).
+    // Let's test ADDI $t0, $zero, 32767 then ADDI $t0, $t0, 1: 32768 fits; no overflow.
+    // Real overflow: $t0 = INT32_MAX, ADDI $t0, $t0, 1.
+    mips::SingleCycleCpu cpu(1u << 16);
+    cpu.regs().write(enc::t0, 0x7FFF'FFFFu);
+    // ADDI t1, t0, 1
+    const uint32_t addi = enc::I(enc::ADDI, enc::t0, enc::t1, 1);
+    cpu.load_program({addi, enc::HALT_AT_0}, 0);
+    const auto r = cpu.step();
+    CHECK(r == mips::StepResult::Exception);
+    CHECK(cpu.cp0().last_exception() == mips::ExceptionCode::Ov);
+}
+
+static void test_single_addr_error_load() {
+    // LW from address 0xFFFF (out of 64KB memory)
+    mips::SingleCycleCpu cpu(1u << 16);
+    // LW $t0, 0($t1) where $t1 = 0xFFFF (misaligned or OOB)
+    cpu.regs().write(enc::t1, 0xFFFC);  // points to last word — actually in bounds
+    // Use an address definitely out of bounds: 0x10000
+    cpu.regs().write(enc::t1, 0x1'0000);
+    const uint32_t lw = enc::I(enc::LW, enc::t1, enc::t0, 0);
+    cpu.load_program({lw, enc::HALT_AT_0}, 0);
+    const auto r = cpu.step();
+    CHECK(r == mips::StepResult::Exception);
+    CHECK(cpu.cp0().last_exception() == mips::ExceptionCode::AdEL);
+    CHECK(cpu.cp0().bad_vaddr() == 0x1'0000u);
+}
+
+static void test_single_mfc0_mtc0() {
+    mips::SingleCycleCpu cpu(1u << 16);
+    // MTC0 $t0, Status — set Status via MTC0
+    // MFC0 $t1, Status — read it back into $t1
+    cpu.regs().write(enc::t0, 0x1234'5678);
+    const std::vector<uint32_t> prog = {
+        enc::MTC0(enc::t0, mips::Cp0::kRegStatus),  // CP0.Status = t0
+        enc::MFC0(enc::t1, mips::Cp0::kRegStatus),  // t1 = CP0.Status
+        enc::HALT_AT_0,
+    };
+    cpu.load_program(prog, 0);
+    cpu.step();  // MTC0
+    cpu.step();  // MFC0
+    CHECK(cpu.regs().read(enc::t1) == 0x1234'5678u);
+}
+
+static void test_single_eret() {
+    mips::SingleCycleCpu cpu(1u << 16);
+    // Raise an exception to set EPC, then ERET to return.
+    cpu.load_program({enc::SYSCALL, enc::ERET, enc::HALT_AT_0}, 0);
+    cpu.step();  // SYSCALL — raises Sys exception, PC → exception vector
+    // EPC should be 0x0000 (address of SYSCALL)
+    CHECK(cpu.cp0().epc() == 0x0000u);
+    // Manually set PC back to the ERET instruction (next instruction after SYSCALL).
+    // (Normally the exception handler would do this; we shortcut for the test.)
+    cpu.set_pc(4);  // address of ERET
+    cpu.step();     // ERET — PC ← EPC = 0
+    CHECK(!cpu.cp0().in_exception());
+    CHECK(cpu.pc() == 0x0000u);
+}
+
+// ─── PipelinedCpu exception tests ────────────────────────────────────────────
+
+static void test_pipelined_syscall() {
+    mips::PipelinedCpu cpu(1u << 16);
+    // SYSCALL at 0, then a few NOPs (SLL $zero, $zero, 0 = 0x00000000).
+    const uint32_t NOP = 0x00000000u;
+    cpu.load_program({enc::SYSCALL, NOP, NOP, NOP, enc::HALT_AT_0}, 0);
+    // Step until Exception (may take a few cycles to propagate through the pipeline).
+    mips::StepResult r = mips::StepResult::Ok;
+    for (int i = 0; i < 10 && r == mips::StepResult::Ok; ++i)
+        r = cpu.step();
+    CHECK(r == mips::StepResult::Exception);
+    CHECK(cpu.cp0().last_exception() == mips::ExceptionCode::Sys);
+}
+
+static void test_pipelined_break() {
+    mips::PipelinedCpu cpu(1u << 16);
+    const uint32_t     NOP = 0x00000000u;
+    cpu.load_program({enc::BREAK_INSTR, NOP, NOP, NOP, enc::HALT_AT_0}, 0);
+    mips::StepResult r = mips::StepResult::Ok;
+    for (int i = 0; i < 10 && r == mips::StepResult::Ok; ++i)
+        r = cpu.step();
+    CHECK(r == mips::StepResult::Exception);
+    CHECK(cpu.cp0().last_exception() == mips::ExceptionCode::Bp);
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+int main() {
+    // Cp0 unit tests
+    test_cp0_raise_eret();
+    test_cp0_badvaddr();
+    test_cp0_read_write();
+    test_cp0_reset();
+
+    // SingleCycleCpu exception tests
+    test_single_syscall();
+    test_single_break();
+    test_single_overflow_add();
+    test_single_addi_overflow();
+    test_single_addr_error_load();
+    test_single_mfc0_mtc0();
+    test_single_eret();
+
+    // PipelinedCpu exception tests
+    test_pipelined_syscall();
+    test_pipelined_break();
+
+    std::printf("\n%d passed, %d failed\n", g_passed, g_failed);
+    return g_failed ? 1 : 0;
+}

--- a/tests/mips/cpu_test.cpp
+++ b/tests/mips/cpu_test.cpp
@@ -196,17 +196,17 @@ static void test_zero_and_faults() {
     CHECK(cpu.run() == StepResult::Halt);
     CHECK(cpu.regs().read(zero) == 0);
 
-    // An undecodable opcode faults rather than running off the rails.
+    // An undecodable opcode raises a Reserved Instruction (RI) exception.
     Cpu cpu2;
     CHECK(cpu2.load_program({0xFC00'0000u}));  // opcode 0x3F — not in ISA
-    CHECK(cpu2.step() == StepResult::Fault);
+    CHECK(cpu2.step() == StepResult::Exception);
 
-    // Running past the end of memory faults on fetch.
+    // Running past the end of memory raises an AdEL (address error on load) exception.
     Cpu cpu3(8);  // 8 bytes = 2 words
     CHECK(cpu3.load_program({I(ADDI, zero, t0, 1), I(ADDI, zero, t1, 2)}));
-    CHECK(cpu3.step() == StepResult::Ok);     // addr 0
-    CHECK(cpu3.step() == StepResult::Ok);     // addr 4
-    CHECK(cpu3.step() == StepResult::Fault);  // addr 8 — out of bounds
+    CHECK(cpu3.step() == StepResult::Ok);         // addr 0
+    CHECK(cpu3.step() == StepResult::Ok);         // addr 4
+    CHECK(cpu3.step() == StepResult::Exception);  // addr 8 — AdEL
 }
 
 int main() {

--- a/tests/mips/elf_loader_test.cpp
+++ b/tests/mips/elf_loader_test.cpp
@@ -1,0 +1,260 @@
+// ELF loader tests — parse_elf and load_elf_into_processor.
+//
+// Uses hand-crafted minimal MIPS ELF32 (LE) binaries so the tests have zero
+// external dependencies (no cross-compiler required).  The ELF images are
+// synthesised in-memory and fed through a std::istringstream.
+
+#include "mips/elf_loader.h"
+#include "mips/single_cycle_cpu.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <vector>
+
+static int g_passed = 0, g_failed = 0;
+
+#define CHECK(expr)                                                                                \
+    do {                                                                                           \
+        if (expr) {                                                                                \
+            ++g_passed;                                                                            \
+        } else {                                                                                   \
+            std::fprintf(stderr, "FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);                  \
+            ++g_failed;                                                                            \
+        }                                                                                          \
+    } while (false)
+
+// ─── Minimal ELF32 builder ────────────────────────────────────────────────────
+// Constructs the smallest valid MIPS LE ELF32 executable in memory.
+
+#pragma pack(push, 1)
+struct Elf32Ehdr {
+    uint8_t  e_ident[16];
+    uint16_t e_type;
+    uint16_t e_machine;
+    uint32_t e_version;
+    uint32_t e_entry;
+    uint32_t e_phoff;
+    uint32_t e_shoff;
+    uint32_t e_flags;
+    uint16_t e_ehsize;
+    uint16_t e_phentsize;
+    uint16_t e_phnum;
+    uint16_t e_shentsize;
+    uint16_t e_shnum;
+    uint16_t e_shstrndx;
+};
+struct Elf32Phdr {
+    uint32_t p_type;
+    uint32_t p_offset;
+    uint32_t p_vaddr;
+    uint32_t p_paddr;
+    uint32_t p_filesz;
+    uint32_t p_memsz;
+    uint32_t p_flags;
+    uint32_t p_align;
+};
+#pragma pack(pop)
+
+// Build a one-segment ELF: `words` loaded at `vaddr`, entry = `entry`.
+static std::string make_elf(const std::vector<uint32_t>& words, uint32_t vaddr, uint32_t entry) {
+    const auto seg_bytes = static_cast<uint32_t>(words.size() * sizeof(uint32_t));
+    // File layout: ELF header, then one program header, then segment data.
+    const uint32_t phdr_offset = sizeof(Elf32Ehdr);
+    const uint32_t data_offset = phdr_offset + sizeof(Elf32Phdr);
+
+    Elf32Ehdr eh{};
+    eh.e_ident[0]  = 0x7f;
+    eh.e_ident[1]  = 'E';
+    eh.e_ident[2]  = 'L';
+    eh.e_ident[3]  = 'F';
+    eh.e_ident[4]  = 1;  // ELFCLASS32
+    eh.e_ident[5]  = 1;  // ELFDATA2LSB
+    eh.e_ident[6]  = 1;  // EV_CURRENT
+    eh.e_type      = 2;  // ET_EXEC
+    eh.e_machine   = 8;  // EM_MIPS
+    eh.e_version   = 1;
+    eh.e_entry     = entry;
+    eh.e_phoff     = phdr_offset;
+    eh.e_ehsize    = sizeof(Elf32Ehdr);
+    eh.e_phentsize = sizeof(Elf32Phdr);
+    eh.e_phnum     = 1;
+
+    Elf32Phdr ph{};
+    ph.p_type   = 1;  // PT_LOAD
+    ph.p_offset = data_offset;
+    ph.p_vaddr  = vaddr;
+    ph.p_paddr  = vaddr;
+    ph.p_filesz = seg_bytes;
+    ph.p_memsz  = seg_bytes;
+    ph.p_flags  = 5;  // PF_R | PF_X
+    ph.p_align  = 4;
+
+    std::string out;
+    out.resize(data_offset + seg_bytes);
+    std::memcpy(out.data(), &eh, sizeof(eh));
+    std::memcpy(out.data() + phdr_offset, &ph, sizeof(ph));
+    std::memcpy(out.data() + data_offset, words.data(), seg_bytes);
+    return out;
+}
+
+static mips::ElfImage parse_from_bytes(const std::string& bytes) {
+    std::istringstream s(bytes);
+    return mips::parse_elf(s);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+static void test_parse_valid_elf() {
+    // Two-word segment at vaddr=0, entry=0.
+    const std::vector<uint32_t> words = {0x00000000u, 0x0800'0000u};
+    const auto                  img   = parse_from_bytes(make_elf(words, 0, 0));
+    CHECK(img.ok());
+    CHECK(img.entry == 0);
+    CHECK(img.segments.size() == 1);
+    CHECK(img.segments[0].vaddr == 0);
+    CHECK(img.segments[0].filesz == 8);
+    CHECK(img.segments[0].data.size() == 8);
+    // Verify the raw bytes in the segment.
+    CHECK(img.segments[0].data[0] == 0x00);
+    CHECK(img.segments[0].data[4] == 0x00);
+    CHECK(img.segments[0].data[7] == 0x08);
+}
+
+static void test_parse_entry_point() {
+    const std::vector<uint32_t> words = {0x0800'0001u};
+    const auto                  img   = parse_from_bytes(make_elf(words, 0x1000, 0x1004));
+    CHECK(img.ok());
+    CHECK(img.entry == 0x1004u);
+    CHECK(img.segments[0].vaddr == 0x1000u);
+}
+
+static void test_parse_bad_magic() {
+    std::string bad(16 + 36, '\0');  // short header, wrong magic
+    bad[0] = 'N';
+    bad[1] = 'O';
+    bad[2] = 'P';
+    bad[3] = 'E';
+    std::istringstream s(bad);
+    const auto         img = mips::parse_elf(s);
+    CHECK(!img.ok());
+    CHECK(img.error.has_value());
+}
+
+static void test_parse_big_endian_rejected() {
+    auto bytes = make_elf({0u}, 0, 0);
+    bytes[5]   = 2;  // ELFDATA2MSB — patch endianness byte
+    std::istringstream s(bytes);
+    const auto         img = mips::parse_elf(s);
+    CHECK(!img.ok());
+}
+
+static void test_parse_wrong_machine() {
+    auto bytes = make_elf({0u}, 0, 0);
+    // Patch e_machine to x86 (3) at offset 18 (LE).
+    bytes[18] = 3;
+    bytes[19] = 0;
+    std::istringstream s(bytes);
+    const auto         img = mips::parse_elf(s);
+    CHECK(!img.ok());
+}
+
+static void test_parse_too_short() {
+    const std::string  empty;
+    std::istringstream s(empty);
+    const auto         img = mips::parse_elf(s);
+    CHECK(!img.ok());
+}
+
+static void test_load_into_processor() {
+    // Halt instruction (J self at address 0): 0x08000000
+    const std::vector<uint32_t> words = {0x0800'0000u};
+    const auto                  img   = parse_from_bytes(make_elf(words, 0, 0));
+    CHECK(img.ok());
+
+    mips::SingleCycleCpu cpu(1u << 16);
+    std::string          err;
+    const bool           ok = mips::load_elf_into_processor(cpu, img, err);
+    CHECK(ok);
+    CHECK(cpu.pc() == 0u);
+
+    // The loaded word at address 0 should be the halt instruction.
+    const auto w = cpu.mem().read_word(0);
+    CHECK(w.has_value());
+    CHECK(*w == 0x0800'0000u);
+
+    // Actually running one step should return Halt.
+    const auto r = cpu.step();
+    CHECK(r == mips::StepResult::Halt);
+}
+
+static void test_load_respects_vaddr() {
+    // Load two words at vaddr=0x0100, entry=0x0100.
+    const std::vector<uint32_t> words = {0xDEAD'BEEFu, 0xCAFE'BABEu};
+    const auto                  img   = parse_from_bytes(make_elf(words, 0x0100, 0x0100));
+    CHECK(img.ok());
+
+    mips::SingleCycleCpu cpu(1u << 16);
+    std::string          err;
+    CHECK(mips::load_elf_into_processor(cpu, img, err));
+    CHECK(cpu.pc() == 0x0100u);
+    CHECK(cpu.mem().read_word(0x0100).value_or(0) == 0xDEAD'BEEFu);
+    CHECK(cpu.mem().read_word(0x0104).value_or(0) == 0xCAFE'BABEu);
+}
+
+static void test_load_out_of_bounds() {
+    // Segment at vaddr beyond the processor's 64KB memory.
+    const std::vector<uint32_t> words = {0u};
+    const auto                  img   = parse_from_bytes(make_elf(words, 0x1'0000, 0x1'0000));
+    CHECK(img.ok());
+
+    mips::SingleCycleCpu cpu(1u << 16);  // 64 KB
+    std::string          err;
+    const bool           ok = mips::load_elf_into_processor(cpu, img, err);
+    CHECK(!ok);
+    CHECK(!err.empty());
+}
+
+static void test_bss_zero_fill() {
+    // Build a segment where memsz > filesz so BSS is zero-filled.
+    // We patch the phdr by hand.
+    const std::vector<uint32_t> words = {0xAAAA'AAAAu};
+    auto                        bytes = make_elf(words, 0x200, 0x200);
+
+    // Patch p_memsz at offset sizeof(Elf32Ehdr) + 24 (p_memsz is the 6th field).
+    const size_t memsz_off = sizeof(Elf32Ehdr) + 20;  // p_memsz offset in Elf32Phdr
+    uint32_t     new_memsz = 8;                       // 4 file bytes + 4 BSS bytes
+    std::memcpy(bytes.data() + memsz_off, &new_memsz, 4);
+
+    std::istringstream s(bytes);
+    const auto         img = mips::parse_elf(s);
+    CHECK(img.ok());
+    CHECK(img.segments[0].memsz == 8);
+    CHECK(img.segments[0].filesz == 4);
+
+    mips::SingleCycleCpu cpu(1u << 16);
+    std::string          err;
+    CHECK(mips::load_elf_into_processor(cpu, img, err));
+    // BSS byte at vaddr+4 should be zero.
+    CHECK(cpu.mem().read_byte(0x204).value_or(0xFF) == 0);
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+int main() {
+    test_parse_valid_elf();
+    test_parse_entry_point();
+    test_parse_bad_magic();
+    test_parse_big_endian_rejected();
+    test_parse_wrong_machine();
+    test_parse_too_short();
+    test_load_into_processor();
+    test_load_respects_vaddr();
+    test_load_out_of_bounds();
+    test_bss_zero_fill();
+
+    std::printf("\n%d passed, %d failed\n", g_passed, g_failed);
+    return g_failed ? 1 : 0;
+}

--- a/tests/mips/processor_test.cpp
+++ b/tests/mips/processor_test.cpp
@@ -182,13 +182,13 @@ static void test_zero_hardwired(IProcessor& cpu, std::string_view label) {
 static void test_fault_oob(IProcessor& cpu, std::string_view label) {
     using namespace enc;
     // A word with opcode 0x3F has no defined MIPS instruction — Decoder::decode
-    // returns nullopt and the CPU must return Fault.  Single-cycle faults on
-    // step 1 (decode happens in the same step as fetch).  Pipelined faults on
-    // step 2 (instruction reaches ID where decode happens).  run() stops on the
-    // first non-Ok result, so both implementations converge here.
+    // returns nullopt and the CPU raises a Reserved Instruction (RI) exception.
+    // Single-cycle raises on step 1 (decode + execute in same step).  Pipelined
+    // raises on step 2 (instruction reaches ID stage where decode happens).
+    // run() stops on the first non-Ok result, so both implementations converge.
     cpu.reset(true);
     CHECK(cpu.load_program({0xFC00'0000u}));
-    CHECK(cpu.run(10) == StepResult::Fault);
+    CHECK(cpu.run(10) == StepResult::Exception);
     (void)label;
 }
 

--- a/wiki/CP0-Exceptions.md
+++ b/wiki/CP0-Exceptions.md
@@ -1,0 +1,108 @@
+# CP0 and the MIPS Exception Model
+
+clearCore's `mips_core` library now implements a minimal **Coprocessor 0 (CP0)** that models the MIPS32r2 exception architecture. Every `IProcessor` implementation — both `SingleCycleCpu` and `PipelinedCpu` — integrates with CP0 so exceptions are raised, recorded, and observable in the same way real MIPS hardware handles them.
+
+## Why exceptions matter for an emulator
+
+Before CP0, any bad instruction or memory access returned `StepResult::Fault` and stopped the CPU cold. That makes debugging impossible: there is no context to inspect, no way to recover, and no signal to a debugger. The MIPS hardware exception model solves all three:
+
+- **Recoverable:** the faulting PC is saved in EPC. An exception handler (or GDB) can inspect the problem and resume.
+- **Observable:** the Cause register names the exception type; BadVAddr records the faulting address for address errors.
+- **Composable with the GDB stub:** the stub intercepts exceptions and translates them to GDB signals (SIGTRAP for BREAK, SIGSYS for SYSCALL, SIGSEGV for address errors), enabling real debugger-driven inspection.
+
+## Supported exception types
+
+| Code | Name  | Trigger |
+|------|-------|---------|
+| 0    | Int   | Hardware interrupt (not generated internally; modelled for completeness) |
+| 4    | AdEL  | Address error on instruction fetch or data load (OOB, misaligned) |
+| 5    | AdES  | Address error on data store (OOB, misaligned) |
+| 8    | Sys   | `SYSCALL` instruction |
+| 9    | Bp    | `BREAK` instruction |
+| 10   | RI    | Reserved (unrecognised) instruction |
+| 12   | Ov    | Signed arithmetic overflow (`ADD`, `ADDI`, `SUB`) |
+
+## New instructions
+
+| Instruction | Encoding | Behaviour |
+|-------------|----------|-----------|
+| `SYSCALL`   | `SPECIAL funct=0x0C` | Raises `ExceptionCode::Sys`. Conventionally: $v0 holds the syscall number, $a0–$a3 hold arguments. |
+| `BREAK`     | `SPECIAL funct=0x0D` | Raises `ExceptionCode::Bp`. Used by GDB for software breakpoints. |
+| `MFC0 rt, rd` | `COP0 rs=0` | Moves CP0 register `rd` into GPR `rt`. |
+| `MTC0 rt, rd` | `COP0 rs=4` | Moves GPR `rt` into CP0 register `rd`. |
+| `ERET`      | `COP0 rs=0x10 funct=0x18` | Clears `Status.EXL`, restores PC from EPC. Used at the end of every exception handler. |
+
+## CP0 registers
+
+| Reg # | Name     | Accessible via | Meaning |
+|-------|----------|----------------|---------|
+| 8     | BadVAddr | `MFC0 rt, $8`  | Address that caused the most recent AdEL or AdES exception |
+| 12    | Status   | `MFC0`/`MTC0 rt, $12` | `EXL` bit (bit 1) is 1 while inside an exception handler |
+| 13    | Cause    | `MFC0 rt, $13` | ExcCode field [6:2] holds the exception code |
+| 14    | EPC      | `MFC0`/`MTC0 rt, $14` | Return address for ERET |
+
+## Exception vector
+
+Real MIPS hardware vectors to `0x8000_0180` (Status.BEV=0). clearCore uses this same address. Because the default memory size is 64 KB, you must either:
+
+1. **Run under the GDB stub** — the stub intercepts exceptions before the CPU fetches from the vector, so no handler code is needed at `0x8000_0180`.
+2. **Increase memory size** — pass a larger `mem_bytes` value to the `IProcessor` constructor, then map handler code at the vector address.
+3. **ERET in the handler** — for testing, load a minimal handler (`ERET` at `0x8000_0180`) to return execution to EPC+4.
+
+## StepResult changes
+
+`StepResult::Exception` is the new return value for any step where a MIPS exception was raised. The previous `Fault` return (for truly unrecoverable internal errors) is still present but no longer returned for address errors or unrecognised instructions — those are now proper CP0 exceptions.
+
+```cpp
+switch (cpu.step()) {
+case StepResult::Ok:        /* normal */         break;
+case StepResult::Halt:      /* self-jump */      break;
+case StepResult::Exception: /* CP0 exception */
+    std::cout << "Exception: " << mips::exception_name(cpu.cp0().last_exception())
+              << " EPC=0x" << std::hex << cpu.cp0().epc() << "\n";
+    break;
+case StepResult::Fault:     /* internal error */ break;
+}
+```
+
+## Example: writing a minimal syscall handler
+
+```mips
+# Entry point
+main:
+    ori  $v0, $zero, 1         # syscall 1 = "print int"
+    ori  $a0, $zero, 42
+    syscall                    # raises Sys exception → vectors to 0x8000_0180
+
+# Exception handler (must be mapped at 0x8000_0180)
+exc_handler:
+    mfc0 $k0, $13              # read Cause
+    andi $k0, $k0, 0x7C        # extract ExcCode field
+    srl  $k0, $k0, 2
+    ori  $k1, $zero, 8         # 8 = Sys (SYSCALL)
+    bne  $k0, $k1, not_syscall
+    # handle syscall: read $v0, dispatch ...
+    addiu $k0, $14, 4          # EPC + 4 = instruction after SYSCALL
+    mtc0 $k0, $14
+not_syscall:
+    eret                       # clear EXL, restore PC from EPC
+```
+
+## API reference
+
+```cpp
+#include "mips/cp0.h"
+#include "mips/processor.h"
+
+// After step() returns Exception:
+const mips::Cp0& cp0 = cpu.cp0();
+cp0.last_exception();   // ExceptionCode enum value
+cp0.epc();             // faulting instruction address
+cp0.cause();           // raw Cause register
+cp0.bad_vaddr();       // for AdEL/AdES: the bad address
+cp0.in_exception();    // true while Status.EXL == 1
+
+// MFC0/MTC0 via the register number interface:
+cp0.read(mips::Cp0::kRegStatus);
+cp0.write(mips::Cp0::kRegEpc, new_epc);
+```

--- a/wiki/ELF-Loader.md
+++ b/wiki/ELF-Loader.md
@@ -1,0 +1,116 @@
+# ELF Loader
+
+clearCore can now load real compiled MIPS binaries directly into the emulator's memory, instead of requiring hand-assembled word arrays or the custom hex format. The ELF loader parses MIPS ELF32 executables, maps each `PT_LOAD` segment into the processor's address space, and sets the initial PC to the ELF entry point.
+
+## Supported format
+
+| Property | Supported value |
+|----------|----------------|
+| Architecture | EM_MIPS (8) |
+| Class | ELFCLASS32 (32-bit) |
+| Endianness | **ELFDATA2LSB (little-endian / mipsel only)** |
+| Type | ET_EXEC (static executable) |
+| Segments | All `PT_LOAD` segments are mapped; BSS (memsz > filesz) is zero-filled |
+
+Big-endian MIPS ELF files (`ELFDATA2MSB`) are rejected with a clear error message. The emulator's `Memory` model is little-endian, so loading a big-endian ELF without byte-swapping every instruction would produce garbage. Use a `mipsel` (little-endian) toolchain instead.
+
+## Building compatible programs
+
+### Bare-metal assembly (recommended for learning)
+
+```bash
+# Install the mipsel cross-toolchain
+sudo dnf install gcc-mipsel-linux-gnu binutils-mipsel-linux-gnu  # Fedora
+sudo apt install binutils-mipsel-linux-gnu gcc-mipsel-linux-gnu  # Debian/Ubuntu
+
+# hello.s: add two numbers and store the result
+.text
+.global _start
+_start:
+    ori  $t0, $zero, 10
+    ori  $t1, $zero, 20
+    add  $t2, $t0, $t1      # t2 = 30
+    # Halt: self-targeting jump
+    b    .
+
+# Assemble and link
+mipsel-linux-gnu-as -mips32r2 -EL -o hello.o hello.s
+mipsel-linux-gnu-ld -e _start -Ttext=0x0000 -o hello hello.o
+```
+
+### C programs with musl libc
+
+```bash
+# musl gives you a self-contained static libc without glibc baggage
+# Install: https://musl.cc/ or build from source
+
+mipsel-linux-musl-gcc -static -O2 -o hello hello.c
+```
+
+### Running from the assembler hex format (legacy)
+
+The existing `load_hex_file()` / `parse_hex_program()` API still works and is unchanged.
+
+## C++ API
+
+```cpp
+#include "mips/elf_loader.h"
+#include "mips/single_cycle_cpu.h"
+
+mips::SingleCycleCpu cpu(4u << 20);  // 4 MB address space
+std::string err;
+
+// One-shot: open, parse, and load in one call.
+if (!mips::load_elf_file_into_processor(cpu, "hello", err)) {
+    std::cerr << "ELF load failed: " << err << "\n";
+    return 1;
+}
+// cpu.pc() is now the ELF entry point.
+```
+
+Or in two steps if you need to inspect the image first:
+
+```cpp
+mips::ElfImage img = mips::load_elf_file("hello");
+if (!img) {
+    std::cerr << img.error.value() << "\n";
+    return 1;
+}
+
+std::cout << "Entry: 0x" << std::hex << img.entry << "\n";
+for (const auto& seg : img.segments)
+    std::cout << "  PT_LOAD vaddr=0x" << seg.vaddr
+              << " size=" << seg.filesz << "\n";
+
+std::string err;
+mips::load_elf_into_processor(cpu, img, err);
+```
+
+Parsing from an in-memory stream:
+
+```cpp
+std::istringstream buf(elf_bytes);
+mips::ElfImage img = mips::parse_elf(buf);
+```
+
+## Memory sizing
+
+The default `IProcessor` constructor allocates 64 KB. Most real programs need more. Increase it when constructing the CPU:
+
+```cpp
+mips::SingleCycleCpu cpu(4u << 20);  // 4 MB
+mips::PipelinedCpu   cpu(1u << 24);  // 16 MB
+```
+
+The ELF loader will return an error with a descriptive message if any segment does not fit.
+
+## Impact
+
+| Without ELF loader | With ELF loader |
+|---|---|
+| Programs must be hand-assembled as `std::vector<uint32_t>` or custom `.hex` files | Compile with `mipsel-linux-gnu-gcc` and load directly |
+| Only the ISA subset implemented in the emulator can be exercised | Any valid MIPS LE binary can run (within the emulated ISA subset) |
+| Testing requires writing instruction encoders by hand | Unit tests can use real compiled programs for regression coverage |
+| Students cannot reuse existing MIPS assembly from coursework | Students can load standard MIPS assignments directly |
+
+The ELF loader is also the prerequisite for the upcoming syscall emulation (Stage 5 stretch goal): once programs can set up a Linux O32 ABI stack and call `$v0=4` (`write`), the exception handler can intercept SYSCALL and forward it to the host OS.

--- a/wiki/GDB-Stub.md
+++ b/wiki/GDB-Stub.md
@@ -1,0 +1,138 @@
+# GDB Stub (Remote Serial Protocol)
+
+clearCore includes a built-in **GDB Remote Serial Protocol (RSP) server** that lets you connect a real `mips-linux-gnu-gdb` or `gdb-multiarch` instance to the emulator. This means you can set breakpoints, single-step, inspect and modify registers and memory, and examine the call stack — all from an industry-standard debugger rather than the emulator's own UI.
+
+This is modelled on the same mechanism that QEMU exposes with `-s -S`.
+
+## Quick start
+
+```cpp
+#include "mips/gdb_stub.h"
+#include "mips/elf_loader.h"
+#include "mips/single_cycle_cpu.h"
+
+int main() {
+    mips::SingleCycleCpu cpu(4u << 20);
+    std::string err;
+    mips::load_elf_file_into_processor(cpu, "my_program", err);
+
+    // Start the GDB server on port 1234 (default) and wait for GDB to connect.
+    mips::GdbStub stub(cpu);
+    stub.listen();   // blocks until GDB sends 'k' (kill) or 'D' (detach)
+}
+```
+
+Then in a second terminal:
+
+```bash
+# Connect GDB to the stub
+mipsel-linux-gnu-gdb my_program
+(gdb) target remote localhost:1234
+(gdb) break _start
+(gdb) continue
+(gdb) info registers
+(gdb) x/10i $pc
+(gdb) stepi
+```
+
+## Supported RSP commands
+
+| Command | Description |
+|---------|-------------|
+| `?`     | Stop reason (SIGTRAP) |
+| `g`     | Read all 38 MIPS registers |
+| `G`     | Write all registers |
+| `p n`   | Read single register n |
+| `P n=v` | Write single register n |
+| `m addr,len` | Read `len` bytes from `addr` |
+| `M addr,len:data` | Write bytes to memory |
+| `c [addr]` | Continue execution (optionally from `addr`) |
+| `s [addr]` | Step one instruction |
+| `Z0,addr,kind` | Insert software breakpoint at `addr` |
+| `z0,addr,kind` | Remove software breakpoint |
+| `k` | Kill (exit the RSP loop) |
+| `D` | Detach (exit the RSP loop, leave CPU running) |
+| `qSupported` | Feature negotiation (`swbreak+`) |
+| `qAttached` | Always `1` (attached to existing process) |
+| `H`, `T` | Thread ops (ignored — single-threaded emulator) |
+
+## MIPS register layout
+
+GDB addresses 38 registers by number in the `g`/`G`/`p`/`P` commands:
+
+| GDB register | MIPS name | Source |
+|---|---|---|
+| 0–31 | $zero, $at, $v0–$v1, $a0–$a3, $t0–$t9, $s0–$s7, $k0, $k1, $gp, $sp, $fp, $ra | `IProcessor::regs()` |
+| 32 | CP0 Status | `IProcessor::cp0().status()` |
+| 33 | LO | `IProcessor::lo()` |
+| 34 | HI | `IProcessor::hi()` |
+| 35 | CP0 BadVAddr | `IProcessor::cp0().bad_vaddr()` |
+| 36 | CP0 Cause | `IProcessor::cp0().cause()` |
+| 37 | PC | `IProcessor::pc()` |
+
+## Software breakpoints
+
+GDB's `break` / `hbreak` commands use software breakpoints by default. The stub:
+
+1. Reads the 4-byte word at the target address.
+2. Saves it internally.
+3. Writes the `BREAK` instruction (`0x0000000D`) in its place.
+
+When the CPU executes `BREAK`, it raises a `Bp` exception. The stub catches `StepResult::Exception` with `ExceptionCode::Bp`, sends `T05` (SIGTRAP) to GDB with PC set to the faulting instruction's address, and waits for the next GDB command.
+
+On `z0` (remove breakpoint), the original word is restored.
+
+## Exception-to-signal mapping
+
+| CP0 exception | GDB signal | Typical cause |
+|---|---|---|
+| `Bp` (BREAK) | SIGTRAP (5) | Software breakpoint or manual `break` instruction |
+| `Sys` (SYSCALL) | SIGSYS (12) | Unhandled system call |
+| `RI` (reserved instruction) | SIGILL (4) | Unrecognised opcode |
+| `Ov` (overflow) | SIGFPE (8) | Signed arithmetic overflow |
+| `AdEL` / `AdES` | SIGSEGV (11) | Bad memory address |
+
+## Choosing a port
+
+The default port is 1234 (same as QEMU):
+
+```cpp
+mips::GdbStub stub(cpu, 9000);  // listen on port 9000 instead
+```
+
+The stub binds to `127.0.0.1` only — it is not exposed on any network interface.
+
+## Build configuration
+
+The GDB stub is enabled by default but requires POSIX socket headers (`sys/socket.h`). It is automatically disabled if those headers are absent, with a CMake warning:
+
+```cmake
+cmake --preset debug -DBUILD_GDB_STUB=OFF   # disable explicitly
+```
+
+Code that conditionally uses the stub:
+
+```cpp
+#if CLEARCORE_GDB_STUB_ENABLED
+    mips::GdbStub stub(cpu);
+    stub.listen();
+#endif
+```
+
+## Compared to other emulator debugging approaches
+
+| Method | Breakpoint precision | Setup cost | Tooling |
+|---|---|---|---|
+| clearCore TUI step mode | Cycle-accurate | Zero | Built-in |
+| GDB stub (`this feature`) | Instruction-accurate | Low (one `target remote` command) | Full GDB: backtraces, watchpoints, scripting |
+| QEMU user-mode emulation | Instruction-accurate | High (need full MIPS sysroot) | Full GDB |
+| MARS simulator | Instruction-accurate | Medium (Java) | MARS-only debugger |
+
+The GDB stub's key advantage over MARS is that it works with the same clearCore CPU models that produce the pipeline visualisation — breakpoints and single-stepping interact with the real forwarding unit, hazard detector, and CP0 state, not a separate interpreter.
+
+## Limitations
+
+- **Single-threaded**: the CPU runs on the same OS thread as the RSP loop. `continue` runs the CPU in a tight loop in `handle_continue()`; the UI is paused while the CPU is running. For interactive use, pair with `step` (`si`/`ni`) or set a breakpoint near the target instruction.
+- **No hardware breakpoints**: only software breakpoints (`Z0`/`z0`) are supported. `Z1`–`Z4` return empty responses (GDB falls back gracefully).
+- **No `vCont`**: GDB may warn about this. It falls back to `c`/`s` automatically.
+- **Exception vector must be mapped**: if the CPU takes an exception and there is no handler at `0x8000_0180`, the GDB stub catches the exception (sets PC back to EPC) before the next fetch, so GDB sees the faulting instruction rather than an OOB crash.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -16,6 +16,9 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 - **Telemetry** — running cycle count, CPI, stall/forward/flush tallies
 - **In-app MIPS assembler** — the Qt6 Code Editor assembles labeled assembly source directly into loadable instruction words (no external toolchain)
 - **Differential testing** — the `tests/golden/` suite cross-checks both CPU models against MARS, the classroom-standard MIPS simulator
+- **CP0 exception model** — SYSCALL, BREAK, overflow, address errors, and reserved-instruction faults raise MIPS32r2 exceptions; Status, Cause, EPC, and BadVAddr are fully modelled; ERET/MFC0/MTC0 are supported
+- **ELF loader** — load `mipsel` (little-endian) ELF32 executables compiled with `mipsel-linux-gnu-gcc` or `mipsel-linux-musl-gcc` directly into the emulated address space
+- **GDB RSP stub** — attach `mipsel-linux-gnu-gdb` to port 1234 for breakpoints, single-step, register/memory inspection, and exception-driven stop signals
 
 ---
 
@@ -26,6 +29,9 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 | [Getting Started](Getting-Started)               | Build instructions, dependencies, first run               |
 | [Architecture](Architecture)                     | Module layout, `IProcessor` interface, design pillars     |
 | [MIPS CPU Simulator](MIPS-CPU-Emulator)          | Pipeline stages, hazard detection, forwarding, ISA subset |
+| [CP0 and Exceptions](CP0-Exceptions)             | Exception model, SYSCALL/BREAK, MFC0/MTC0/ERET, EPC      |
+| [ELF Loader](ELF-Loader)                         | Loading compiled MIPS binaries; mipsel toolchain guide    |
+| [GDB Stub](GDB-Stub)                             | GDB RSP server — breakpoints, single-step, signals        |
 | [Terminal UI](Terminal-UI)                       | FTXUI interface — tabs, controls, visualizations          |
 | [Qt6 GUI](Qt6-GUI)                               | Desktop interface — views, signal flow, thread safety     |
 | [Roadmap](Roadmap)                               | Stage-by-stage feature status and upcoming work            |


### PR DESCRIPTION
## Summary

- **CP0 / Exceptions (MIPS32r2)** — Adds a `Cp0` class tracking Status (EXL), Cause (ExcCode), EPC, and BadVAddr. Both `SingleCycleCpu` and `PipelinedCpu` now raise proper MIPS exceptions (AdEL, AdES, Sys, Bp, RI, Ov) instead of returning `StepResult::Fault`. New instructions: `SYSCALL`, `BREAK`, `MFC0`, `MTC0`, `ERET`.
- **ELF Loader** — `load_elf_file_into_processor()` parses MIPS ELF32 little-endian binaries, maps all `PT_LOAD` segments into the processor's address space, zero-fills BSS, and sets PC to the entry point. Big-endian ELF is rejected with a clear toolchain hint.
- **GDB RSP Stub** — A blocking TCP server (port 1234) implementing the GDB Remote Serial Protocol. Supports `g/G`, `p/P`, `m/M`, `c`, `s`, `Z0/z0`, `?`, `k`, `D`, and `q*` packets. 38-register MIPS layout. Software breakpoints via `BREAK` instruction replacement. CP0 exceptions translate to UNIX signals (SIGTRAP, SIGSYS, SIGILL, SIGFPE, SIGSEGV). Gated on `BUILD_GDB_STUB` CMake option; auto-disabled without POSIX socket headers.

## Changes

- `include/mips/cp0.h` + `src/mips/cp0.cpp` — new Cp0 class
- `include/mips/elf_loader.h` + `src/mips/elf_loader.cpp` — new ELF loader
- `include/mips/gdb_stub.h` + `src/mips/gdb_stub.cpp` — new GDB stub
- `include/mips/processor.h` — `StepResult::Exception`, CP0/HI/LO accessors on `IProcessor`
- `include/mips/decoder.h` — `Opcode::COP0`, `FunctCode::SYSCALL/BREAK/ERET`
- `src/mips/single_cycle_cpu.cpp` / `pipelined_cpu.cpp` — exception dispatch in all stages
- `tests/mips/cp0_test.cpp` — 21 new tests (Cp0 unit, SC exceptions, pipeline exceptions)
- `tests/mips/elf_loader_test.cpp` — 9 new tests (parse, load, BSS, bounds)
- `tests/mips/cpu_test.cpp` + `processor_test.cpp` — updated: `Fault` → `Exception` for RI/AdEL
- `CMakeLists.txt` — new source files, `BUILD_GDB_STUB` option, `cp0_test`/`elf_loader_test` targets
- `README.md` — new "CP0 / Exceptions, ELF Loader, and GDB Stub" section; Stage 2.6 in roadmap
- `wiki/CP0-Exceptions.md`, `wiki/ELF-Loader.md`, `wiki/GDB-Stub.md` — new wiki pages
- `wiki/Home.md` — navigation table updated with new pages

## Test plan

- [x] `ctest --preset core-only` — 21/21 pass (includes 2 new test targets: `cp0_test`, `elf_loader_test`)
- [x] All 7 MARS golden tests pass for both `SingleCycleCpu` and `PipelinedCpu`
- [x] `cpu_test` and `processor_test` updated to reflect RI/AdEL now returning `Exception` instead of `Fault`
- [ ] Manual: compile a `mipsel-linux-gnu-as` assembly file, load via ELF loader, connect `mipsel-linux-gnu-gdb`, verify breakpoint and single-step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement a full MIPS32r2-style exception and CP0 model, add ELF32 loading and an optional GDB RSP stub, and integrate these capabilities into both CPU cores, the build, tests, and documentation.

New Features:
- Introduce a CP0-based MIPS32r2 exception model with new SYSCALL/BREAK/MFC0/MTC0/ERET instructions and expose CP0/HI/LO through the processor interface.
- Add a MIPS ELF32 (little-endian) loader to map PT_LOAD segments, zero-fill BSS, and set the CPU entry point from ELF binaries.
- Provide an optional GDB Remote Serial Protocol stub that exposes registers, memory, and software breakpoints over TCP for debugging the emulator.

Enhancements:
- Update single-cycle and pipelined CPU cores to raise CP0 exceptions instead of generic faults for decode, memory, and arithmetic errors, and integrate exception flushing into the pipeline.
- Extend the decoder and tests to cover new COP0 and exception-related instructions and adjust existing tests for the new StepResult::Exception semantics.
- Expand documentation and wiki with sections covering CP0/exception handling, ELF loading, and GDB stub usage, and mark roadmap Stage 2.6 as complete.

Build:
- Wire new CP0, ELF loader, and GDB stub sources into the CMake build, add an option to toggle the GDB stub based on POSIX socket availability, and register new cp0/elf loader tests.

Documentation:
- Document the CP0 exception model, ELF loader, and GDB stub in the README and dedicated wiki pages, including toolchain guidance and debugger usage.

Tests:
- Add unit and integration tests for CP0 behaviour, exception paths in both CPU models, and the ELF loader’s parsing, loading, and bounds handling.
- Update existing CPU and processor contract tests to expect exceptions instead of faults for reserved instructions and address errors.