### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,8 +36,8 @@ keywords:
   - qt6
   - terminal-ui
 license: MIT
-version: 0.0.1
-date-released: '2026-07-02'
+version: 0.0.2
+date-released: '2026-07-04'
 # After enabling the GitHub–Zenodo integration and publishing a
 # release, add the minted DOI here so the "Cite this repository"
 # export includes it, e.g.:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 project(clearCore
-        VERSION 0.0.1
+        VERSION 0.0.2
         LANGUAGES CXX C  # C may be needed by some dependencies
         DESCRIPTION "Educational MIPS CPU emulator with pipeline visualization"
 )

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -44,7 +44,7 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 ## At a glance
 
 ```
-C++20 · CMake 3.20+ · MIT license · v0.0.1
+C++20 · CMake 3.20+ · MIT license · v0.0.2
 FTXUI v7.0.0 · GSL · spdlog (all auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM 15–20 (optional) · KSyntaxHighlighting (optional)
 Six core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
 ```


### PR DESCRIPTION
## Summary

Prepares the **0.0.2** release by bumping the version everywhere it's declared:

- **`CMakeLists.txt`** — `project(VERSION 0.0.1 → 0.0.2)`, so CPack packages and the release/AppImage artifacts carry the correct internal version (the workflows already derive the *filename* from the git tag; this fixes the version *inside* the package and binary).
- **`CITATION.cff`** — `version: 0.0.2`, `date-released: 2026-07-04`. Adjust the date if you publish on a different day.
- **`wiki/Home.md`** — the `v0.0.1` badge line → `v0.0.2`.

## Deliberately not changed

- **`CHANGELOG.md`** — your `update-changelog.yml` promotes `[Unreleased]` to a versioned entry when the release is published, so editing it here would conflict with that automation.

## After this merges

1. Merge `develop` → `main` (separate PR).
2. Enable the GitHub–Zenodo integration.
3. Publish the `v0.0.2` release → fires `release.yml` (.tar.gz), `appimage.yml` (AppImage), `update-changelog.yml`, and the Zenodo archive.
4. Paste the minted DOI into `CITATION.cff`.

## Type of change

- [x] Build / CI / tooling

## Checklist

- [x] Branch created from and targets `develop`
- [x] CMake reports `0.0.2`; `CITATION.cff` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)