### PR TITLE
chore: remove unused cpu-logo.png

### DIFF
--- a/assets/cpu-logo.png
+++ b/assets/cpu-logo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:832f356c5eb499c03950ddf3c4abe5961acf099b70194926daa8353df0e74a84
-size 3926058


### PR DESCRIPTION
## Summary

Removes `assets/cpu-logo.png`. The README header now uses `assets/clearcore_social_preview.png`, and a repo-wide `git grep` confirms no tracked file references `cpu-logo.png`.

## Type of change

- [x] Documentation / housekeeping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Delete the obsolete assets/cpu-logo.png file as part of repository housekeeping.