### PR TITLE
docs: add JOSS paper draft

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,67 @@
+@book{patterson,
+  author    = {Patterson, David A. and Hennessy, John L.},
+  title     = {Computer Organization and Design {MIPS} Edition: The Hardware/Software Interface},
+  edition   = {5},
+  publisher = {Morgan Kaufmann},
+  address   = {Waltham, MA},
+  year      = {2013},
+  isbn      = {978-0124077263}
+}
+
+@book{harris,
+  author    = {Harris, David Money and Harris, Sarah L.},
+  title     = {Digital Design and Computer Architecture},
+  edition   = {2},
+  publisher = {Morgan Kaufmann},
+  address   = {Waltham, MA},
+  year      = {2012},
+  isbn      = {978-0123944245}
+}
+
+@misc{ripes,
+  author       = {Petersen, Morten Borup},
+  title        = {{Ripes}: A graphical processor simulator and assembly editor for the {RISC-V} {ISA}},
+  howpublished = {\url{https://github.com/mortbopet/Ripes}},
+  note         = {Accessed: 2026-07-04},
+  year         = {2024}
+}
+
+@misc{edumips64,
+  author       = {{EduMIPS64 Development Team}},
+  title        = {{EduMIPS64}: A visual {MIPS64} {CPU} simulator},
+  howpublished = {\url{https://github.com/EduMIPS64/edumips64}},
+  note         = {Accessed: 2026-07-04},
+  year         = {2024}
+}
+
+@misc{drmips,
+  author       = {Nunes, Bruno},
+  title        = {{DrMIPS}: An educational {MIPS} processor simulator},
+  howpublished = {\url{https://github.com/brunonova/drmips}},
+  note         = {Accessed: 2026-07-04},
+  year         = {2018}
+}
+
+@misc{qtmips,
+  author       = {{\v{S}}usta, Pavel and {contributors}},
+  title        = {{QtMips}: {MIPS} {CPU} simulator for education purposes},
+  howpublished = {\url{https://github.com/cvut/QtMips}},
+  note         = {Accessed: 2026-07-04},
+  year         = {2021}
+}
+
+@misc{ftxui,
+  author       = {Coulon, Arthur Sonzogni},
+  title        = {{FTXUI}: A simple cross-platform C++ library for terminal based user interfaces},
+  howpublished = {\url{https://github.com/ArthurSonzogni/FTXUI}},
+  note         = {Accessed: 2026-07-04},
+  year         = {2024}
+}
+
+@misc{qt,
+  author       = {{The Qt Company}},
+  title        = {{Qt}: Cross-platform software development framework},
+  howpublished = {\url{https://www.qt.io}},
+  note         = {Accessed: 2026-07-04},
+  year         = {2024}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,91 @@
+---
+title: 'clearCore: An educational MIPS CPU simulator with live pipeline visualization'
+tags:
+  - C++
+  - computer architecture
+  - computer organization
+  - CPU simulator
+  - MIPS
+  - pipeline
+  - hazard detection
+  - education
+authors:
+  - name: Kevin Henderson
+    orcid: 0009-0002-8847-5459
+    affiliation: 1
+affiliations:
+  - name: Independent Researcher, San Antonio, TX, USA
+    index: 1
+date: 4 July 2026
+bibliography: paper.bib
+---
+
+# Summary
+
+`clearCore` is a MIPS CPU simulator built for *seeing* how a processor
+executes instructions. A student writes MIPS assembly in a built-in editor,
+steps the processor cycle by cycle, and watches each instruction move through
+the five classic pipeline stages — instruction fetch, decode, execute, memory
+access, and write-back — with data hazards, pipeline stalls, control flushes,
+and forwarding paths highlighted as they occur. Two execution engines, a
+single-cycle datapath and a five-stage pipeline, implement a common
+`IProcessor` interface and can be swapped at runtime without rebuilding, letting
+learners contrast the two models on the same program. Beyond hand-typed
+programs, `clearCore` loads little-endian MIPS ELF32 binaries, implements
+Coprocessor 0 exception handling per the MIPS32r2 specification, and exposes a
+GDB remote-serial-protocol stub so that a standard `gdb` client can attach to
+the running emulator for breakpoints, single-stepping, and register inspection.
+
+The simulator is written in C++20 and ships three interchangeable front ends
+that all drive the same core libraries: a keyboard-driven terminal user
+interface built with FTXUI [@ftxui], a Qt6 Widgets desktop GUI, and a Qt
+Quick/QML GUI [@qt]. The processor and instruction-decoding logic live in
+UI-independent libraries that are unit-tested in isolation, so pipeline behavior
+is identical across every interface. The design follows the canonical
+undergraduate computer-architecture texts by Patterson and Hennessy [@patterson]
+and Harris and Harris [@harris].
+
+# Statement of need
+
+Pipelined execution — and the hazards, stalls, and forwarding it introduces — is
+one of the most difficult concepts in an undergraduate computer-organization
+course. Static datapath diagrams in textbooks show the *structure* of a pipeline
+but not its *dynamics*: students struggle to connect a printed instruction ×
+cycle diagram to the moment-to-moment movement of data through the datapath, and
+in particular to why a stall or a forwarding path is required for a specific
+sequence of instructions.
+
+Existing educational simulators address parts of this gap. Ripes [@ripes]
+provides a rich graphical datapath schematic but targets RISC-V; EduMIPS64
+[@edumips64] and DrMIPS [@drmips] visualize MIPS execution through Java/Swing
+GUIs; and QtMips [@qtmips] offers a Qt-based MIPS datapath view. `clearCore`
+occupies a distinct point in this space: it pairs a modern C++20 core with
+*multiple* front ends — including a fully keyboard-driven terminal UI that runs
+over SSH with no graphical environment — and it emphasizes runtime-swappable
+execution backends so that the same program can be observed under both a
+single-cycle and a pipelined model. The terminal front end, in particular,
+lowers the barrier to use in headless lab and remote-teaching settings where
+installing a desktop GUI toolkit is impractical.
+
+`clearCore` also goes beyond the pedagogical minimum by implementing hardware
+behavior that is usually abstracted away in teaching simulators: real CP0
+exceptions that vector rather than halting the machine, an ELF loader that
+accepts binaries produced by an ordinary `mipsel` cross-toolchain, and a GDB
+stub that lets students debug emulated programs with the same tool they use for
+native code. These features let a single tool span an introductory
+"what is a pipeline" lesson and a more advanced "how does exception handling and
+debugging actually work" lesson.
+
+The software is intended for undergraduate students learning computer
+organization, instructors preparing lab exercises and lecture demonstrations,
+and self-directed learners exploring processor internals. Its permissive MIT
+license and unit-tested, UI-independent core also make it a reusable foundation
+for coursework that extends the simulator — for example, adding branch
+prediction or additional pipeline stages.
+
+# Acknowledgements
+
+We thank the maintainers of the open-source libraries `clearCore` builds upon,
+in particular FTXUI and Qt.
+
+# References


### PR DESCRIPTION
## Summary

Adds a Journal of Open Source Software (JOSS) submission draft under `paper/`.

- **`paper/paper.md`** — Summary (dual single-cycle/pipelined backends, three front ends, CP0/ELF/GDB, textbook grounding) and a Statement of Need positioning clearCore against Ripes, EduMIPS64, DrMIPS, and QtMips. 601 words, within JOSS's ~250–1000 range. Author metadata (name, ORCID, affiliation) is complete.
- **`paper/paper.bib`** — textbook references (Patterson & Hennessy; Harris & Harris) plus related-software and library citations. All 8 cited keys resolve against the bib.

## Notes for reviewers

- Related-tool citations point to their repositories (`@misc`), not formal papers, to avoid fabricated references. These can be upgraded to published citations later.
- This is a draft to iterate on; actual JOSS submission depends on project maturity (release history, user base), which is a separate consideration from the paper's structure.

## Type of change

- [x] Documentation / wiki

## How was this verified?

- Word count checked (601, within JOSS range).
- Every `@key` used in the paper confirmed present in `paper.bib`.
- Pre-commit hooks pass.

## Checklist

- [x] Branch is based on and targets `develop`
- [x] Docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)