### PR TITLE
build(cmake): force spdlog's bundled fmt to fix find_package(fmt) fai…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,12 @@ FetchContent_Declare(GSL
 set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+# Force the bundled fmt. We never provide an external fmt package, so if
+# SPDLOG_FMT_EXTERNAL is ever left ON (e.g. a stale cache value or an IDE-set
+# CMake option), spdlog's own CMakeLists runs find_package(fmt CONFIG REQUIRED)
+# and configuration fails. FORCE overrides any such cached/command-line value.
+set(SPDLOG_FMT_EXTERNAL OFF CACHE BOOL "" FORCE)
+set(SPDLOG_FMT_EXTERNAL_HO OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(spdlog
         GIT_REPOSITORY "https://github.com/gabime/spdlog.git"


### PR DESCRIPTION
…lure

spdlog's CMakeLists runs find_package(fmt CONFIG REQUIRED) whenever SPDLOG_FMT_EXTERNAL is ON. A stale ON value in the build caches made configuration fail with "Could not find a package configuration file provided by fmt", since no external fmt package is provided.

Force SPDLOG_FMT_EXTERNAL and SPDLOG_FMT_EXTERNAL_HO OFF so a stale cache, IDE-set option, or command-line -D can't re-enable external fmt. This matches the documented intent to use spdlog's bundled fmt copy.

## Summary by Sourcery

Build:
- Set SPDLOG_FMT_EXTERNAL and SPDLOG_FMT_EXTERNAL_HO CMake cache options to OFF with FORCE so external fmt is never required during configuration.