### PR TITLE
ci: reduce PR job count with path filters and conditional jobs

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,7 +1,11 @@
 name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'fuzz/**'
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ on:
       - 'src/**'
       - 'include/**'
       - 'tests/**'
-      - 'CMakeLists.txt'
+      - 'qml/**'
+      - '**/CMakeLists.txt'
       - 'cmake/**'
       - 'CMakePresets.json'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -139,7 +140,7 @@ jobs:
         run: ctest --preset ${{ matrix.preset }}
 
   full-build:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'CMakePresets.json'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read
@@ -54,6 +62,7 @@ jobs:
         run: exit 1
 
   coverage:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -130,6 +139,7 @@ jobs:
         run: ctest --preset ${{ matrix.preset }}
 
   full-build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,12 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - '**/CMakeLists.txt'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- **`ci.yml`**: add `paths` filter to PR trigger so CI skips on docs/wiki-only changes; `coverage` job restricted to push events only; `full-build` skips draft PRs
- **`cflite_pr.yml`**: narrow fuzzing to PRs targeting `main` only (removed `develop`); add source-file path filter
- **`dependency-review.yml`**: trigger only when CMake dependency files change

## Expected savings

| Scenario | Before | After |
|---|---|---|
| Source-change PR to `develop` | 7 jobs | 4 jobs |
| Source-change PR to `main` | 8 jobs | 5 jobs |
| Docs-only PR | 7 jobs | 0 jobs |
| Draft PR | 7 jobs | 3 jobs |

## Test plan

- [ ] Open a source-change PR to `develop` and confirm `format`, `core-tests` ×2, and `full-build` run (coverage and CFL should not)
- [ ] Open a docs-only PR and confirm no CI jobs trigger
- [ ] Mark a PR as draft and confirm `full-build` is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce CI workload for pull requests by introducing path-based triggers and conditional job execution.

Build:
- Limit dependency review workflow to run only when CMake-related files change.
- Restrict ClusterFuzzLite PR workflow to main branch and relevant source/fuzz file paths.

CI:
- Add path filters to main CI workflow so PRs only trigger when source, tests, build config, or CI config files change.
- Run coverage job only on push events instead of pull requests.
- Skip the full-build job for draft pull requests to avoid unnecessary CI usage.