### PR TITLE
Develop

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,7 +1,11 @@
 name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'fuzz/**'
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ on:
       - 'src/**'
       - 'include/**'
       - 'tests/**'
-      - 'CMakeLists.txt'
+      - 'qml/**'
+      - '**/CMakeLists.txt'
       - 'cmake/**'
       - 'CMakePresets.json'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -139,7 +140,7 @@ jobs:
         run: ctest --preset ${{ matrix.preset }}
 
   full-build:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'CMakePresets.json'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read
@@ -54,6 +62,7 @@ jobs:
         run: exit 1
 
   coverage:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -130,6 +139,7 @@ jobs:
         run: ctest --preset ${{ matrix.preset }}
 
   full-build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,12 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - '**/CMakeLists.txt'
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to optimize when CI, fuzzing, and dependency review workflows are triggered. The main changes restrict workflow runs to specific branches and file paths, and add conditions to certain jobs to reduce unnecessary CI runs.

**Workflow trigger optimizations:**

* [`.github/workflows/cflite_pr.yml`](diffhunk://#diff-901d28e78554ed027d6845dc00bca07d9fa96a70159d9d5db422de24de389f46L4-R8): The PR fuzzing workflow is now only triggered for PRs targeting the `main` branch and only when changes are made in the `src/`, `include/`, or `fuzz/` directories.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR23-R31): The CI workflow for pull requests is now limited to changes in key source, test, and configuration files or directories, reducing unnecessary runs.
* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L10-R15): The dependency review workflow now only runs when CMake-related files or directories are changed in a pull request.

**Conditional job execution:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR66): The `coverage` job now only runs on `push` events, not on pull requests.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR143): The `full-build` job will only run for non-draft pull requests or on push events, skipping draft PRs to save resources.

## Summary by Sourcery

Tighten GitHub Actions workflow triggers and job conditions to reduce unnecessary CI, fuzzing, and dependency review runs.

CI:
- Restrict the main CI workflow to run on pull requests that modify key source, test, QML, CMake, or workflow files.
- Limit the coverage job to run only on push events.
- Run the full-build job only for non-draft pull requests or on push events, skipping draft PRs.
- Constrain the dependency review workflow to pull requests that change CMake-related files or directories.
- Limit the ClusterFuzzLite PR fuzzing workflow to pull requests targeting the main branch that touch core source, header, or fuzzing directories.