### PR TITLE
tighten changelog workflow top-level permissions to read-all

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,8 +8,7 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   update-changelog:


### PR DESCRIPTION
tighten changelog workflow top-level permissions to read-all

## Summary by Sourcery

CI:
- Adjust changelog workflow permissions configuration to use the consolidated read-all setting.