### PR TITLE
Develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,19 @@
 #   ctest --preset debug
 #
 # Options (all default ON except sanitizers):
-#   -DBUILD_NYXSTONE=ON|OFF      Nyxstone assembler/disassembler (needs LLVM 15+)
+#   -DBUILD_NYXSTONE=ON|OFF      Nyxstone assembler/disassembler (needs LLVM 15-20 + clang)
 #   -DBUILD_QT6_UI=ON|OFF        Qt6 Widgets GUI
 #   -DBUILD_QT6_QUICK_UI=ON|OFF  Qt Quick (QML) GUI
 #   -DENABLE_SANITIZERS=ON|OFF   ASan + UBSan
 #
 # Dependencies (FTXUI, GSL, spdlog, Nyxstone are auto-downloaded; Qt/LLVM are not):
-#   Fedora/RHEL:   sudo dnf install cmake gcc-c++ qt6-qtbase-devel qt6-qtdeclarative-devel llvm-devel
-#   Ubuntu/Debian: sudo apt install cmake build-essential qt6-base-dev qt6-declarative-dev llvm-dev
-#   macOS:         brew install cmake qt@6 llvm@15
+#   Fedora/RHEL:   sudo dnf install cmake gcc-c++ qt6-qtbase-devel qt6-qtdeclarative-devel llvm19-devel clang19-devel
+#   Ubuntu/Debian: sudo apt install cmake build-essential qt6-base-dev qt6-declarative-dev llvm-19-dev libclang-19-dev
+#   macOS:         brew install cmake qt@6 llvm@19
+#
+# Nyxstone v0.1.8 supports LLVM 15-20 only. If your system default LLVM is newer
+# (21+), install an in-range one and point Nyxstone at it, e.g.:
+#   NYXSTONE_LLVM_PREFIX=/usr/lib64/llvm19 cmake --preset debug
 #
 # ============================================================================
 
@@ -116,12 +120,30 @@ option(BUILD_NYXSTONE "Enable Nyxstone assembler/disassembler (MIT License)" ON)
 if (BUILD_NYXSTONE)
     message(STATUS "Configuring Nyxstone assembler/disassembler framework...")
 
-    find_package(LLVM 15 QUIET CONFIG
+    # Nyxstone v0.1.8 supports LLVM 15–20 only: it relies on LLVM's internal MC
+    # headers, which shift every major version. Newer LLVM (21+) does not build.
+    set(NYXSTONE_LLVM_MIN 15)
+    set(NYXSTONE_LLVM_MAX 20)
+
+    # Note: find_package(LLVM <version>) demands an *exact* major.minor match
+    # (LLVM's config-version file is not "any newer"), so we must query
+    # unversioned and range-check the major ourselves. Honour Nyxstone's own
+    # NYXSTONE_LLVM_PREFIX convention so a pinned in-range install is found even
+    # when a newer system LLVM (e.g. 22) is the default.
+    set(_llvm_hints "")
+    if (DEFINED ENV{NYXSTONE_LLVM_PREFIX})
+        list(APPEND _llvm_hints
+                "$ENV{NYXSTONE_LLVM_PREFIX}/lib/cmake/llvm"
+                "$ENV{NYXSTONE_LLVM_PREFIX}/lib64/cmake/llvm")
+    endif ()
+
+    find_package(LLVM QUIET CONFIG
             NAMES LLVM llvm
-            HINTS ENV LLVM_DIR ENV NYXSTONE_LLVM_PREFIX
+            HINTS ${_llvm_hints} ENV LLVM_DIR
     )
 
-    if (LLVM_FOUND)
+    if (LLVM_FOUND AND LLVM_VERSION_MAJOR GREATER_EQUAL NYXSTONE_LLVM_MIN
+                   AND LLVM_VERSION_MAJOR LESS_EQUAL NYXSTONE_LLVM_MAX)
         message(STATUS "  ✓ Found LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} at ${LLVM_DIR}")
 
         FetchContent_Declare(nyxstone
@@ -132,17 +154,36 @@ if (BUILD_NYXSTONE)
         FetchContent_MakeAvailable(nyxstone)
 
         if (TARGET nyxstone)
+            # Nyxstone v0.1.8's CMake hardcodes ${CMAKE_SOURCE_DIR}/include for
+            # its public headers, which only resolves correctly when Nyxstone is
+            # the top-level project. Under FetchContent ${CMAKE_SOURCE_DIR} is
+            # *our* tree, so nyxstone.h is not found. Re-point the target at the
+            # fetched source's real include/vendor directories.
+            target_include_directories(nyxstone PUBLIC
+                    $<BUILD_INTERFACE:${nyxstone_SOURCE_DIR}/include>
+                    $<BUILD_INTERFACE:${nyxstone_SOURCE_DIR}/vendor>)
             message(STATUS "  ✓ Built Nyxstone from source (CMake target found)")
             set(NYXSTONE_TARGET nyxstone)
         else ()
             message(WARNING "Nyxstone target not found. Build may have failed. Disabling.")
             set(BUILD_NYXSTONE OFF)
         endif ()
+    elseif (LLVM_FOUND)
+        message(WARNING
+                "Found LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}, but Nyxstone v0.1.8 "
+                "supports LLVM ${NYXSTONE_LLVM_MIN}-${NYXSTONE_LLVM_MAX} only. Disabling "
+                "Nyxstone. Install an in-range LLVM (e.g. 'sudo dnf install llvm19-devel "
+                "clang19-devel') and point Nyxstone at it with "
+                "-DCMAKE_PREFIX_PATH or the NYXSTONE_LLVM_PREFIX env var "
+                "(e.g. NYXSTONE_LLVM_PREFIX=/usr/lib64/llvm19)."
+        )
+        set(BUILD_NYXSTONE OFF)
     else ()
         message(WARNING
-                "LLVM 15+ not found; disabling Nyxstone. Install llvm-devel (Fedora), "
-                "llvm-dev (Debian/Ubuntu), or brew install llvm@15 (macOS), "
-                "or set -DLLVM_DIR=/path/to/llvm/cmake."
+                "LLVM not found; disabling Nyxstone. Install an in-range LLVM "
+                "(${NYXSTONE_LLVM_MIN}-${NYXSTONE_LLVM_MAX}): llvm19-devel + clang19-devel "
+                "(Fedora), llvm-19-dev (Debian/Ubuntu), or brew install llvm@19 (macOS), "
+                "then set NYXSTONE_LLVM_PREFIX or -DLLVM_DIR=/path/to/llvm/cmake."
         )
         set(BUILD_NYXSTONE OFF)
     endif ()
@@ -167,6 +208,8 @@ add_library(mips_core STATIC
         src/mips/disassembler.cpp     # Machine code back to assembly
         src/mips/cp0.cpp              # Coprocessor 0: exception model (Status/Cause/EPC)
         src/mips/elf_loader.cpp       # MIPS ELF32 (mipsel) binary loader
+        src/mips/trace.cpp            # Shared spdlog logger (instruction/hazard/exception tracing)
+        src/mips/nyxstone_backend.cpp # Nyxstone (LLVM MC) assemble/disassemble wrapper (guarded)
 )
 
 # ── GDB RSP stub (optional — requires POSIX sockets; excluded on non-POSIX) ──
@@ -470,6 +513,14 @@ clearcore_add_test(disasm_test tests/mips/disasm_test.cpp mips_core)  # Disassem
 clearcore_add_test(cp0_test tests/mips/cp0_test.cpp mips_core)  # CP0 exception model
 clearcore_add_test(elf_loader_test tests/mips/elf_loader_test.cpp mips_core)  # ELF32 loader
 clearcore_add_test(nsc_tests tests/nsc/convert_test.cpp nsc_core)   # Number conversion
+
+# ---- nyxstone_test: differential Decoder/Disassembler vs LLVM (if enabled) ----
+# Only meaningful when Nyxstone was actually built; mips_core carries the
+# CLEARCORE_NYXSTONE_ENABLED definition either way, so the source also compiles
+# to a passing no-op when disabled.
+if (BUILD_NYXSTONE AND NYXSTONE_TARGET)
+    clearcore_add_test(nyxstone_test tests/mips/nyxstone_test.cpp mips_core)
+endif ()
 
 # ---- qt_ui_test: exercises assembler/controller/widgets (if Qt6 enabled) ----
 if (BUILD_QT6_UI)

--- a/include/mips/nyxstone_backend.h
+++ b/include/mips/nyxstone_backend.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// ─── nyxstone_backend.h ──────────────────────────────────────────────────────
+// Thin clearCore wrapper over Nyxstone (LLVM's MC layer) configured for
+// little-endian MIPS32. It provides a *ground-truth* assembler/disassembler so
+// the hand-written Decoder, Disassembler, and Qt assembler can be differentially
+// validated against a production toolchain (see tests/mips/nyxstone_test.cpp).
+//
+// Compiled only when CLEARCORE_NYXSTONE_ENABLED — i.e. an in-range LLVM (15–20)
+// was found at configure time. All LLVM/Nyxstone types are pimpl'd away, so
+// consumers of this header never need LLVM include paths.
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mips {
+
+#if CLEARCORE_NYXSTONE_ENABLED
+
+class NyxstoneBackend {
+public:
+    // Outcome of an assemble/disassemble call. On failure `error` is non-empty
+    // and carries LLVM's diagnostic; `value` is then unspecified.
+    template <typename T> struct Result {
+        T                  value{};
+        std::string        error;
+        [[nodiscard]] bool ok() const noexcept { return error.empty(); }
+        explicit           operator bool() const noexcept { return ok(); }
+    };
+
+    // Build a backend for little-endian MIPS32 ("mipsel"). Returns nullopt if
+    // LLVM cannot construct the target machine (e.g. the Mips target was not
+    // linked into the LLVM build).
+    [[nodiscard]] static std::optional<NyxstoneBackend> create();
+
+    NyxstoneBackend(NyxstoneBackend&&) noexcept;
+    NyxstoneBackend& operator=(NyxstoneBackend&&) noexcept;
+    ~NyxstoneBackend();
+    NyxstoneBackend(const NyxstoneBackend&)            = delete;
+    NyxstoneBackend& operator=(const NyxstoneBackend&) = delete;
+
+    // Assemble MIPS assembly text into 32-bit instruction words. `address` is
+    // the base virtual address (relevant to PC-relative operands). Labels and
+    // comments are handled by LLVM's assembler.
+    [[nodiscard]] Result<std::vector<uint32_t>> assemble(const std::string& text,
+                                                         uint32_t           address = 0) const;
+
+    // Disassemble instruction words into canonical MIPS assembly text.
+    [[nodiscard]] Result<std::string> disassemble(const std::vector<uint32_t>& words,
+                                                  uint32_t                     address = 0) const;
+
+private:
+    struct Impl;
+    explicit NyxstoneBackend(std::unique_ptr<Impl> impl);
+    std::unique_ptr<Impl> impl_;
+};
+
+#endif  // CLEARCORE_NYXSTONE_ENABLED
+
+}  // namespace mips

--- a/include/mips/trace.h
+++ b/include/mips/trace.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// ─── trace.h ─────────────────────────────────────────────────────────────────
+// Central spdlog logger for the MIPS core: instruction tracing, pipeline
+// hazard/stall/flush events, exception raises, and memory faults.
+//
+// The logger is created lazily on first use and defaults to the `warn` level so
+// normal runs, unit tests, and both GUIs stay quiet. Opt in at runtime via the
+// CLEARCORE_LOG_LEVEL environment variable, e.g.
+//
+//     CLEARCORE_LOG_LEVEL=trace ./number_system_converter
+//
+// Accepted values are spdlog's level names: trace, debug, info, warn, error,
+// critical, off. Output goes to stderr so stdout stays clean for program output.
+//
+// Hot-path callers should guard disassembly/formatting work behind
+// mips::trace_enabled(level) so a quiet run pays nothing beyond a level compare.
+
+#include <spdlog/spdlog.h>
+
+namespace mips {
+
+// The shared "clearcore" logger. Thread-safe; safe to call from anywhere.
+[[nodiscard]] spdlog::logger& trace_log();
+
+// True when a message at `level` would actually be emitted. Use this to skip
+// building trace strings (e.g. disassembly) on quiet runs.
+[[nodiscard]] inline bool trace_enabled(spdlog::level::level_enum level) {
+    return trace_log().should_log(level);
+}
+
+}  // namespace mips

--- a/src/mips/cp0.cpp
+++ b/src/mips/cp0.cpp
@@ -1,5 +1,7 @@
 #include "mips/cp0.h"
 
+#include "mips/trace.h"
+
 namespace mips {
 
 std::string_view exception_name(ExceptionCode code) noexcept {
@@ -29,6 +31,8 @@ uint32_t Cp0::raise(ExceptionCode code, uint32_t faulting_pc, uint32_t bad_addr)
     cause_    = (cause_ & ~0x7Cu) | (static_cast<uint32_t>(code) << 2);
     status_ |= kStatusEXL;
     bad_vaddr_ = bad_addr;
+    trace_log().debug("exception {} raised: epc={:#010x} bad_vaddr={:#010x} -> vector {:#010x}",
+                      exception_name(code), faulting_pc, bad_addr, kExceptionVector);
     return kExceptionVector;
 }
 

--- a/src/mips/gdb_stub.cpp
+++ b/src/mips/gdb_stub.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdio>
 #include <cstring>
+#include <gsl/gsl>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -43,6 +44,21 @@ void GdbStub::listen() {
     server_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
     if (server_fd_ < 0) return;
 
+    // Close and invalidate both sockets on *every* exit path — the bind-failure
+    // and accept-failure early returns included. gsl::finally keeps that
+    // guarantee in one place; the previous accept-failure return leaked the
+    // listening socket until the GdbStub was destroyed.
+    auto sockets = gsl::finally([this] {
+        if (client_fd_ >= 0) {
+            ::close(client_fd_);
+            client_fd_ = -1;
+        }
+        if (server_fd_ >= 0) {
+            ::close(server_fd_);
+            server_fd_ = -1;
+        }
+    });
+
     const int yes = 1;
     ::setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 
@@ -51,11 +67,7 @@ void GdbStub::listen() {
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     addr.sin_port        = htons(port_);
 
-    if (::bind(server_fd_, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) < 0) {
-        ::close(server_fd_);
-        server_fd_ = -1;
-        return;
-    }
+    if (::bind(server_fd_, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) < 0) return;
     ::listen(server_fd_, 1);
 
     sockaddr_in peer{};
@@ -72,11 +84,6 @@ void GdbStub::listen() {
     while (recv_packet(pkt)) {
         dispatch(pkt);
     }
-
-    ::close(client_fd_);
-    client_fd_ = -1;
-    ::close(server_fd_);
-    server_fd_ = -1;
 }
 
 // ─── Packet I/O ──────────────────────────────────────────────────────────────

--- a/src/mips/memory.cpp
+++ b/src/mips/memory.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <gsl/gsl>
+#include <vector>
 
 namespace mips {
 
@@ -52,6 +53,11 @@ bool Memory::write_byte(uint32_t addr, uint8_t value) noexcept {
 }
 
 bool Memory::load_words(uint32_t addr, const std::vector<uint32_t>& words) noexcept {
+    // Word alignment is a precondition, not a runtime-recoverable error: a
+    // misaligned base would make every write_word below silently fail while we
+    // still returned success, loading nothing. Program/data images always load
+    // at word-aligned bases, so a violation is a caller bug — fail loudly.
+    Expects((addr & 0x3u) == 0);
     if (!in_bounds(addr, words.size() * 4)) return false;
     for (std::size_t i = 0; i < words.size(); ++i) {
         write_word(addr + gsl::narrow_cast<uint32_t>(i * 4), words[i]);

--- a/src/mips/nyxstone_backend.cpp
+++ b/src/mips/nyxstone_backend.cpp
@@ -1,0 +1,101 @@
+#include "mips/nyxstone_backend.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if CLEARCORE_NYXSTONE_ENABLED
+
+#include <nyxstone.h>
+
+namespace mips {
+
+namespace {
+
+// LLVM triple for little-endian MIPS32. Matches the emulator's memory model
+// (Memory stores/reads words little-endian) and the base MIPS32 ISA the
+// Decoder/Alu implement.
+constexpr const char* kTriple = "mipsel-linux-gnu";
+
+}  // namespace
+
+// Holds the LLVM-backed Nyxstone instance out of line so no LLVM/Nyxstone type
+// appears in the public header.
+struct NyxstoneBackend::Impl {
+    std::unique_ptr<nyxstone::Nyxstone> nyx;
+};
+
+NyxstoneBackend::NyxstoneBackend(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+NyxstoneBackend::NyxstoneBackend(NyxstoneBackend&&) noexcept            = default;
+NyxstoneBackend& NyxstoneBackend::operator=(NyxstoneBackend&&) noexcept = default;
+NyxstoneBackend::~NyxstoneBackend()                                     = default;
+
+std::optional<NyxstoneBackend> NyxstoneBackend::create() {
+    auto built = nyxstone::NyxstoneBuilder(std::string{kTriple}).build();
+    if (!built) return std::nullopt;
+
+    auto impl = std::make_unique<Impl>();
+    impl->nyx = std::move(built.value());
+    return NyxstoneBackend(std::move(impl));
+}
+
+NyxstoneBackend::Result<std::vector<uint32_t>> NyxstoneBackend::assemble(const std::string& text,
+                                                                         uint32_t address) const {
+    Result<std::vector<uint32_t>> out;
+
+    // Assemble in no-reorder mode. clearCore's CPUs do not model MIPS branch
+    // delay slots — jumps and branches take effect immediately — whereas LLVM's
+    // default (.set reorder) auto-inserts a nop into the delay slot after every
+    // control-transfer instruction. Prefixing the directive keeps LLVM's output
+    // one-word-per-instruction, matching our execution model.
+    const std::string src = ".set noreorder\n" + text;
+
+    auto bytes = impl_->nyx->assemble(src, address, /*labels=*/{});
+    if (!bytes) {
+        out.error = bytes.error();
+        return out;
+    }
+
+    const auto& raw = bytes.value();
+    if (raw.size() % 4 != 0) {
+        out.error = "assembled byte count (" + std::to_string(raw.size()) +
+                    ") is not a multiple of 4; not whole MIPS32 words";
+        return out;
+    }
+
+    out.value.reserve(raw.size() / 4);
+    for (std::size_t i = 0; i < raw.size(); i += 4) {
+        // mipsel: instruction bytes are little-endian in the object stream.
+        out.value.push_back(
+            static_cast<uint32_t>(raw[i]) | (static_cast<uint32_t>(raw[i + 1]) << 8) |
+            (static_cast<uint32_t>(raw[i + 2]) << 16) | (static_cast<uint32_t>(raw[i + 3]) << 24));
+    }
+    return out;
+}
+
+NyxstoneBackend::Result<std::string>
+NyxstoneBackend::disassemble(const std::vector<uint32_t>& words, uint32_t address) const {
+    Result<std::string> out;
+
+    std::vector<uint8_t> bytes;
+    bytes.reserve(words.size() * 4);
+    for (const uint32_t w : words) {
+        bytes.push_back(static_cast<uint8_t>(w & 0xFFu));
+        bytes.push_back(static_cast<uint8_t>((w >> 8) & 0xFFu));
+        bytes.push_back(static_cast<uint8_t>((w >> 16) & 0xFFu));
+        bytes.push_back(static_cast<uint8_t>((w >> 24) & 0xFFu));
+    }
+
+    auto text = impl_->nyx->disassemble(bytes, address, /*count=*/0);
+    if (!text) {
+        out.error = text.error();
+        return out;
+    }
+    out.value = text.value();
+    return out;
+}
+
+}  // namespace mips
+
+#endif  // CLEARCORE_NYXSTONE_ENABLED

--- a/src/mips/pipelined_cpu.cpp
+++ b/src/mips/pipelined_cpu.cpp
@@ -1,9 +1,12 @@
 #include "mips/pipelined_cpu.h"
 
+#include <string>
 #include <vector>
 
 #include "mips/alu.h"
 #include "mips/decoder.h"
+#include "mips/disassembler.h"
+#include "mips/trace.h"
 
 // ─── pipelined_cpu.cpp ───────────────────────────────────────────────────────
 // Each step() models one clock cycle.  The five stages are processed in the
@@ -428,6 +431,24 @@ id_done: {}
         next_pc = pc_;     // do not advance
         new_if  = cur_if;  // hold (overwrite the bubble we may have computed)
         new_id  = {};      // bubble
+    }
+
+    // ── Trace: hazard/stall/flush events and the instruction entering ID ──────
+    if (trace_enabled(spdlog::level::trace)) {
+        if (stall_load_use)
+            trace_log().trace("pl  cyc={:<6} load-use hazard: stall, bubble into ID/EX", cycle_);
+        if (flush_from_ex)
+            trace_log().trace("pl  cyc={:<6} flush 2 (branch/jump/exception) -> pc={:#010x}",
+                              cycle_, branch_pc);
+        else if (flush_from_id)
+            trace_log().trace("pl  cyc={:<6} flush 1 (j/jal) -> pc={:#010x}", cycle_, jump_pc);
+        if (new_if.valid) {
+            const auto        if_dec = Decoder::decode(new_if.instr);
+            const std::string asm_text =
+                if_dec ? Disassembler::to_string(*if_dec, new_if.pc) : "<undecodable>";
+            trace_log().trace("pl  cyc={:<6} IF pc={:#010x}  {:#010x}  {}", cycle_, new_if.pc,
+                              new_if.instr, asm_text);
+        }
     }
 
     // ── Commit ───────────────────────────────────────────────────────────────

--- a/src/mips/single_cycle_cpu.cpp
+++ b/src/mips/single_cycle_cpu.cpp
@@ -4,6 +4,8 @@
 
 #include "mips/alu.h"
 #include "mips/decoder.h"
+#include "mips/disassembler.h"
+#include "mips/trace.h"
 
 namespace mips {
 
@@ -238,6 +240,11 @@ StepResult SingleCycleCpu::step() {
     const auto     decoded = Decoder::decode(*fetched);
     if (!decoded) return raise(ExceptionCode::RI, cur_pc);
     const DecodedInstr& d = *decoded;
+
+    // Per-instruction trace. Guarded so a quiet run never pays for disassembly.
+    if (trace_enabled(spdlog::level::trace))
+        trace_log().trace("sc  cyc={:<6} pc={:#010x}  {:#010x}  {}", cycle_, cur_pc, *fetched,
+                          Disassembler::to_string(d, cur_pc));
 
     ctrl_            = derive_control(d);
     uint32_t next_pc = pc4;

--- a/src/mips/trace.cpp
+++ b/src/mips/trace.cpp
@@ -1,0 +1,43 @@
+#include "mips/trace.h"
+
+#include <cstdlib>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace mips {
+
+namespace {
+
+// Read the desired level from CLEARCORE_LOG_LEVEL, defaulting to `warn`.
+// spdlog::level::from_str() returns `off` for anything it doesn't recognise, so
+// a typo would silently disable logging entirely; guard against that by only
+// honouring `off` when the text literally says "off".
+spdlog::level::level_enum level_from_env() {
+    const char* env = std::getenv("CLEARCORE_LOG_LEVEL");
+    if (env == nullptr || *env == '\0') return spdlog::level::warn;
+
+    const auto level = spdlog::level::from_str(env);
+    if (level == spdlog::level::off && std::string_view(env) != "off") return spdlog::level::warn;
+    return level;
+}
+
+std::shared_ptr<spdlog::logger> make_logger() {
+    auto sink   = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+    auto logger = std::make_shared<spdlog::logger>("clearcore", std::move(sink));
+    logger->set_level(level_from_env());
+    logger->set_pattern("[clearcore %^%L%$] %v");  // e.g. "[clearcore T] fetch pc=..."
+    return logger;
+}
+
+}  // namespace
+
+spdlog::logger& trace_log() {
+    // Function-local static: constructed once, on first use, thread-safely.
+    static const std::shared_ptr<spdlog::logger> logger = make_logger();
+    return *logger;
+}
+
+}  // namespace mips

--- a/tests/mips/nyxstone_test.cpp
+++ b/tests/mips/nyxstone_test.cpp
@@ -1,0 +1,160 @@
+// nyxstone_test.cpp — differential validation of the hand-written Decoder +
+// Disassembler against Nyxstone (LLVM's MC layer) for little-endian MIPS32.
+//
+// For each instruction word in the corpus we:
+//   1. decode + disassemble it with clearCore's own Decoder/Disassembler,
+//   2. re-assemble that text with Nyxstone (LLVM),
+//   3. assert LLVM produced exactly one word equal to the original.
+//
+// A pass means our disassembly is semantically faithful: an independent
+// production assembler re-encodes it to the identical bits. This is the raison
+// d'être for the Nyxstone dependency.
+//
+// Requires CLEARCORE_NYXSTONE_ENABLED (an in-range LLVM found at configure
+// time). When Nyxstone is disabled the test compiles to a no-op that passes.
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "mips/decoder.h"
+#include "mips/disassembler.h"
+
+#if CLEARCORE_NYXSTONE_ENABLED
+#include "mips/nyxstone_backend.h"
+#endif
+
+using namespace mips;
+
+static int g_passed = 0, g_failed = 0;
+
+// ── Encoding helpers (H&H Appendix B) ─────────────────────────────────────────
+static uint32_t enc_r(uint8_t rs, uint8_t rt, uint8_t rd, uint8_t sh, uint8_t funct) {
+    return (static_cast<uint32_t>(rs) << 21) | (static_cast<uint32_t>(rt) << 16) |
+           (static_cast<uint32_t>(rd) << 11) | (static_cast<uint32_t>(sh) << 6) |
+           static_cast<uint32_t>(funct);
+}
+static uint32_t enc_i(uint8_t op, uint8_t rs, uint8_t rt, uint16_t imm) {
+    return (static_cast<uint32_t>(op) << 26) | (static_cast<uint32_t>(rs) << 21) |
+           (static_cast<uint32_t>(rt) << 16) | static_cast<uint32_t>(imm);
+}
+
+#if CLEARCORE_NYXSTONE_ENABLED
+
+// One differential case: our disassembly of `word` must re-assemble (via LLVM)
+// back to `word`.
+static void check_roundtrip(const NyxstoneBackend& nyx, uint32_t word, uint32_t pc = 0) {
+    const auto decoded = Decoder::decode(word);
+    if (!decoded) {
+        ++g_failed;
+        std::printf("  FAIL 0x%08x  our Decoder rejected a word LLVM should know\n", word);
+        return;
+    }
+    const std::string our_text = Disassembler::to_string(*decoded, pc);
+
+    const auto asmres = nyx.assemble(our_text, pc);
+    if (!asmres) {
+        ++g_failed;
+        std::printf("  FAIL 0x%08x  \"%s\"  LLVM rejected our text: %s\n", word, our_text.c_str(),
+                    asmres.error.c_str());
+        return;
+    }
+    if (asmres.value.size() != 1) {
+        ++g_failed;
+        std::printf("  FAIL 0x%08x  \"%s\"  LLVM produced %zu words, expected 1\n", word,
+                    our_text.c_str(), asmres.value.size());
+        return;
+    }
+    if (asmres.value[0] != word) {
+        ++g_failed;
+        std::printf("  FAIL 0x%08x  \"%s\"  LLVM re-encoded to 0x%08x\n", word, our_text.c_str(),
+                    asmres.value[0]);
+        return;
+    }
+    ++g_passed;
+}
+
+static void run(const NyxstoneBackend& nyx) {
+    // ── R-type arithmetic/logic (rs=$t0=8, rt=$t1=9, rd=$t2=10) ──
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x20));  // add  $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x21));  // addu $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x22));  // sub  $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x23));  // subu $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x24));  // and  $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x25));  // or   $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x26));  // xor  $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x27));  // nor  $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x2A));  // slt  $t2,$t0,$t1
+    check_roundtrip(nyx, enc_r(8, 9, 10, 0, 0x2B));  // sltu $t2,$t0,$t1
+
+    // ── R-type shifts (rt=$t1=9, rd=$t0=8, shamt=4; var-shift rs=$t2=10) ──
+    check_roundtrip(nyx, enc_r(0, 9, 8, 4, 0x00));   // sll  $t0,$t1,4
+    check_roundtrip(nyx, enc_r(0, 9, 8, 4, 0x02));   // srl  $t0,$t1,4
+    check_roundtrip(nyx, enc_r(0, 9, 8, 4, 0x03));   // sra  $t0,$t1,4
+    check_roundtrip(nyx, enc_r(10, 9, 8, 0, 0x04));  // sllv $t0,$t1,$t2
+    check_roundtrip(nyx, enc_r(10, 9, 8, 0, 0x06));  // srlv $t0,$t1,$t2
+
+    // ── jr $ra ──
+    check_roundtrip(nyx, enc_r(31, 0, 0, 0, 0x08));  // jr $ra
+
+    // ── I-type arithmetic/logic (rs=$t0=8, rt=$t1=9) ──
+    check_roundtrip(nyx, enc_i(0x08, 8, 9, 100));   // addi  $t1,$t0,100
+    check_roundtrip(nyx, enc_i(0x09, 8, 9, 100));   // addiu $t1,$t0,100
+    check_roundtrip(nyx, enc_i(0x0A, 8, 9, 5));     // slti  $t1,$t0,5
+    check_roundtrip(nyx, enc_i(0x0B, 8, 9, 5));     // sltiu $t1,$t0,5
+    check_roundtrip(nyx, enc_i(0x0C, 8, 9, 0xFF));  // andi  $t1,$t0,0xff
+    check_roundtrip(nyx, enc_i(0x0D, 8, 9, 0xFF));  // ori   $t1,$t0,0xff
+    check_roundtrip(nyx, enc_i(0x0E, 8, 9, 0xFF));  // xori  $t1,$t0,0xff
+
+    // ── lui $t1, 0x1234 ──
+    check_roundtrip(nyx, enc_i(0x0F, 0, 9, 0x1234));
+
+    // ── Loads / stores: rt=$t1=9, base rs=$sp=29, offset ±N ──
+    check_roundtrip(nyx, enc_i(0x23, 29, 9, 8));                          // lw  $t1,8($sp)
+    check_roundtrip(nyx, enc_i(0x2B, 29, 9, 8));                          // sw  $t1,8($sp)
+    check_roundtrip(nyx, enc_i(0x24, 29, 9, 8));                          // lbu $t1,8($sp)
+    check_roundtrip(nyx, enc_i(0x25, 29, 9, 8));                          // lhu $t1,8($sp)
+    check_roundtrip(nyx, enc_i(0x23, 29, 9, static_cast<uint16_t>(-4)));  // lw  $t1,-4($sp)
+
+    // ── Exercise the disassemble() path: LLVM's text must name the same
+    //    mnemonic our Decoder does, for a couple of representative words. ──
+    struct DisCase {
+        uint32_t    word;
+        const char* mnemonic;
+    };
+    for (const auto& c :
+         {DisCase{enc_r(8, 9, 10, 0, 0x20), "add"}, DisCase{enc_i(0x23, 29, 9, 8), "lw"},
+          DisCase{enc_r(31, 0, 0, 0, 0x08), "jr"}}) {
+        const auto dis = nyx.disassemble({c.word});
+        if (dis && dis.value.find(c.mnemonic) != std::string::npos) {
+            ++g_passed;
+        } else {
+            ++g_failed;
+            std::printf("  FAIL 0x%08x  disassemble did not yield \"%s\" (got: %s%s)\n", c.word,
+                        c.mnemonic,
+                        dis ? dis.value.c_str() : "<error: ", dis ? "" : dis.error.c_str());
+        }
+    }
+}
+
+int main() {
+    auto backend = NyxstoneBackend::create();
+    if (!backend) {
+        std::printf("nyxstone_test: backend unavailable (LLVM Mips target missing) — skipping\n");
+        return 0;
+    }
+    run(*backend);
+    std::printf("\n%d passed, %d failed\n", g_passed, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}
+
+#else  // !CLEARCORE_NYXSTONE_ENABLED
+
+int main() {
+    std::printf(
+        "nyxstone_test: built without Nyxstone (CLEARCORE_NYXSTONE_ENABLED=0) — skipping\n");
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
This pull request introduces significant improvements to the build system and core MIPS emulator, focusing on robust integration with the Nyxstone assembler/disassembler (LLVM MC backend), enhanced tracing/logging, and improved resource management. The most important changes are grouped below.

**Nyxstone/LLVM Integration and Build Improvements:**

* Updated the `CMakeLists.txt` to require and detect LLVM versions 15–20 for Nyxstone support, improved environment variable handling (`NYXSTONE_LLVM_PREFIX`), clarified dependency instructions, and provided detailed user guidance if the LLVM version is out of range. The build now disables Nyxstone if an unsupported LLVM version is found. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL18-R30) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL119-R146) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR157-R186)
* Added `nyxstone_backend.cpp` and `nyxstone_backend.h`: a thin wrapper over Nyxstone, exposing assembler/disassembler functionality for little-endian MIPS32, fully pimpl'd to hide LLVM/Nyxstone types from consumers. [[1]](diffhunk://#diff-f82021702e690883a1b4f7a7d43b5f12aeed72a5e55c739dbaa791a271a6f819R1-R101) [[2]](diffhunk://#diff-d7073b56e7f1b3372db1486b71be8e42f60f641a9c7a2ec6120b3af96815998dR1-R63)
* Included new sources (`src/mips/nyxstone_backend.cpp`, `src/mips/trace.cpp`) in the build and added a new test (`nyxstone_test`) that exercises differential decoding/disassembly when Nyxstone is enabled. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR211-R212) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR517-R524)

**Tracing and Logging Enhancements:**

* Introduced a central spdlog-based logger (`trace.h`, `trace.cpp`) for the MIPS core, supporting runtime-configurable log levels and efficient, guarded logging for instruction execution, hazards, exceptions, and memory faults.
* Added detailed trace logging in the pipelined and single-cycle CPU implementations for instruction flow, hazards, flushes, and exceptions, all guarded by the logger's enabled level for zero overhead when disabled. [[1]](diffhunk://#diff-94cda554166e77c33db08ebc2ae8fe5641d9133c70c680d80f6a150fecfd593fR3-R9) [[2]](diffhunk://#diff-94cda554166e77c33db08ebc2ae8fe5641d9133c70c680d80f6a150fecfd593fR436-R453) [[3]](diffhunk://#diff-24720e50f8784b395ca7daf1d0fd7a09476980e0058eed3f984a86b4b824a9eeR7-R8) [[4]](diffhunk://#diff-24720e50f8784b395ca7daf1d0fd7a09476980e0058eed3f984a86b4b824a9eeR244-R248) [[5]](diffhunk://#diff-6491fb7c8bf4a333f7086f769d60f9c5d67e5fa16763afd248ecd921cbe3a63fR3-R4) [[6]](diffhunk://#diff-6491fb7c8bf4a333f7086f769d60f9c5d67e5fa16763afd248ecd921cbe3a63fR34-R35)

**Resource Management and Safety:**

* Improved socket resource management in `gdb_stub.cpp` by using `gsl::finally` to guarantee cleanup of sockets on all exit paths, preventing resource leaks even on early returns. [[1]](diffhunk://#diff-7b2e4ac405ce2f0a1dda5640e12b9c311fd28026cc15e3315a59878ef9228649R8) [[2]](diffhunk://#diff-7b2e4ac405ce2f0a1dda5640e12b9c311fd28026cc15e3315a59878ef9228649R47-R61) [[3]](diffhunk://#diff-7b2e4ac405ce2f0a1dda5640e12b9c311fd28026cc15e3315a59878ef9228649L54-R70) [[4]](diffhunk://#diff-7b2e4ac405ce2f0a1dda5640e12b9c311fd28026cc15e3315a59878ef9228649L75-L79)
* Strengthened memory alignment checks in `Memory::load_words` to assert word-aligned addresses, ensuring correctness and preventing silent failures. [[1]](diffhunk://#diff-ffa145969d49b333b546acb6bafa4357b2e4bb6d3a233829fb97adfe267892b3R5) [[2]](diffhunk://#diff-ffa145969d49b333b546acb6bafa4357b2e4bb6d3a233829fb97adfe267892b3R56-R60)

## Summary by Sourcery

Strengthen the MIPS emulator by integrating a Nyxstone/LLVM-backed assembler/disassembler, adding centralized trace logging, tightening resource and memory safety, and improving CMake-based Nyxstone/LLVM configuration and testing.

New Features:
- Integrate a Nyxstone-based LLVM MC backend wrapper for little-endian MIPS32 assembly/disassembly.
- Add a centralized spdlog-backed tracing facility and wire it into the MIPS CPUs and exception handling.
- Introduce a Nyxstone differential test to validate decoder/disassembler correctness when Nyxstone is available.

Bug Fixes:
- Ensure GDB stub sockets are reliably cleaned up on all exit paths to prevent descriptor leaks.
- Enforce word-aligned base addresses in bulk memory word loads to avoid silent write failures.

Enhancements:
- Tighten Nyxstone/LLVM CMake integration with explicit supported version range handling, environment-based discovery, and clearer dependency guidance.
- Include new trace and Nyxstone backend sources in the core MIPS build and gate Nyxstone-dependent tests on actual backend availability.

Build:
- Refine CMake LLVM discovery to support Nyxstone against LLVM 15–20 with better error messaging and environment hinting, and adjust platform package recommendations accordingly.
- Add conditional nyxstone_test target to the CTest suite when Nyxstone is built.

Tests:
- Add nyxstone_test to differentially validate MIPS instruction round-tripping and disassembly against Nyxstone/LLVM when enabled.