### PR TITLE
chore: sync cpu-logo.png removal to main

### DIFF
--- a/assets/cpu-logo.png
+++ b/assets/cpu-logo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:832f356c5eb499c03950ddf3c4abe5961acf099b70194926daa8353df0e74a84
-size 3926058


### PR DESCRIPTION
## Summary

Syncs the removal of the unused `assets/cpu-logo.png` (#55) to `main`.

Housekeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Delete unused assets/cpu-logo.png file as part of housekeeping.