### PR TITLE
ci: add release workflow to publish binary artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+# clearCore release artifacts.
+#
+# Builds a full Release (TUI + both Qt6 GUIs) and packages it with CPack, then
+# attaches the resulting .tar.gz to the GitHub release that triggered the run.
+#
+# Trigger: publishing a GitHub release (the release-drafter draft, once you hit
+# "Publish"). This is the same event that fires the GitHub->Zenodo archive, so
+# a published release gets both a DOI and downloadable binaries. Also runnable
+# manually via workflow_dispatch to smoke-test packaging without a release.
+#
+# NOTE: the .tar.gz contains clearCore's binaries but assumes Qt6 is present on
+# the user's system. A self-contained AppImage (bundling Qt) is a planned
+# follow-up layered on the same CPack install rules.
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# Read-only by default; the packaging job elevates to contents: write only to
+# upload release assets.
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  linux-package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # upload assets to the release
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install build dependencies
+        run: >
+          sudo apt-get update && sudo apt-get install -y
+          ninja-build qt6-base-dev qt6-base-private-dev qt6-declarative-dev
+          llvm-dev zlib1g-dev
+
+      - name: Install KSyntaxHighlighting (optional)
+        run: sudo apt-get install -y libkf6syntaxhighlighting-dev || true
+
+      - name: Configure (Release, all UIs)
+        run: cmake --preset release
+
+      - name: Build
+        run: cmake --build --preset release
+
+      # Gate the artifacts on a passing test run so we never publish a broken
+      # binary. qt_ui_test uses Qt's offscreen platform (set in CMake).
+      - name: Test
+        run: ctest --test-dir build/release --output-on-failure
+
+      - name: Package (CPack)
+        id: package
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"          # strip leading 'v' (v0.0.2 -> 0.0.2)
+          else
+            VERSION="0.0.0-dev"
+          fi
+          echo "Packaging clearCore $VERSION"
+          # CMake bakes CPACK_PACKAGE_FILE_NAME into CPackConfig.cmake as a
+          # literal, so overriding CPACK_PACKAGE_VERSION alone won't rename the
+          # archive — set the file name explicitly (with arch) as well.
+          cpack --config build/release/CPackConfig.cmake -G TGZ \
+                -D CPACK_PACKAGE_VERSION="$VERSION" \
+                -D CPACK_PACKAGE_FILE_NAME="clearCore-${VERSION}-Linux-x86_64" \
+                -B "${{ github.workspace }}/dist"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          ls -la "${{ github.workspace }}/dist"/*.tar.gz
+
+      - name: Upload workflow artifact (always)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: clearCore-linux-${{ steps.package.outputs.version }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+      - name: Attach to the GitHub release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist/*.tar.gz --clobber --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so that publishing a GitHub release automatically builds and attaches downloadable binaries — instead of leaving only the source zips GitHub generates. Builds on the install/CPack rules from #41.

**Flow:** you publish the release-drafter draft → this workflow builds a full Release (TUI + both Qt6 GUIs), runs the test suite, packages with CPack, and attaches the `.tar.gz` to that release. It's the same `release: published` event that fires the GitHub→Zenodo archive, so a published release gets a DOI *and* binaries together.

## Design choices (matching repo conventions)

- **Trigger:** `release: published` + `workflow_dispatch` (manual smoke-test that uploads only a workflow artifact, not a release asset).
- **Tests gate packaging** — `ctest` runs before CPack, so a broken build never ships.
- **Version from the tag:** overrides `CPACK_PACKAGE_VERSION` *and* `CPACK_PACKAGE_FILE_NAME` (CMake bakes the file name as a literal, so the version override alone doesn't rename the archive — verified locally). Artifacts are named e.g. `clearCore-0.0.2-Linux-x86_64.tar.gz` regardless of `project(VERSION)`.
- **No new third-party action:** assets upload via the built-in `gh` CLI. `harden-runner`, `checkout`, and `upload-artifact` are pinned to full commit SHAs; `upload-artifact` SHA resolved from its `v7.0.1` tag.
- **Least privilege:** `contents: read` by default; `contents: write` only on the packaging job.

## Verified locally

- `release.yml` is valid YAML.
- The exact CPack invocation was reproduced against the `core-only` build tree: `-D CPACK_PACKAGE_VERSION` alone left the archive named `0.0.1`; adding `-D CPACK_PACKAGE_FILE_NAME` correctly produced `clearCore-0.0.2-Linux-x86_64.tar.gz`.

## Scope / follow-ups

- **TGZ only** for now (assumes Qt6 present). DEB/RPM need `dpkg-shlibdeps`/`rpmbuild` to resolve the bundled QADS shared lib, and a self-contained **AppImage** is the planned next step — both layer on the same install rules.
- Best merged after #41 (the install/CPack rules it depends on).

## Type of change

- [x] Build / CI / tooling

## Checklist

- [x] Branch is based on and targets `develop`
- [x] YAML validated; CPack invocation verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)