### PR TITLE
fix(ci): repair changelog workflow and promote CHANGELOG to 0.1.0

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: step-security/harden-runner@ec9f2d5744a09e4fc2bb41ae8fb3f8a3c5f2e5e3 # v2.13.0
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
@@ -35,50 +35,27 @@ jobs:
           import os, re
 
           tag_raw = os.environ["RELEASE_TAG"]
-          tag     = tag_raw[1:] if tag_raw.startswith("v") else tag_raw
-          date    = os.environ["RELEASE_DATE"][:10]   # YYYY-MM-DD
+          tag     = tag_raw[1:] if tag_raw.startswith("v") else tag_raw  # v0.1.0 -> 0.1.0
+          date    = os.environ["RELEASE_DATE"][:10]                     # YYYY-MM-DD
 
-          with open("CHANGELOG.md", "r") as f:
+          with open("CHANGELOG.md") as f:
               content = f.read()
 
-          # Insert a fresh empty [Unreleased] section, then the released version heading.
-          # The existing Unreleased contents remain in-place and therefore become the body
-          # of the released entry.
+          # Rename the current [Unreleased] heading to the released version and add a
+          # fresh, empty [Unreleased] above it. The existing Unreleased content stays
+          # in place and becomes the body of the released entry.
           new_section = (
               "## [Unreleased]\n\n"
               "---\n\n"
-              f"## [{tag}] - {date}\n\n"
+              f"## [{tag}] - {date}"
           )
-          python3 - <<'EOF'
-          import os, re, textwrap
-
-          tag   = os.environ["RELEASE_TAG"]
-          date  = os.environ["RELEASE_DATE"][:10]   # YYYY-MM-DD
-          body  = os.environ["RELEASE_BODY"].strip()
-
-          with open("CHANGELOG.md", "r") as f:
-              content = f.read()
-
-          # Replace the [Unreleased] heading with the new versioned heading.
-          # Also insert a blank [Unreleased] section above it for the next cycle.
-          new_section = (
-              "## [Unreleased]\n\n"
-              "---\n\n"
-              f"## [{tag}] - {date}\n\n"
-              f"{body}\n"
-          )
-
-          updated = re.sub(
-              r"## \[Unreleased\]",
-              new_section,
-              content,
-              count=1,
-          )
+          updated, n = re.subn(r"## \[Unreleased\]", new_section, content, count=1)
+          if n == 0:
+              raise SystemExit("error: no '## [Unreleased]' section found in CHANGELOG.md")
 
           with open("CHANGELOG.md", "w") as f:
               f.write(updated)
-
-          print(f"CHANGELOG.md promoted [Unreleased] → [{tag}] - {date}")
+          print(f"Promoted [Unreleased] -> [{tag}] - {date}")
           EOF
 
       - name: Commit and push to develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,47 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### CI / Internal
+- Fixed `update-changelog.yml`: corrected the `harden-runner` commit SHA (previously unresolvable, which failed the
+  job at startup) and rewrote the malformed promote step so the CHANGELOG auto-promotes on each published release.
+
+---
+
+## [0.1.0] - 2026-07-04
+
+First feature release since v0.0.1 — clearCore becomes citable and downloadable. Adds packaging (CPack,
+`.deb`/`.rpm`), a self-contained AppImage of the Qt6 GUI, release automation, and full citation/community metadata.
+
 ### Added
+- Self-contained **AppImage** of the Qt6 Widgets GUI — bundles Qt6 and the Qt Advanced Docking System so it runs
+  with no toolchain or Qt install; built and Xvfb-smoke-tested via `.github/workflows/appimage.yml`. (#43)
+- Release workflow (`.github/workflows/release.yml`): on a published release, builds, tests, and attaches a
+  `clearCore-<version>-Linux-x86_64.tar.gz`. (#42)
+- `install()` rules and CPack packaging (`.tar.gz`/`.deb`/`.rpm`) with a clean install tree that excludes
+  dependency headers and CMake files. (#41)
+- `CITATION.cff` enabling GitHub's "Cite this repository" button, with a slot for a Zenodo DOI. (#39)
+- JOSS paper draft under `paper/`. (#40)
+- `CODE_OF_CONDUCT.md`, a root `CONTRIBUTING.md`, and a pull-request template — community health to 100%. (#39)
+- Issue templates (bug report / feature request / custom) and a Sponsor button (`FUNDING.yml`). (#35, #36, #38)
 - ClusterFuzzLite libFuzzer harness (`tests/fuzz/fuzz_hex_loader.cpp`) targeting `mips::parse_hex_program`;
   runs 120 s on every PR via `.github/workflows/cflite_pr.yml`. Addresses OpenSSF Scorecard fuzzing signal.
-  `fuzz_hex_loader` CMake target is gated on `-DFUZZING_ENGINE=<engine>` — normal builds are unaffected.
-  ClusterFuzzLite config lives in `.clusterfuzzlite/` (project.yaml, Dockerfile, build.sh). (#8, #9)
+  `fuzz_hex_loader` CMake target is gated on `-DFUZZING_ENGINE=<engine>` — normal builds are unaffected. (#8, #9)
+
+### Changed
+- Version set to `0.1.0` across `CMakeLists.txt`, `CITATION.cff`, and the wiki. (#47)
 
 ### Fixed
 - Qt GUI: set each dock widget's `objectName` to its title for improved panel identification and debugging. (#7)
 
 ### Documentation
-- Full README and wiki pass covering all changes introduced in PRs #2–#9: KSyntaxHighlighting, ClusterFuzzLite,
-  security hardening, v0.0.1 release, and CI workflow table. Added release badge, CHANGELOG, and
-  release-drafter automation.
+- Restructured the README for new-developer readability. (#25)
+- Documented the Qt Quick/QML GUI and Nyxstone; corrected the test-suite count. (#21)
+- Full README and wiki pass covering PRs #2–#9 (KSyntaxHighlighting, ClusterFuzzLite, security hardening, the
+  v0.0.1 release, and the CI workflow table); added the release badge and release-drafter automation.
+
+### CI / Internal
+- Reduced PR job count with path filters and conditional jobs. (#23)
+- Tightened the changelog workflow's top-level token permissions to `read-all`. (#27)
 
 ---
 


### PR DESCRIPTION
## Summary

The `Update CHANGELOG on release` workflow **failed** on the v0.1.0 release. This fixes it and back-fills the CHANGELOG entry the broken workflow couldn't produce.

### Two bugs in `update-changelog.yml` (both pre-existing)
1. **Unresolvable action SHA** — `harden-runner` was pinned to `ec9f2d57…`, which doesn't exist, so the job failed at "Set up job" before running anything. Corrected to `9af89fc7…` (v2.19.4), the SHA used across the other workflows.
2. **Malformed promote step** — it contained *two* nested `python3 <<'EOF'` heredocs; the second referenced an unset `RELEASE_BODY` and didn't strip the leading `v` from the tag (would have produced `## [v0.1.0]`). Replaced with a single script that renames `[Unreleased]` → the released version and inserts a fresh `[Unreleased]`.

### CHANGELOG
- Manually promoted `[Unreleased]` → **`[0.1.0]`** (2026-07-04) with a complete entry: packaging/CPack, AppImage, release automation, citation & community, docs, and CI/internal.
- Fresh `[Unreleased]` records this workflow fix.

## How was this verified?

- Workflow YAML validates.
- The rewritten promote script was **dry-run on a copy** of `CHANGELOG.md` with `RELEASE_TAG=v0.2.0`: it correctly produced `## [0.2.0] - …` under a new empty `## [Unreleased]`, preserving existing content as the released body.

## Type of change

- [x] Build / CI / tooling

## Checklist

- [x] Branch created from and targets `develop`
- [x] Workflow YAML validated; promote logic dry-run tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)