### PR TITLE
docs: refine bug report template (placeholder env, absolute Discussions URL)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for reporting a bug! Please fill out the sections below so we can
         reproduce and fix it quickly. For questions or ideas, use the **Custom
-        issue** template or [Discussions](../../discussions) instead.
+        issue** template or [Discussions](https://github.com/khenderson20/clearCore/discussions) instead.
 
   - type: checkboxes
     id: preflight
@@ -70,7 +70,7 @@ body:
     attributes:
       label: Environment
       description: Run `cmake --version` and note your compiler/OS. Qt version only if using a GUI.
-      value: |
+      placeholder: |
         - clearCore version / commit:
         - OS:
         - Compiler (GCC/Clang + version):


### PR DESCRIPTION
Follow-up to #36 addressing code-review feedback on the bug report form.

- Switch the required **Environment** textarea from `value` to `placeholder` so reporters can't submit the unedited template — with `required: true`, a pre-filled `value` would satisfy the requirement without real input.
- Replace the relative `../../discussions` link with an absolute Discussions URL, which resolves reliably from the rendered issue form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine the GitHub bug report issue template to improve guidance and input quality.

Documentation:
- Update the bug report template introduction to use a stable absolute link to the repository Discussions page.
- Change the Environment field in the bug report template to use a placeholder instead of a pre-filled value so reporters provide their own details.