### PR TITLE
docs: add issue templates (bugs, report, feature request, custom)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,16 +51,16 @@ body:
     id: component
     attributes:
       label: Component
-      description: Which part of clearCore is affected?
+      description: Which part of clearCore is affected? (Note the engine — single-cycle or pipeline — in the repro steps if relevant.)
       options:
-        - Core / simulation engine (single-cycle)
-        - Core / simulation engine (5-stage pipeline)
+        - Core / simulation engine
         - Terminal UI (FTXUI)
         - Qt6 Widgets GUI
         - Qt Quick / QML GUI
         - GDB remote stub / debugging
         - Number-system converter
-        - Build system / CI (CMake, presets, workflows)
+        - Build system / CI
+        - Documentation
         - Other / not sure
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for reporting a bug! Please fill out the sections below so we can
         reproduce and fix it quickly. For questions or ideas, use the **Custom
-        issue** template or [Discussions](../../discussions) instead.
+        issue** template or [Discussions](https://github.com/khenderson20/clearCore/discussions) instead.
 
   - type: checkboxes
     id: preflight
@@ -70,7 +70,7 @@ body:
     attributes:
       label: Environment
       description: Run `cmake --version` and note your compiler/OS. Qt version only if using a GUI.
-      value: |
+      placeholder: |
         - clearCore version / commit:
         - OS:
         - Compiler (GCC/Clang + version):

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a reproducible defect in clearCore
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below so we can
+        reproduce and fix it quickly. For questions or ideas, use the **Custom
+        issue** template or [Discussions](../../discussions) instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues (open and closed) and this is not a duplicate.
+          required: true
+        - label: I am running the latest release or `develop`, or I've noted my version below.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug and what you expected instead.
+      placeholder: |
+        When I ..., clearCore does X. I expected it to do Y.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, exact steps. Include an assembly snippet or ELF if relevant.
+      placeholder: |
+        1. Start clearCore with `...`
+        2. Load / type this program:
+           ```mips
+           addi $t0, $zero, 5
+           ...
+           ```
+        3. Step / run to ...
+        4. See error
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of clearCore is affected?
+      options:
+        - Core / simulation engine (single-cycle)
+        - Core / simulation engine (5-stage pipeline)
+        - Terminal UI (FTXUI)
+        - Qt6 Widgets GUI
+        - Qt Quick / QML GUI
+        - GDB remote stub / debugging
+        - Number-system converter
+        - Build system / CI (CMake, presets, workflows)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Run `cmake --version` and note your compiler/OS. Qt version only if using a GUI.
+      value: |
+        - clearCore version / commit:
+        - OS:
+        - Compiler (GCC/Clang + version):
+        - CMake version:
+        - Qt version (if applicable):
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, backtrace, or screenshots
+      description: Paste relevant output. Terminal logs are automatically formatted, no backticks needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/khenderson20/clearCore/discussions
+    about: Ask questions, share ideas, or get help using clearCore.
+  - name: Documentation
+    url: https://github.com/khenderson20/clearCore#readme
+    about: Read the README and docs before opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/khenderson20/clearCore/security/advisories/new
+    about: Report security issues privately — please do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -46,13 +46,13 @@ assignees: ''
 
 <!-- Delete the ones that don't apply. -->
 
-- [ ] Core / simulation engine (single-cycle or 5-stage pipeline)
+- [ ] Core / simulation engine
 - [ ] Terminal UI (FTXUI)
 - [ ] Qt6 Widgets GUI
 - [ ] Qt Quick / QML GUI
 - [ ] GDB remote stub / debugging
 - [ ] Number-system converter
-- [ ] Build system / CI (CMake, presets, workflows)
+- [ ] Build system / CI
 - [ ] Documentation
 - [ ] Other / not sure
 
@@ -72,5 +72,9 @@ assignees: ''
 
 ---
 
-- [ ] I searched existing issues and this is not a duplicate.
-- [ ] I read the README and relevant docs.
+<!--
+  Optional guidance (not enforced) — the Bug report and Feature request
+  forms enforce these checks; this catch-all template does not. Please still:
+    - Search existing issues to avoid duplicates.
+    - Skim the README and relevant docs.
+-->

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,76 @@
+---
+name: Custom issue
+about: For anything that doesn't fit the bug report or feature request forms
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+  Thanks for taking the time to open an issue for clearCore!
+
+  Use this template for things that aren't a plain bug report or feature
+  request — for example: a question, a documentation gap, a design proposal,
+  a refactor idea, or a task you'd like tracked.
+
+  For reproducible defects, prefer the "Bug report" template.
+  For new capabilities, prefer the "Feature request" template.
+
+  Before you file, please:
+    - Search existing issues (open and closed) to avoid duplicates.
+    - Check the README and the docs/ directory.
+-->
+
+## Summary
+
+<!-- One or two sentences: what is this issue about? -->
+
+## Context / motivation
+
+<!--
+  Why does this matter? What problem are you trying to solve, or what
+  prompted this? Link related issues/PRs with #number where relevant.
+-->
+
+## Details
+
+<!--
+  Put the substance here. Depending on the type of issue, that might be:
+    - A question and what you've already tried or read.
+    - A proposal, with the change you'd like and alternatives you considered.
+    - A task description, with a rough definition of "done".
+  Include code, assembly snippets, or logs in fenced blocks where they help.
+-->
+
+## Which part of clearCore does this touch?
+
+<!-- Delete the ones that don't apply. -->
+
+- [ ] Core / simulation engine (single-cycle or 5-stage pipeline)
+- [ ] Terminal UI (FTXUI)
+- [ ] Qt6 Widgets GUI
+- [ ] Qt Quick / QML GUI
+- [ ] GDB remote stub / debugging
+- [ ] Number-system converter
+- [ ] Build system / CI (CMake, presets, workflows)
+- [ ] Documentation
+- [ ] Other / not sure
+
+## Environment (if relevant)
+
+<!-- Only needed if this depends on your setup. -->
+
+- clearCore version / commit:
+- OS:
+- Compiler (GCC/Clang + version):
+- CMake version:
+- Qt version (if using a GUI):
+
+## Additional information
+
+<!-- Screenshots, references, links, or anything else that helps. -->
+
+---
+
+- [ ] I searched existing issues and this is not a duplicate.
+- [ ] I read the README and relevant docs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: Feature request
+description: Suggest a new capability or improvement for clearCore
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve clearCore! Please describe the problem you're
+        trying to solve, not just the solution — it helps us find the best fit.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues (open and closed) and this is not a duplicate.
+          required: true
+        - label: I checked the README and docs to confirm this doesn't already exist.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what's getting in the way today?
+      placeholder: |
+        I'm always frustrated when ... / It's hard to ... because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like clearCore to do? Sketch the behavior or UI if you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds, or prior art (e.g. how Ripes/DrMIPS/MARS handle it).
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of clearCore would this affect?
+      options:
+        - Core / simulation engine
+        - Terminal UI (FTXUI)
+        - Qt6 Widgets GUI
+        - Qt Quick / QML GUI
+        - GDB remote stub / debugging
+        - Number-system converter
+        - Build system / CI
+        - Documentation
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, references, links, or anything else that helps.
+    validations:
+      required: false


### PR DESCRIPTION
This pull request introduces a comprehensive set of GitHub issue templates and configuration to improve the clarity, structure, and triage of issues reported for the project. It adds dedicated forms for bug reports and feature requests, a catch-all template for other issue types, and a configuration file that directs users to discussions or documentation as appropriate.

**New issue templates:**

- Added a detailed bug report form (`bug_report.yml`) to standardize defect reporting, including required fields for reproduction steps, environment details, and affected components.
- Added a feature request form (`feature_request.yml`) to guide users in proposing new capabilities, including sections for motivation, proposed solution, alternatives, and affected components.
- Introduced a custom issue template (`custom.md`) for questions, ideas, proposals, or tasks that don’t fit the bug or feature forms, with prompts for context and affected parts of the project.

**Issue triage and guidance improvements:**

- Added a configuration file (`config.yml`) to disable blank issues and provide direct links for questions, documentation, and security advisories, helping users choose the appropriate channel before opening an issue.

## Summary by Sourcery

Introduce structured GitHub issue templates to standardize reporting and guide contributors to the right support channels.

CI:
- Configure GitHub issue settings to disable blank issues and surface links to discussions, documentation, and security advisories.

Documentation:
- Add structured bug report and feature request issue forms with required context and component selection fields.

Chores:
- Add a general-purpose custom issue template for questions, proposals, and other non-standard requests.