### PR TITLE
docs: use social preview banner as README header image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/cpu-logo.png" alt="clearCore" width="2048"/>
+  <img src="assets/clearcore_social_preview.png" alt="clearCore" width="100%"/>
 </p>
 
 <h1 align="center">clearCore</h1>

--- a/assets/clearcore_social_preview.png
+++ b/assets/clearcore_social_preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4fb253eb54650c5e3fe6fbf0e328cc7a413fd6ad1e503a9c2e521e1408aa805
+size 59698


### PR DESCRIPTION
## Summary

Swaps the README header image from the square `cpu-logo.png` to the new **1280×640 social-preview banner** (`assets/clearcore_social_preview.png`), and drops the oversized `width="2048"` in favor of responsive full-width.

`cpu-logo.png` is retained in `assets/` (still usable elsewhere).

## Type of change

- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)