### PR TITLE
docs: add citation metadata and community health files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for contributing to clearCore!
+PRs should target the `develop` branch. See CONTRIBUTING.md for the full guide.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issues
+
+<!-- e.g. "Closes #123" or "Refs #123". Delete if none. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation / wiki
+- [ ] Build / CI / tooling
+
+## How was this verified?
+
+<!-- Commands run and results. -->
+
+- [ ] `cmake --build --preset debug` succeeds
+- [ ] `ctest --preset debug` passes
+- [ ] `ctest --preset asan` passes (if the change touches core logic)
+- [ ] Added or updated tests under `tests/`
+
+## Checklist
+
+- [ ] Branch is based on and targets `develop`
+- [ ] Code is `clang-format`-clean
+- [ ] Core libraries (`nsc_core`, `mips_core`) include no UI headers
+- [ ] Docs / CHANGELOG updated if the change is user-facing

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,44 @@
+cff-version: 1.2.0
+title: >-
+  clearCore: An educational MIPS CPU simulator with
+  live 5-stage pipeline visualization
+message: >-
+  If you use clearCore in your research, teaching, or a
+  derivative project, please cite it using the metadata
+  in this file.
+type: software
+authors:
+  - given-names: Kevin
+    family-names: Henderson
+    email: kevin.d.hende@gmail.com
+    alias: khenderson20
+repository-code: 'https://github.com/khenderson20/clearCore'
+url: 'https://github.com/khenderson20/clearCore'
+abstract: >-
+  clearCore is a C++20 MIPS CPU simulator built for seeing
+  how a processor works. It provides two interchangeable
+  execution engines — a single-cycle datapath and a 5-stage
+  pipeline sharing one IProcessor interface — and three
+  front ends (a terminal UI, a Qt6 Widgets GUI, and a Qt
+  Quick/QML GUI) that render pipeline state, hazards,
+  stalls, forwarding paths, CP0 exceptions, and an ELF
+  loader. A built-in GDB remote stub lets real GDB attach
+  to the running emulator.
+keywords:
+  - computer-architecture
+  - mips
+  - cpu-simulator
+  - pipeline
+  - hazard-detection
+  - data-forwarding
+  - educational
+  - cpp20
+  - qt6
+  - terminal-ui
+license: MIT
+version: 0.0.1
+date-released: '2026-07-02'
+# After enabling the GitHub–Zenodo integration and publishing a
+# release, add the minted DOI here so the "Cite this repository"
+# export includes it, e.g.:
+# doi: 10.5281/zenodo.XXXXXXX

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**kevin.d.hende@gmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to clearCore
+
+Thanks for your interest in improving clearCore! Contributions of all kinds are
+welcome — bug reports, documentation fixes, new tests, and features.
+
+The full contributor guide lives in the wiki:
+**[Contributing](https://github.com/khenderson20/clearCore/wiki/Contributing)**
+(branching model, code style, testing conventions, and CI details).
+
+## Quick start
+
+1. Fork the repository.
+2. Create a feature branch **from `develop`** (not `main`) with a descriptive name,
+   e.g. `feat/branch-predictor` or `fix/decoder-signext`.
+3. Make your changes, keeping core libraries (`nsc_core`, `mips_core`) free of any
+   UI headers — see the [code style rules](https://github.com/khenderson20/clearCore/wiki/Contributing#code-style).
+4. Add tests covering your change under `tests/`, mirroring the `src/` layout.
+5. Verify locally:
+   ```bash
+   cmake --preset debug
+   cmake --build --preset debug
+   ctest --preset debug        # or: ctest --preset asan
+   ```
+6. Open a pull request **targeting `develop`**. Fill out the PR template so
+   reviewers can see what changed and how it was verified.
+
+## Before you open a PR
+
+- Run `clang-format` (CI enforces it) — the project ships a `.clang-format`.
+- Keep commits focused; a PR that does one thing is easier to review and land.
+- If your change is user-facing, note it so it can be captured in the
+  [CHANGELOG](CHANGELOG.md).
+
+## Reporting bugs and requesting features
+
+Use the [issue templates](https://github.com/khenderson20/clearCore/issues/new/choose)
+(bug report / feature request). For security issues, follow
+[SECURITY.md](SECURITY.md) instead of opening a public issue.
+
+## Code of Conduct
+
+Participation in this project is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md). By taking part, you agree to uphold it.


### PR DESCRIPTION
## Summary

Adds the citation and community-health files that GitHub's community profile flagged as missing, taking the repo to 100% community health.

- **`CITATION.cff`** — GitHub renders a **"Cite this repository"** button (APA/BibTeX export). The DOI field is left commented, ready to fill in after enabling the GitHub–Zenodo integration and publishing a release.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, maintainer email as the enforcement contact.
- **`CONTRIBUTING.md`** — root-level guide (GitHub surfaces this in the issue/PR composer) that links the fuller wiki page and encodes the `develop`-target branching model and the no-UI-headers-in-core rule.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — verification steps + checklist mirroring the contributing rules.

`FUNDING.yml` was intentionally left out — it already exists on `main`.

## Type of change

- [x] Documentation / wiki
- [x] Build / CI / tooling

## How was this verified?

- Pre-commit hooks pass (end-of-file, trailing whitespace, secrets scan).
- `CITATION.cff` validated as well-formed YAML with the required CFF keys.

## Checklist

- [x] Branch is based on and targets `develop`
- [x] Docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add citation metadata and community health documentation to improve GitHub community profile completeness.

Build:
- Add a standardized pull request template aligning with contributing and verification guidelines.

Documentation:
- Add a Contributor Covenant–based code of conduct for project participation.
- Add a contributor guide summarizing branching, testing, and reporting conventions.
- Add citation metadata (CITATION.cff) so the repository can be easily cited in academic contexts.