### PR TITLE
feat: wire up spdlog, GSL, and Nyxstone so each dependency is used

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -15,8 +15,8 @@ clearCore is organized into independent libraries and interface layers that shar
 ┌───────────────────────────────────────────────────────────────────────┐
 │                               mips_core                               │
 │   IProcessor ◄── SingleCycleCpu / PipelinedCpu                        │
-│   Decoder · ALU · RegisterFile · Memory · Disassembler                │
-│   (optional) Nyxstone (LLVM-based assembler/disassembler)             │
+│   Decoder · ALU · RegisterFile · Memory · Disassembler · trace (spdlog)│
+│   (optional) NyxstoneBackend (LLVM-based assembler/disassembler)      │
 └──────────────────────────────┬────────────────────────────────────────┘
                                 │
                     ┌───────────┘
@@ -37,7 +37,7 @@ clearCore is organized into independent libraries and interface layers that shar
 
 **Rule:** `nsc_core` and `mips_core` must never include UI headers. This boundary is enforced in `CMakeLists.txt` through target link dependencies.
 
-All three UI targets, plus `BUILD_NYXSTONE` (LLVM-based assembler/disassembler) and `GOLDEN_TESTS` (MARS differential testing), default to **ON** and degrade gracefully — the build still configures and the TUI still builds even if Qt6, LLVM, or a JRE is missing. See [Getting Started](Getting-Started) for the CMake options.
+All three UI targets, plus `BUILD_NYXSTONE` (LLVM-based assembler/disassembler, LLVM 15–20) and `GOLDEN_TESTS` (MARS differential testing), default to **ON** and degrade gracefully — the build still configures and the TUI still builds even if Qt6, an in-range LLVM, or a JRE is missing. See [Getting Started](Getting-Started) for the CMake options.
 
 ---
 
@@ -90,7 +90,8 @@ A single `derive_control()` free function maps an opcode/funct pair to the full 
 | `PipelinedCpu`    | `src/mips/pipelined_cpu.cpp`     | Concurrent pipeline with five pipeline registers               |
 | Hazard detection  | (internal to `PipelinedCpu`)     | Load-use stall detection, branch/jump flush                    |
 | Forwarding unit   | (internal to `PipelinedCpu`)     | EX/MEM → EX and MEM/WB → EX forwarding paths                   |
-| Nyxstone bridge    | (optional, `CLEARCORE_NYXSTONE_ENABLED`) | LLVM-based text ↔ machine-code assembler/disassembler for testing and display, when LLVM 15+ is found at configure time |
+| Trace log         | `include/mips/trace.h`           | Shared spdlog logger for instruction/pipeline/exception tracing; quiet by default, enable with `CLEARCORE_LOG_LEVEL` |
+| `NyxstoneBackend` | `include/mips/nyxstone_backend.h` (optional, `CLEARCORE_NYXSTONE_ENABLED`) | LLVM-based text ↔ machine-code assembler/disassembler; pimpl'd so no LLVM headers leak. Differentially validates the Decoder/Disassembler (see `nyxstone_test`). Built when LLVM 15–20 is found at configure time |
 
 ---
 
@@ -108,7 +109,7 @@ Widget code never touches the CPU directly and never needs a mutex. `nsc_qt` als
 
 ## Testing architecture
 
-Beyond the five core CTest suites and the Qt smoke-test suite (see [Getting Started](Getting-Started)), `tests/golden/` runs **differential tests**: each `.asm` program in that directory is assembled and executed independently by MARS (a Java-based reference MIPS simulator) and by both clearCore CPU models via `golden_runner`, and the resulting register files are compared for an exact match. This is separate from — and a stronger correctness signal than — the polymorphic `IProcessor` contract tests, which only check the two clearCore backends against each other rather than against an external reference. Golden tests are skipped automatically if no JRE or Python 3 is available.
+Beyond the six core CTest suites (one, `nyxstone_test`, built only when Nyxstone is enabled) and the Qt smoke-test suite (see [Getting Started](Getting-Started)), `tests/golden/` runs **differential tests**: each `.asm` program in that directory is assembled and executed independently by MARS (a Java-based reference MIPS simulator) and by both clearCore CPU models via `golden_runner`, and the resulting register files are compared for an exact match. This is separate from — and a stronger correctness signal than — the polymorphic `IProcessor` contract tests, which only check the two clearCore backends against each other rather than against an external reference. Golden tests are skipped automatically if no JRE or Python 3 is available.
 
 **Fuzz testing**: `tests/fuzz/fuzz_hex_loader.cpp` is a libFuzzer harness targeting `mips::parse_hex_program`. It is not part of the normal CTest runs; it is built and exercised by the ClusterFuzzLite CI workflow (`.github/workflows/cflite_pr.yml`) on every PR. See [Contributing § Fuzzing](Contributing#fuzzing) for how to add new harnesses.
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -113,7 +113,8 @@ If you add a new function that parses untrusted text or binary input, consider a
 
 - All new `.cpp` files must be added to the appropriate target in `CMakeLists.txt`. Forgetting this produces a linker error, not a compile error, so it can be confusing.
 - Qt's MOC requires that `Q_OBJECT` classes be listed explicitly in CMake — they are not discovered automatically.
-- FTXUI, GSL, spdlog, and (if enabled) Nyxstone are fetched by CMake at configure time (`FetchContent`). Do not vendor them manually.
+- FTXUI, GSL, spdlog, and (if enabled) Nyxstone are fetched by CMake at configure time (`FetchContent`). Do not vendor them manually. Nyxstone additionally needs a system LLVM+Clang in the **15–20** range; if your default LLVM is newer, point Nyxstone at an in-range install with the `NYXSTONE_LLVM_PREFIX` env var (see [Getting Started](Getting-Started#pinning-an-in-range-llvm-for-nyxstone)).
+- Core code (`mips_core`) must not leak third-party headers through its own public headers: `NyxstoneBackend` pimpls away all LLVM/Nyxstone types, and the spdlog logger is reached only through `include/mips/trace.h`. When adding tracing, guard hot-path formatting behind `mips::trace_enabled(level)`.
 - Prefer the CMake presets (`debug`, `release`, `asan`, `core-only`) over ad hoc configure invocations — they keep local builds, CI, and this wiki's instructions consistent.
 
 ---

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -9,10 +9,10 @@
 | FTXUI                | v7.0.0  | Auto-fetched via `FetchContent` — no manual install needed             |
 | Qt6                  | 6.x     | Optional — powers both `clearCore-gui` (Widgets) and `clearCore-quick` (QML); disable with `-DBUILD_QT6_UI=OFF -DBUILD_QT6_QUICK_UI=OFF` |
 | KSyntaxHighlighting  | KF6     | Optional — adds MIPS syntax highlighting to the Qt6 Code Editor; auto-detected at configure time (`kf6-syntax-highlighting-devel` / `libkf6syntaxhighlighting-dev`) |
-| LLVM                 | 15+     | Optional — powers the Nyxstone assembler/disassembler bridge; disable with `-DBUILD_NYXSTONE=OFF` |
+| LLVM + Clang         | 15–20   | Optional — powers the Nyxstone assembler/disassembler bridge; disable with `-DBUILD_NYXSTONE=OFF`. Nyxstone v0.1.8 supports **LLVM 15–20 only**; a newer system LLVM (21+) is auto-detected and Nyxstone is cleanly disabled unless you point it at an in-range install (see below). |
 | Java + Python 3      | any     | Optional — needed only for the MARS differential ("golden") test suite; skipped automatically if missing |
 
-GSL and spdlog are also auto-fetched via `FetchContent` and need no manual install.
+GSL and spdlog are also auto-fetched via `FetchContent` and need no manual install. spdlog powers the runtime instruction/pipeline trace log — see [Runtime logging](#runtime-logging).
 
 ### Installing Qt6, LLVM, and KSyntaxHighlighting
 
@@ -20,16 +20,27 @@ Only needed if you want the desktop GUIs, the Nyxstone assembler bridge, or MIPS
 
 ```bash
 # Fedora / RHEL
-sudo dnf install qt6-qtbase-devel qt6-qtdeclarative-devel llvm-devel kf6-syntax-highlighting-devel
+sudo dnf install qt6-qtbase-devel qt6-qtdeclarative-devel llvm19-devel clang19-devel kf6-syntax-highlighting-devel
 
 # Ubuntu / Debian (KSyntaxHighlighting requires Ubuntu 25.10+)
-sudo apt install qt6-base-dev qt6-declarative-dev llvm-dev libkf6syntaxhighlighting-dev
+sudo apt install qt6-base-dev qt6-declarative-dev llvm-19-dev libclang-19-dev libkf6syntaxhighlighting-dev
 
 # macOS
-brew install qt@6 llvm@15
+brew install qt@6 llvm@19
 ```
 
 KSyntaxHighlighting is auto-detected — omitting it is fine, the Code Editor just stays plain text.
+
+#### Pinning an in-range LLVM for Nyxstone
+
+If your distribution's **default** LLVM is newer than 20 (e.g. Fedora ships LLVM 22 as the default `llvm-devel`), install an in-range compat package and point Nyxstone at it with the `NYXSTONE_LLVM_PREFIX` environment variable — Nyxstone then searches that prefix exclusively:
+
+```bash
+# Fedora example: default LLVM is 22, but llvm19 is installed side-by-side
+NYXSTONE_LLVM_PREFIX=/usr/lib64/llvm19 cmake --preset debug
+```
+
+Without this, configuration prints a clear warning and continues with Nyxstone disabled — the TUI, GUIs, and all other tests build normally.
 
 ---
 
@@ -103,6 +114,30 @@ If Qt6 or LLVM aren't found during configuration, the corresponding target is si
 
 ---
 
+## Runtime logging
+
+`mips_core` emits a structured trace log (via **spdlog**) covering instruction fetch/decode (with disassembly), pipeline stall/flush/hazard events, CP0 exception raises, and memory faults. It is **quiet by default** (level `warn`) so normal runs, the UIs, and tests are unaffected.
+
+Opt in at runtime with the `CLEARCORE_LOG_LEVEL` environment variable — accepted values are spdlog's level names (`trace`, `debug`, `info`, `warn`, `error`, `critical`, `off`). Output goes to **stderr**, keeping stdout clean for program output:
+
+```bash
+# Full per-instruction + pipeline-event trace
+CLEARCORE_LOG_LEVEL=trace ./cmake-build-debug/number_system_converter
+
+# Just exceptions and memory faults
+CLEARCORE_LOG_LEVEL=debug ./cmake-build-debug/number_system_converter
+```
+
+Example trace output (pipelined model):
+
+```
+[clearcore T] pl  cyc=3      IF pc=0x00000008  0x01094820  add $t1, $t0, $t1
+[clearcore T] pl  cyc=4      load-use hazard: stall, bubble into ID/EX
+[clearcore D] exception AdEL raised: epc=0x00002000 bad_vaddr=0xdeadbeef -> vector 0x80000180
+```
+
+---
+
 ## Running tests
 
 ```bash
@@ -123,6 +158,7 @@ The suite covers:
 - `cpu_test` — CPU execution against known programs (both models)
 - `processor_test` — polymorphic harness running both `SingleCycleCpu` and `PipelinedCpu` through identical programs via the `IProcessor` contract
 - `disasm_test` — disassembler and hex program loader
+- `nyxstone_test` — differential validation of the Decoder + Disassembler against Nyxstone (LLVM's assembler): our disassembly of each corpus word is re-encoded by LLVM and asserted bit-identical. Built only when `BUILD_NYXSTONE=ON` and an in-range LLVM was found; self-skips otherwise.
 - `nsc_tests` — number system converter (`parseBase`, conversions)
 - `qt_ui_test` — Qt6 assembler/controller/widget smoke tests (built only when `BUILD_QT6_UI=ON`; runs headless via `QT_QPA_PLATFORM=offscreen`)
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -45,8 +45,8 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 
 ```
 C++20 · CMake 3.20+ · MIT license · v0.0.1
-FTXUI v7.0.0 (auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM (optional) · KSyntaxHighlighting (optional)
-Five core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
+FTXUI v7.0.0 · GSL · spdlog (all auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM 15–20 (optional) · KSyntaxHighlighting (optional)
+Six core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
 ```
 
 Build presets: `debug`, `release`, `asan`, `core-only` (TUI-only, no Qt/LLVM). See [Getting Started](Getting-Started).

--- a/wiki/MIPS-CPU-Emulator.md
+++ b/wiki/MIPS-CPU-Emulator.md
@@ -120,7 +120,7 @@ Programs are flat arrays of 32-bit instruction words. Load them via:
 
 - **TUI Program Loader tab** — paste hex words one per line
 - **Qt6 Code Editor** — write MIPS assembly with labels and branches; the in-app assembler (`nsc_qt::assemble()`) emits the word array. It supports the full instruction set above plus label resolution, but not pseudo-instructions or assembler directives (`.data`/`.text`/`.word`) yet — that's Stage 3, see [Roadmap](Roadmap).
-- **Nyxstone** (when `BUILD_NYXSTONE=ON` and LLVM 15+ is available) — an LLVM-based assembler/disassembler bridge used internally for test generation and text↔machine-code conversion
+- **`NyxstoneBackend`** (when `BUILD_NYXSTONE=ON` and LLVM 15–20 is available) — an LLVM-backed assemble/disassemble bridge for little-endian MIPS32. It is primarily a **ground-truth oracle**: the `nyxstone_test` suite re-encodes the Disassembler's output through LLVM and asserts bit-equality, differentially validating the hand-written decoder/disassembler. `NyxstoneBackend::assemble()` also returns a word array usable for loading.
 - **`IProcessor::load(std::vector<uint32_t>)`** — call directly from C++ for testing
 
 Memory is byte-addressable. The program is placed starting at address `0x00000000`. The stack conventionally grows down from `0xFFFFFFFF`.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -59,7 +59,8 @@ The project follows a staged development plan. Each stage builds on the previous
 - Statistics tab (post-run CPI and hazard-type breakdown)
 - Built on two additional fetched dependencies: Qt-Advanced-Docking-System (dockable panels) and QHexView (Memory tab)
 - A second, parallel **Qt Quick / QML** interface (`clearCore-quick`, `src/nsc_quick`, `qml/ClearCore/`) targeting the same backend, built by default alongside the Widgets GUI — see [Qt6 GUI § QML](Qt6-GUI#qml-nsc_quick)
-- Optional **Nyxstone** (LLVM-based) assembler/disassembler bridge in `mips_core`, gated behind `BUILD_NYXSTONE` and LLVM 15+ availability
+- Optional **Nyxstone** (LLVM-based) assemble/disassemble bridge in `mips_core` (`NyxstoneBackend`), gated behind `BUILD_NYXSTONE` and LLVM 15–20 availability. Used as a ground-truth oracle: the `nyxstone_test` suite differentially validates the hand-written decoder/disassembler by round-tripping through LLVM's assembler.
+- **Instruction/pipeline trace logging** (`mips::trace`, spdlog) — fetch/decode, stall/flush/hazard events, exception raises, and memory faults; quiet by default, enable at runtime with `CLEARCORE_LOG_LEVEL`
 - **MARS differential ("golden") test suite** (`tests/golden/`) — cross-checks both CPU models against MARS, the classroom-standard reference MIPS simulator, on seven corpus programs
 
 ---


### PR DESCRIPTION
## Summary

These three dependencies were declared and linked in `CMakeLists.txt` but **never actually used** in the source. This PR gives each a real, load-bearing role, plus fixes two latent CMake bugs found along the way — and updates the wiki to match.

## What each dependency now does

- **spdlog** — a shared `clearcore` logger (`include/mips/trace.h`, `src/mips/trace.cpp`) for instruction tracing (with disassembly), pipeline stall/flush/hazard events, CP0 exception raises, and memory faults. Quiet by default (`warn`); opt in at runtime with `CLEARCORE_LOG_LEVEL`. Wired into `single_cycle_cpu`, `pipelined_cpu`, and `cp0`.
- **Microsoft GSL** — beyond the existing `narrow_cast`/`span` usage: `gsl::finally` for socket cleanup in `gdb_stub` (**also fixes a real fd leak** — the `accept()`-failure path returned without closing the listening socket), and a `gsl::Expects` contract in `Memory::load_words` (a misaligned base silently loaded nothing before).
- **Nyxstone** — `NyxstoneBackend` (pimpl, no LLVM headers leak) assembles/disassembles little-endian MIPS32 via LLVM's MC layer, plus a **differential test** (`nyxstone_test`) that re-encodes our `Disassembler` output through LLVM and asserts bit-equality — 32 cases. Assembles with `.set noreorder` to match our delay-slot-free execution model.

## CMake fixes

- `find_package(LLVM 15)` required an **exact** major.minor match, silently rejecting every LLVM except 15.0 (even in-range 18/19). Now queries unversioned and range-checks the major against Nyxstone's supported **15–20**, reports clearly for out-of-range (e.g. system LLVM 22), and honors `NYXSTONE_LLVM_PREFIX`.
- Patches Nyxstone v0.1.8's include dirs post-FetchContent (it hardcodes `${CMAKE_SOURCE_DIR}/include`, which breaks under FetchContent).

## Docs

Updated 6 wiki pages (Getting-Started, Architecture, MIPS-CPU-Emulator, Roadmap, Home, Contributing): LLVM 15–20 requirement, `NYXSTONE_LLVM_PREFIX` pinning, a Runtime-logging section for `CLEARCORE_LOG_LEVEL`, and reframing Nyxstone from aspirational to a real ground-truth oracle.

## Testing

- **21 tests** pass with `core-only` (Nyxstone off).
- **22 tests** pass with Nyxstone on (adds `nyxstone_test`, built against llvm19), incl. MARS golden differential suite.
- Graceful degradation verified on the default system LLVM 22 (Nyxstone cleanly disables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document runtime logging, Nyxstone backend usage, and LLVM version constraints, clarifying how spdlog, GSL, and Nyxstone integrate into mips_core and the test suite.

Documentation:
- Explain LLVM + Clang 15–20 requirement for Nyxstone, including how to pin an in-range LLVM with NYXSTONE_LLVM_PREFIX and updated install commands for major platforms.
- Describe the new runtime trace logging facility powered by spdlog and how to enable it via CLEARCORE_LOG_LEVEL, including example output.
- Document the nyxstone_test differential test suite and its role in validating the decoder/disassembler, and update counts of core CTest suites.
- Clarify the NyxstoneBackend role as an optional LLVM-based assemble/disassemble bridge and ground-truth oracle, and note its enablement conditions and version constraints.
- Update contributor guidance on dependency fetching, Nyxstone’s LLVM requirements, third-party header encapsulation via NyxstoneBackend/trace, and tracing best practices.