### PR TITLE
build(cmake): force spdlog's bundled fmt to fix find_package(fmt) failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,12 @@ FetchContent_Declare(GSL
 set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+# Force the bundled fmt. We never provide an external fmt package, so if
+# SPDLOG_FMT_EXTERNAL is ever left ON (e.g. a stale cache value or an IDE-set
+# CMake option), spdlog's own CMakeLists runs find_package(fmt CONFIG REQUIRED)
+# and configuration fails. FORCE overrides any such cached/command-line value.
+set(SPDLOG_FMT_EXTERNAL OFF CACHE BOOL "" FORCE)
+set(SPDLOG_FMT_EXTERNAL_HO OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(spdlog
         GIT_REPOSITORY "https://github.com/gabime/spdlog.git"


### PR DESCRIPTION
## Problem

Configuring any preset (`debug`, `release`, `asan`) failed at
`_deps/spdlog-src/CMakeLists.txt:211`:

```
Could not find a package configuration file provided by "fmt"
```

spdlog only calls `find_package(fmt CONFIG REQUIRED)` when
`SPDLOG_FMT_EXTERNAL` (or `_HO`) is ON. All three build caches had a
stale `SPDLOG_FMT_EXTERNAL:BOOL=ON` (likely set once via CLion's CMake
options). Nothing in our `CMakeLists.txt` turned it back off, and we
never provide an external fmt package, so configuration failed.

## Fix

Force `SPDLOG_FMT_EXTERNAL` and `SPDLOG_FMT_EXTERNAL_HO` OFF next to the
other spdlog options. `FORCE` overrides any stale cache entry, IDE-set
option, or command-line `-D`, so external fmt can't silently come back.
This matches the documented intent to use spdlog's bundled fmt copy and
avoids the cross-version fmt/spdlog API mismatch risk.

## Verification

- `cmake --preset {debug,release,asan}` all configure cleanly (no `find_package(fmt)` error)
- `cmake --build --preset debug` builds all 84 targets successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Override spdlog CMake options to disable external fmt usage and ensure consistent builds across presets.