### PR TITLE
Develop

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -15,8 +15,8 @@ clearCore is organized into independent libraries and interface layers that shar
 ┌───────────────────────────────────────────────────────────────────────┐
 │                               mips_core                               │
 │   IProcessor ◄── SingleCycleCpu / PipelinedCpu                        │
-│   Decoder · ALU · RegisterFile · Memory · Disassembler                │
-│   (optional) Nyxstone (LLVM-based assembler/disassembler)             │
+│   Decoder · ALU · RegisterFile · Memory · Disassembler · trace (spdlog)│
+│   (optional) NyxstoneBackend (LLVM-based assembler/disassembler)      │
 └──────────────────────────────┬────────────────────────────────────────┘
                                 │
                     ┌───────────┘
@@ -37,7 +37,7 @@ clearCore is organized into independent libraries and interface layers that shar
 
 **Rule:** `nsc_core` and `mips_core` must never include UI headers. This boundary is enforced in `CMakeLists.txt` through target link dependencies.
 
-All three UI targets, plus `BUILD_NYXSTONE` (LLVM-based assembler/disassembler) and `GOLDEN_TESTS` (MARS differential testing), default to **ON** and degrade gracefully — the build still configures and the TUI still builds even if Qt6, LLVM, or a JRE is missing. See [Getting Started](Getting-Started) for the CMake options.
+All three UI targets, plus `BUILD_NYXSTONE` (LLVM-based assembler/disassembler, LLVM 15–20) and `GOLDEN_TESTS` (MARS differential testing), default to **ON** and degrade gracefully — the build still configures and the TUI still builds even if Qt6, an in-range LLVM, or a JRE is missing. See [Getting Started](Getting-Started) for the CMake options.
 
 ---
 
@@ -90,7 +90,8 @@ A single `derive_control()` free function maps an opcode/funct pair to the full 
 | `PipelinedCpu`    | `src/mips/pipelined_cpu.cpp`     | Concurrent pipeline with five pipeline registers               |
 | Hazard detection  | (internal to `PipelinedCpu`)     | Load-use stall detection, branch/jump flush                    |
 | Forwarding unit   | (internal to `PipelinedCpu`)     | EX/MEM → EX and MEM/WB → EX forwarding paths                   |
-| Nyxstone bridge    | (optional, `CLEARCORE_NYXSTONE_ENABLED`) | LLVM-based text ↔ machine-code assembler/disassembler for testing and display, when LLVM 15+ is found at configure time |
+| Trace log         | `include/mips/trace.h`           | Shared spdlog logger for instruction/pipeline/exception tracing; quiet by default, enable with `CLEARCORE_LOG_LEVEL` |
+| `NyxstoneBackend` | `include/mips/nyxstone_backend.h` (optional, `CLEARCORE_NYXSTONE_ENABLED`) | LLVM-based text ↔ machine-code assembler/disassembler; pimpl'd so no LLVM headers leak. Differentially validates the Decoder/Disassembler (see `nyxstone_test`). Built when LLVM 15–20 is found at configure time |
 
 ---
 
@@ -108,7 +109,7 @@ Widget code never touches the CPU directly and never needs a mutex. `nsc_qt` als
 
 ## Testing architecture
 
-Beyond the five core CTest suites and the Qt smoke-test suite (see [Getting Started](Getting-Started)), `tests/golden/` runs **differential tests**: each `.asm` program in that directory is assembled and executed independently by MARS (a Java-based reference MIPS simulator) and by both clearCore CPU models via `golden_runner`, and the resulting register files are compared for an exact match. This is separate from — and a stronger correctness signal than — the polymorphic `IProcessor` contract tests, which only check the two clearCore backends against each other rather than against an external reference. Golden tests are skipped automatically if no JRE or Python 3 is available.
+Beyond the six core CTest suites (one, `nyxstone_test`, built only when Nyxstone is enabled) and the Qt smoke-test suite (see [Getting Started](Getting-Started)), `tests/golden/` runs **differential tests**: each `.asm` program in that directory is assembled and executed independently by MARS (a Java-based reference MIPS simulator) and by both clearCore CPU models via `golden_runner`, and the resulting register files are compared for an exact match. This is separate from — and a stronger correctness signal than — the polymorphic `IProcessor` contract tests, which only check the two clearCore backends against each other rather than against an external reference. Golden tests are skipped automatically if no JRE or Python 3 is available.
 
 **Fuzz testing**: `tests/fuzz/fuzz_hex_loader.cpp` is a libFuzzer harness targeting `mips::parse_hex_program`. It is not part of the normal CTest runs; it is built and exercised by the ClusterFuzzLite CI workflow (`.github/workflows/cflite_pr.yml`) on every PR. See [Contributing § Fuzzing](Contributing#fuzzing) for how to add new harnesses.
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -113,7 +113,8 @@ If you add a new function that parses untrusted text or binary input, consider a
 
 - All new `.cpp` files must be added to the appropriate target in `CMakeLists.txt`. Forgetting this produces a linker error, not a compile error, so it can be confusing.
 - Qt's MOC requires that `Q_OBJECT` classes be listed explicitly in CMake — they are not discovered automatically.
-- FTXUI, GSL, spdlog, and (if enabled) Nyxstone are fetched by CMake at configure time (`FetchContent`). Do not vendor them manually.
+- FTXUI, GSL, spdlog, and (if enabled) Nyxstone are fetched by CMake at configure time (`FetchContent`). Do not vendor them manually. Nyxstone additionally needs a system LLVM+Clang in the **15–20** range; if your default LLVM is newer, point Nyxstone at an in-range install with the `NYXSTONE_LLVM_PREFIX` env var (see [Getting Started](Getting-Started#pinning-an-in-range-llvm-for-nyxstone)).
+- Core code (`mips_core`) must not leak third-party headers through its own public headers: `NyxstoneBackend` pimpls away all LLVM/Nyxstone types, and the spdlog logger is reached only through `include/mips/trace.h`. When adding tracing, guard hot-path formatting behind `mips::trace_enabled(level)`.
 - Prefer the CMake presets (`debug`, `release`, `asan`, `core-only`) over ad hoc configure invocations — they keep local builds, CI, and this wiki's instructions consistent.
 
 ---

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -9,10 +9,10 @@
 | FTXUI                | v7.0.0  | Auto-fetched via `FetchContent` — no manual install needed             |
 | Qt6                  | 6.x     | Optional — powers both `clearCore-gui` (Widgets) and `clearCore-quick` (QML); disable with `-DBUILD_QT6_UI=OFF -DBUILD_QT6_QUICK_UI=OFF` |
 | KSyntaxHighlighting  | KF6     | Optional — adds MIPS syntax highlighting to the Qt6 Code Editor; auto-detected at configure time (`kf6-syntax-highlighting-devel` / `libkf6syntaxhighlighting-dev`) |
-| LLVM                 | 15+     | Optional — powers the Nyxstone assembler/disassembler bridge; disable with `-DBUILD_NYXSTONE=OFF` |
+| LLVM + Clang         | 15–20   | Optional — powers the Nyxstone assembler/disassembler bridge; disable with `-DBUILD_NYXSTONE=OFF`. Nyxstone v0.1.8 supports **LLVM 15–20 only**; a newer system LLVM (21+) is auto-detected and Nyxstone is cleanly disabled unless you point it at an in-range install (see below). |
 | Java + Python 3      | any     | Optional — needed only for the MARS differential ("golden") test suite; skipped automatically if missing |
 
-GSL and spdlog are also auto-fetched via `FetchContent` and need no manual install.
+GSL and spdlog are also auto-fetched via `FetchContent` and need no manual install. spdlog powers the runtime instruction/pipeline trace log — see [Runtime logging](#runtime-logging).
 
 ### Installing Qt6, LLVM, and KSyntaxHighlighting
 
@@ -20,16 +20,27 @@ Only needed if you want the desktop GUIs, the Nyxstone assembler bridge, or MIPS
 
 ```bash
 # Fedora / RHEL
-sudo dnf install qt6-qtbase-devel qt6-qtdeclarative-devel llvm-devel kf6-syntax-highlighting-devel
+sudo dnf install qt6-qtbase-devel qt6-qtdeclarative-devel llvm19-devel clang19-devel kf6-syntax-highlighting-devel
 
 # Ubuntu / Debian (KSyntaxHighlighting requires Ubuntu 25.10+)
-sudo apt install qt6-base-dev qt6-declarative-dev llvm-dev libkf6syntaxhighlighting-dev
+sudo apt install qt6-base-dev qt6-declarative-dev llvm-19-dev libclang-19-dev libkf6syntaxhighlighting-dev
 
 # macOS
-brew install qt@6 llvm@15
+brew install qt@6 llvm@19
 ```
 
 KSyntaxHighlighting is auto-detected — omitting it is fine, the Code Editor just stays plain text.
+
+#### Pinning an in-range LLVM for Nyxstone
+
+If your distribution's **default** LLVM is newer than 20 (e.g. Fedora ships LLVM 22 as the default `llvm-devel`), install an in-range compat package and point Nyxstone at it with the `NYXSTONE_LLVM_PREFIX` environment variable — Nyxstone then searches that prefix exclusively:
+
+```bash
+# Fedora example: default LLVM is 22, but llvm19 is installed side-by-side
+NYXSTONE_LLVM_PREFIX=/usr/lib64/llvm19 cmake --preset debug
+```
+
+Without this, configuration prints a clear warning and continues with Nyxstone disabled — the TUI, GUIs, and all other tests build normally.
 
 ---
 
@@ -103,6 +114,30 @@ If Qt6 or LLVM aren't found during configuration, the corresponding target is si
 
 ---
 
+## Runtime logging
+
+`mips_core` emits a structured trace log (via **spdlog**) covering instruction fetch/decode (with disassembly), pipeline stall/flush/hazard events, CP0 exception raises, and memory faults. It is **quiet by default** (level `warn`) so normal runs, the UIs, and tests are unaffected.
+
+Opt in at runtime with the `CLEARCORE_LOG_LEVEL` environment variable — accepted values are spdlog's level names (`trace`, `debug`, `info`, `warn`, `error`, `critical`, `off`). Output goes to **stderr**, keeping stdout clean for program output:
+
+```bash
+# Full per-instruction + pipeline-event trace
+CLEARCORE_LOG_LEVEL=trace ./cmake-build-debug/number_system_converter
+
+# Just exceptions and memory faults
+CLEARCORE_LOG_LEVEL=debug ./cmake-build-debug/number_system_converter
+```
+
+Example trace output (pipelined model):
+
+```
+[clearcore T] pl  cyc=3      IF pc=0x00000008  0x01094820  add $t1, $t0, $t1
+[clearcore T] pl  cyc=4      load-use hazard: stall, bubble into ID/EX
+[clearcore D] exception AdEL raised: epc=0x00002000 bad_vaddr=0xdeadbeef -> vector 0x80000180
+```
+
+---
+
 ## Running tests
 
 ```bash
@@ -123,6 +158,7 @@ The suite covers:
 - `cpu_test` — CPU execution against known programs (both models)
 - `processor_test` — polymorphic harness running both `SingleCycleCpu` and `PipelinedCpu` through identical programs via the `IProcessor` contract
 - `disasm_test` — disassembler and hex program loader
+- `nyxstone_test` — differential validation of the Decoder + Disassembler against Nyxstone (LLVM's assembler): our disassembly of each corpus word is re-encoded by LLVM and asserted bit-identical. Built only when `BUILD_NYXSTONE=ON` and an in-range LLVM was found; self-skips otherwise.
 - `nsc_tests` — number system converter (`parseBase`, conversions)
 - `qt_ui_test` — Qt6 assembler/controller/widget smoke tests (built only when `BUILD_QT6_UI=ON`; runs headless via `QT_QPA_PLATFORM=offscreen`)
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -45,8 +45,8 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 
 ```
 C++20 · CMake 3.20+ · MIT license · v0.0.1
-FTXUI v7.0.0 (auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM (optional) · KSyntaxHighlighting (optional)
-Five core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
+FTXUI v7.0.0 · GSL · spdlog (all auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM 15–20 (optional) · KSyntaxHighlighting (optional)
+Six core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
 ```
 
 Build presets: `debug`, `release`, `asan`, `core-only` (TUI-only, no Qt/LLVM). See [Getting Started](Getting-Started).

--- a/wiki/MIPS-CPU-Emulator.md
+++ b/wiki/MIPS-CPU-Emulator.md
@@ -120,7 +120,7 @@ Programs are flat arrays of 32-bit instruction words. Load them via:
 
 - **TUI Program Loader tab** — paste hex words one per line
 - **Qt6 Code Editor** — write MIPS assembly with labels and branches; the in-app assembler (`nsc_qt::assemble()`) emits the word array. It supports the full instruction set above plus label resolution, but not pseudo-instructions or assembler directives (`.data`/`.text`/`.word`) yet — that's Stage 3, see [Roadmap](Roadmap).
-- **Nyxstone** (when `BUILD_NYXSTONE=ON` and LLVM 15+ is available) — an LLVM-based assembler/disassembler bridge used internally for test generation and text↔machine-code conversion
+- **`NyxstoneBackend`** (when `BUILD_NYXSTONE=ON` and LLVM 15–20 is available) — an LLVM-backed assemble/disassemble bridge for little-endian MIPS32. It is primarily a **ground-truth oracle**: the `nyxstone_test` suite re-encodes the Disassembler's output through LLVM and asserts bit-equality, differentially validating the hand-written decoder/disassembler. `NyxstoneBackend::assemble()` also returns a word array usable for loading.
 - **`IProcessor::load(std::vector<uint32_t>)`** — call directly from C++ for testing
 
 Memory is byte-addressable. The program is placed starting at address `0x00000000`. The stack conventionally grows down from `0xFFFFFFFF`.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -59,7 +59,8 @@ The project follows a staged development plan. Each stage builds on the previous
 - Statistics tab (post-run CPI and hazard-type breakdown)
 - Built on two additional fetched dependencies: Qt-Advanced-Docking-System (dockable panels) and QHexView (Memory tab)
 - A second, parallel **Qt Quick / QML** interface (`clearCore-quick`, `src/nsc_quick`, `qml/ClearCore/`) targeting the same backend, built by default alongside the Widgets GUI — see [Qt6 GUI § QML](Qt6-GUI#qml-nsc_quick)
-- Optional **Nyxstone** (LLVM-based) assembler/disassembler bridge in `mips_core`, gated behind `BUILD_NYXSTONE` and LLVM 15+ availability
+- Optional **Nyxstone** (LLVM-based) assemble/disassemble bridge in `mips_core` (`NyxstoneBackend`), gated behind `BUILD_NYXSTONE` and LLVM 15–20 availability. Used as a ground-truth oracle: the `nyxstone_test` suite differentially validates the hand-written decoder/disassembler by round-tripping through LLVM's assembler.
+- **Instruction/pipeline trace logging** (`mips::trace`, spdlog) — fetch/decode, stall/flush/hazard events, exception raises, and memory faults; quiet by default, enable at runtime with `CLEARCORE_LOG_LEVEL`
 - **MARS differential ("golden") test suite** (`tests/golden/`) — cross-checks both CPU models against MARS, the classroom-standard reference MIPS simulator, on seven corpus programs
 
 ---


### PR DESCRIPTION
This pull request updates the documentation to clarify and expand support for the Nyxstone assembler/disassembler bridge and introduces details about the new runtime trace logging system. The changes ensure users are aware of the stricter LLVM version requirements for Nyxstone, provide instructions for configuring compatible LLVM installations, and document the new spdlog-based tracing capabilities. Several references to Nyxstone have been updated to reflect its encapsulation as `NyxstoneBackend` and its validation role. Test suite and build instructions are also updated accordingly.

**Nyxstone / LLVM integration:**

* Updated all references to Nyxstone to clarify that it requires LLVM **15–20 only**, and added instructions for pinning an in-range LLVM with the `NYXSTONE_LLVM_PREFIX` environment variable. The documentation now warns that newer LLVM versions (21+) will disable Nyxstone unless manually pointed at a compatible version. [[1]](diffhunk://#diff-e5372da78ad3a00a46af5b83becee79e76782fd8a064c35a1bf08969fc038b32L12-R44) [[2]](diffhunk://#diff-3f6db93689127c98f17ab427484dea89885613604032a5880b576f8a35048e18L40-R40) [[3]](diffhunk://#diff-00d0823118413de8d06f7c61e80dfa5b65ae0def0149e23a1c3de1eada47a186L116-R117)
* Renamed and clarified the Nyxstone bridge as `NyxstoneBackend`, emphasizing its encapsulation (pimpl) and role as a ground-truth oracle for differential validation. [[1]](diffhunk://#diff-3f6db93689127c98f17ab427484dea89885613604032a5880b576f8a35048e18L18-R19) [[2]](diffhunk://#diff-3f6db93689127c98f17ab427484dea89885613604032a5880b576f8a35048e18L93-R94) [[3]](diffhunk://#diff-dc2bfd470b0658f3f1ee1facf987331cbf5368155b8686fec2cea4f8a1edb93eL123-R123) [[4]](diffhunk://#diff-cd43b2983005a304f5010c0b44f471788f3f696d808ed4186b8763d1bce76461L62-R63)
* Updated test suite documentation to include the new `nyxstone_test`, which differentially validates the decoder/disassembler against LLVM, and clarified when it is built. [[1]](diffhunk://#diff-abe2cb896ee58cb8385db5e910257f785fe0aea0831acf2f04c9f9dee75334e5L48-R49) [[2]](diffhunk://#diff-3f6db93689127c98f17ab427484dea89885613604032a5880b576f8a35048e18L111-R112) [[3]](diffhunk://#diff-e5372da78ad3a00a46af5b83becee79e76782fd8a064c35a1bf08969fc038b32R161)

**Trace logging system:**

* Documented the new spdlog-based instruction/pipeline trace logging in `mips_core`, including configuration via the `CLEARCORE_LOG_LEVEL` environment variable, output examples, and integration points. Emphasized that tracing is quiet by default and does not affect normal runs or tests. [[1]](diffhunk://#diff-e5372da78ad3a00a46af5b83becee79e76782fd8a064c35a1bf08969fc038b32L12-R44) [[2]](diffhunk://#diff-e5372da78ad3a00a46af5b83becee79e76782fd8a064c35a1bf08969fc038b32R117-R140) [[3]](diffhunk://#diff-3f6db93689127c98f17ab427484dea89885613604032a5880b576f8a35048e18L18-R19) [[4]](diffhunk://#diff-00d0823118413de8d06f7c61e80dfa5b65ae0def0149e23a1c3de1eada47a186L116-R117) [[5]](diffhunk://#diff-cd43b2983005a304f5010c0b44f471788f3f696d808ed4186b8763d1bce76461L62-R63)

**Build and dependency instructions:**

* Updated installation instructions for LLVM and Clang to specify version 19 for Fedora, Ubuntu, and macOS, and clarified the need for both components for Nyxstone.
* Noted that GSL and spdlog are auto-fetched and that spdlog powers the trace log.

**Other improvements:**

* Improved descriptions of test coverage, build behavior when dependencies are missing, and the role of the various test suites. [[1]](diffhunk://#diff-abe2cb896ee58cb8385db5e910257f785fe0aea0831acf2f04c9f9dee75334e5L48-R49) [[2]](diffhunk://#diff-3f6db93689127c98f17ab427484dea89885613604032a5880b576f8a35048e18L111-R112) [[3]](diffhunk://#diff-e5372da78ad3a00a46af5b83becee79e76782fd8a064c35a1bf08969fc038b32R161)

These updates make the documentation more accurate and actionable for users and contributors working with Nyxstone and the new runtime logging features.

## Summary by Sourcery

Clarify Nyxstone’s LLVM version requirements and its role as a validation backend, and document the new spdlog-based runtime trace logging system alongside updated build and test descriptions.

Enhancements:
- Clarify build behavior when optional dependencies like Qt6, in-range LLVM, or JRE are missing and how the system degrades gracefully.
- State constraints on keeping third-party headers out of mips_core public interfaces and how NyxstoneBackend and trace logging respect this boundary.

Build:
- Refine LLVM/Clang installation instructions to prefer version 19 packages on Fedora, Ubuntu, and macOS and note auto-fetching of GSL and spdlog.

Documentation:
- Document stricter LLVM+Clang 15–20 requirement for Nyxstone and how to pin an in-range installation via NYXSTONE_LLVM_PREFIX.
- Describe the spdlog-based runtime instruction and pipeline trace logging, including configuration via CLEARCORE_LOG_LEVEL and example output.
- Explain NyxstoneBackend’s role as an encapsulated LLVM-backed assembler/disassembler and ground-truth oracle, and update references across architecture and emulator docs.
- Update Getting Started, Home, Architecture, Contributing, Roadmap, and MIPS emulator docs to reflect six core CTest suites, nyxstone_test, and improved dependency handling and test coverage descriptions.

Tests:
- Document the nyxstone_test differential validation suite and its build conditions, and update counts and descriptions of the core CTest suites.