### PR TITLE
chore: bump version to 0.1.0 (SemVer correction)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,7 @@ keywords:
   - qt6
   - terminal-ui
 license: MIT
-version: 0.0.2
+version: 0.1.0
 date-released: '2026-07-04'
 # After enabling the GitHub–Zenodo integration and publishing a
 # release, add the minted DOI here so the "Cite this repository"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 project(clearCore
-        VERSION 0.0.2
+        VERSION 0.1.0
         LANGUAGES CXX C  # C may be needed by some dependencies
         DESCRIPTION "Educational MIPS CPU emulator with pipeline visualization"
 )

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -44,7 +44,7 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 ## At a glance
 
 ```
-C++20 · CMake 3.20+ · MIT license · v0.0.2
+C++20 · CMake 3.20+ · MIT license · v0.1.0
 FTXUI v7.0.0 · GSL · spdlog (all auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM 15–20 (optional) · KSyntaxHighlighting (optional)
 Six core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
 ```


### PR DESCRIPTION
## Summary

Corrects the release version to **0.1.0** per Semantic Versioning. This cycle adds new functionality (CPack packaging, release automation, AppImage, citation metadata) with **no bug fixes** — a backward-compatible feature release is a **MINOR** bump, so `0.0.1 → 0.1.0`, not a `0.0.2` PATCH. Supersedes the earlier `0.0.2` bump (#44).

Updates `project(VERSION)`, `CITATION.cff`, and the wiki version string.

## Type of change

- [x] Build / CI / tooling

## Checklist

- [x] Branch created from and targets `develop`
- [x] CMake reports `0.1.0`; `CITATION.cff` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)