### PR TITLE
release: v0.1.0 — packaging, downloadable binaries, and citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,7 @@ keywords:
   - qt6
   - terminal-ui
 license: MIT
-version: 0.0.2
+version: 0.1.0
 date-released: '2026-07-04'
 # After enabling the GitHub–Zenodo integration and publishing a
 # release, add the minted DOI here so the "Cite this repository"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 project(clearCore
-        VERSION 0.0.2
+        VERSION 0.1.0
         LANGUAGES CXX C  # C may be needed by some dependencies
         DESCRIPTION "Educational MIPS CPU emulator with pipeline visualization"
 )

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -44,7 +44,7 @@ The project ships two primary interfaces over identical core logic: a lightweigh
 ## At a glance
 
 ```
-C++20 · CMake 3.20+ · MIT license · v0.0.2
+C++20 · CMake 3.20+ · MIT license · v0.1.0
 FTXUI v7.0.0 · GSL · spdlog (all auto-fetched) · Qt6 (Widgets + Quick, both optional) · Nyxstone/LLVM 15–20 (optional) · KSyntaxHighlighting (optional)
 Six core CTest suites + a Qt smoke-test suite + MARS differential tests + ClusterFuzzLite libFuzzer harness
 ```


### PR DESCRIPTION
## Release: v0.1.0

Promotes `develop` to `main` for the **0.1.0** release (SemVer-corrected from the earlier 0.0.2 — this is a backward-compatible feature release, so a MINOR bump).

### Highlights
- Self-contained **AppImage** + CPack packaging + release automation (download-and-run, no toolchain).
- **`CITATION.cff`** (Cite button), JOSS paper draft, 100% community health.
- Version set to `0.1.0` across build, citation, and wiki.

Publishing the `v0.1.0` release after this merge fires the release/AppImage/changelog workflows and mints the Zenodo DOI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)