### PR TITLE
refactor(isa): introduce ISA-agnostic core (RISC-V groundwork)

### DIFF
--- a/include/isa/memory.h
+++ b/include/isa/memory.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstdint>
+#include <gsl/gsl>
+#include <optional>
+#include <vector>
+
+// ─── isa/memory.h ────────────────────────────────────────────────────────────
+// ISA-agnostic flat memory. Shared by every processor backend (MIPS today,
+// RISC-V next). Nothing here is MIPS-specific: byte-addressable little-endian
+// RAM is common to both ISAs clearCore models. Backends re-export this type
+// into their own namespace via a `using` shim (see mips/memory.h).
+
+namespace isa {
+
+// ─── Memory ───────────────────────────────────────────────────────────────────
+// Flat, byte-addressable RAM with word/half/byte access helpers.
+//
+// Endianness: little-endian. The emulator stores the least-significant byte at
+// the lowest address, which keeps the host (x86/ARM) and emulated views
+// identical and simplifies hex-dump debugging in the memory panel.
+//
+// All accesses are bounds-checked and return std::optional (reads) or a success
+// bool (writes) rather than trapping, matching the project's "optional for
+// fallible operations" convention. Word and half accesses must be naturally
+// aligned (4- and 2-byte respectively); a misaligned access fails like an OOB
+// one, modelling an address-error exception without the exception machinery.
+class Memory {
+public:
+    explicit Memory(std::size_t size_bytes);
+
+    [[nodiscard]] std::size_t size() const noexcept { return data_.size(); }
+
+    // Reads — std::nullopt on out-of-bounds or misalignment.
+    [[nodiscard]] std::optional<uint32_t> read_word(uint32_t addr) const noexcept;
+    [[nodiscard]] std::optional<uint16_t> read_half(uint32_t addr) const noexcept;
+    [[nodiscard]] std::optional<uint8_t>  read_byte(uint32_t addr) const noexcept;
+
+    // Writes — false on out-of-bounds or misalignment; memory left unchanged.
+    bool write_word(uint32_t addr, uint32_t value) noexcept;
+    bool write_half(uint32_t addr, uint16_t value) noexcept;
+    bool write_byte(uint32_t addr, uint8_t value) noexcept;
+
+    // Bulk-load a blob of 32-bit words starting at `addr` (e.g. a program
+    // image). Returns false if it would not fit. Stored little-endian.
+    bool load_words(uint32_t addr, const std::vector<uint32_t>& words) noexcept;
+
+    // Zero the entire address space.
+    void reset() noexcept;
+
+    // Read-only span view of the raw memory buffer
+    [[nodiscard]] gsl::span<const std::uint8_t> raw() const noexcept { return {(data_)}; }
+
+private:
+    [[nodiscard]] bool in_bounds(uint32_t addr, std::size_t n) const noexcept;
+
+    std::vector<uint8_t> data_;
+};
+
+}  // namespace isa

--- a/include/isa/processor.h
+++ b/include/isa/processor.h
@@ -1,0 +1,119 @@
+#pragma once
+
+// ─── isa/processor.h ─────────────────────────────────────────────────────────
+// Abstract, ISA-agnostic processor interface, modelled on the pluggable-backend
+// pattern used by Ripes (Petersen, 2021) and DrMIPS (Nova et al., 2013).
+//
+// Everything here is common to every ISA clearCore models (MIPS today, RISC-V
+// next): a program image of 32-bit words, single-cycle stepping, a 32×32
+// register file, flat memory, and a five-stage pipeline snapshot for the
+// visualisers. ISA-specific state (MIPS coprocessor 0 / HI / LO, RISC-V CSRs)
+// lives in per-backend sub-interfaces, not here.
+//
+//   1. Observable pipeline state is part of the interface (DrMIPS exposes the
+//      datapath graphically; WebRISC-V exposes cycle-by-cycle stage contents).
+//   2. step() advances exactly one clock cycle, regardless of implementation.
+//   3. run() is a default loop over step() so callers never need to change it.
+//   4. Forwarding and stall flags are first-class so the TUI can draw bypass
+//      wires and bubble indicators (Arches, Haydel et al. 2025).
+
+#include "isa/memory.h"
+#include "isa/registers.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace isa {
+
+// ─── StepResult ───────────────────────────────────────────────────────────────
+enum class StepResult : uint8_t {
+    Ok,         // instruction executed; PC advanced normally
+    Exception,  // an ISA trap was raised; the backend updated its trap state and
+                // redirected the PC to its exception/trap vector
+    Fault,      // unrecoverable internal error (should not occur in correct programs)
+    Halt,       // self-targeting jump retired (spin-in-place idiom)
+};
+
+// ─── Pipeline visualisation state ─────────────────────────────────────────────
+// Filled by every implementation; single-cycle backends leave all but EX empty.
+// Directly models the per-stage colour coding in Ripes and WebRISC-V, and the
+// forwarding-wire annotations from Arches (Haydel et al., 2025).
+
+struct StageSnapshot {
+    const char* name    = "";     // "IF", "ID", "EX", "MEM", "WB"
+    bool        valid   = false;  // real instruction present
+    bool        stalled = false;  // bubble from a load-use stall
+    bool        flushed = false;  // bubble from a branch/jump flush
+    uint32_t    pc      = 0;      // PC of the instruction in this stage
+    uint32_t    raw     = 0;      // raw 32-bit word (for mnemonic display)
+};
+
+struct PipelineState {
+    // Index 0 = IF, 1 = ID, 2 = EX, 3 = MEM, 4 = WB
+    std::array<StageSnapshot, 5> stages{};
+
+    // Forwarding indicators (bypass-wire visualisation)
+    bool fwd_ex_to_ex_a  = false;  // EX/MEM → EX input A
+    bool fwd_ex_to_ex_b  = false;
+    bool fwd_mem_to_ex_a = false;  // MEM/WB → EX input A
+    bool fwd_mem_to_ex_b = false;
+
+    // Hazard indicators
+    bool load_stall   = false;
+    bool branch_flush = false;
+
+    std::size_t cycle = 0;
+};
+
+// ─── IProcessor ───────────────────────────────────────────────────────────────
+// The ISA-agnostic contract. The TUI, Qt bridge, and generic tests talk only to
+// this. Backends that expose extra architectural state (MIPS CP0/HI/LO) derive a
+// sub-interface — see mips::IMipsProcessor.
+class IProcessor {
+public:
+    virtual ~IProcessor() = default;
+
+    // Load a flat array of 32-bit instruction words at `addr`, reset the PC.
+    [[nodiscard]] virtual bool load_program(const std::vector<uint32_t>& words,
+                                            uint32_t                     addr = 0) = 0;
+
+    // Advance exactly one clock cycle (or one instruction for single-cycle).
+    [[nodiscard]] virtual StepResult step() = 0;
+
+    // Step until Fault/Halt or the step budget is exhausted.
+    // Default implementation simply loops over step(); concrete classes may
+    // override for performance, but the semantics must be identical.
+    virtual StepResult run(std::size_t max_steps = 100'000) {
+        for (std::size_t i = 0; i < max_steps; ++i) {
+            const StepResult r = step();
+            if (r != StepResult::Ok) return r;
+        }
+        return StepResult::Ok;
+    }
+
+    // Reset registers, PC, and pipeline snapshot.
+    // Pass clear_memory=true to also wipe the address space.
+    virtual void reset(bool clear_memory = false) = 0;
+
+    // ── Accessors ──────────────────────────────────────────────────────────────
+
+    [[nodiscard]] virtual uint32_t pc() const noexcept            = 0;
+    virtual void                   set_pc(uint32_t addr) noexcept = 0;
+
+    [[nodiscard]] virtual const RegisterFile& regs() const noexcept = 0;
+    [[nodiscard]] virtual RegisterFile&       regs() noexcept       = 0;
+
+    [[nodiscard]] virtual const Memory& mem() const noexcept = 0;
+    [[nodiscard]] virtual Memory&       mem() noexcept       = 0;
+
+    // Number of clock cycles elapsed since the last reset().
+    [[nodiscard]] virtual std::size_t cycle_count() const noexcept = 0;
+
+    // Snapshot of all five pipeline stages from the most recent step().
+    // Single-cycle backends only populate stages[2] (EX); pipelined ones fill all five.
+    [[nodiscard]] virtual const PipelineState& pipeline_state() const noexcept = 0;
+};
+
+}  // namespace isa

--- a/include/isa/registers.h
+++ b/include/isa/registers.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+// ─── isa/registers.h ─────────────────────────────────────────────────────────
+// ISA-agnostic general-purpose register file. Both MIPS and RV32I have exactly
+// 32 GPRs with register 0 hardwired to zero, so this type is shared verbatim.
+// ABI mnemonic tables (which differ per ISA) live with each backend, not here.
+
+namespace isa {
+
+// ─── Register file ────────────────────────────────────────────────────────────
+// 32 general-purpose registers, each 32 bits wide.
+//
+// Register 0 is hardwired to 0: reads always return 0 and writes are silently
+// discarded. This mirrors the hardware and lets the ISA use it as both a
+// constant-0 source and a discard sink.
+class RegisterFile {
+public:
+    static constexpr std::size_t kCount = 32;
+
+    // Read register `idx`. Index 0 always reads as 0.
+    [[nodiscard]] uint32_t read(uint8_t idx) const noexcept;
+
+    // Write `value` to register `idx`. Writes to index 0 are ignored.
+    void write(uint8_t idx, uint32_t value) noexcept;
+
+    // Index of the most recently written register, or -1 if none since reset.
+    // Exists for the TUI, which highlights the last-changed register.
+    [[nodiscard]] int last_written() const noexcept { return last_written_; }
+
+    // Restore all registers to 0 and clear the last-written marker.
+    void reset() noexcept;
+
+    // Const view for the TUI register panel / test inspection.
+    [[nodiscard]] const std::array<uint32_t, kCount>& raw() const noexcept { return regs_; }
+
+private:
+    std::array<uint32_t, kCount> regs_{};
+    int                          last_written_ = -1;
+};
+
+}  // namespace isa

--- a/include/mips/gdb_stub.h
+++ b/include/mips/gdb_stub.h
@@ -50,7 +50,7 @@ class GdbStub {
 public:
     // Construct a stub attached to `cpu`, listening on TCP `port`.
     // The stub does NOT take ownership of the processor.
-    explicit GdbStub(IProcessor& cpu, uint16_t port = 1234);
+    explicit GdbStub(IMipsProcessor& cpu, uint16_t port = 1234);
     ~GdbStub();
 
     GdbStub(const GdbStub&)            = delete;
@@ -109,10 +109,10 @@ private:
     // Signal number to send for a given StepResult / exception code.
     int stop_signal() const;
 
-    IProcessor& cpu_;
-    uint16_t    port_;
-    int         server_fd_ = -1;
-    int         client_fd_ = -1;
+    IMipsProcessor& cpu_;
+    uint16_t        port_;
+    int             server_fd_ = -1;
+    int             client_fd_ = -1;
 
     std::vector<Breakpoint> breakpoints_;
     bool                    running_     = false;  // true while inside handle_continue

--- a/include/mips/memory.h
+++ b/include/mips/memory.h
@@ -1,55 +1,12 @@
 #pragma once
 
-#include <cstdint>
-#include <gsl/gsl>
-#include <optional>
-#include <vector>
+// ─── mips/memory.h ───────────────────────────────────────────────────────────
+// Memory is ISA-agnostic and now lives in <isa/memory.h>. This header re-exports
+// it into the `mips` namespace so existing callers (`mips::Memory`) keep working
+// unchanged. New backends should include <isa/memory.h> and use `isa::Memory`.
+
+#include "isa/memory.h"
 
 namespace mips {
-
-// ─── Memory ───────────────────────────────────────────────────────────────────
-// Flat, byte-addressable RAM with word/half/byte access helpers.
-//
-// Endianness: little-endian. MIPS hardware can be configured either way; this
-// emulator stores the least-significant byte at the lowest address, which keeps
-// the host (x86/ARM) and emulated views identical and simplifies hex-dump
-// debugging in the Stage 2 memory panel.
-//
-// All accesses are bounds-checked and return std::optional (reads) or a success
-// bool (writes) rather than trapping, matching the project's "optional for
-// fallible operations" convention. Word and half accesses must be naturally
-// aligned (4- and 2-byte respectively); a misaligned access fails like an OOB
-// one, modelling a MIPS address-error exception without the exception machinery.
-class Memory {
-public:
-    explicit Memory(std::size_t size_bytes);
-
-    [[nodiscard]] std::size_t size() const noexcept { return data_.size(); }
-
-    // Reads — std::nullopt on out-of-bounds or misalignment.
-    [[nodiscard]] std::optional<uint32_t> read_word(uint32_t addr) const noexcept;
-    [[nodiscard]] std::optional<uint16_t> read_half(uint32_t addr) const noexcept;
-    [[nodiscard]] std::optional<uint8_t>  read_byte(uint32_t addr) const noexcept;
-
-    // Writes — false on out-of-bounds or misalignment; memory left unchanged.
-    bool write_word(uint32_t addr, uint32_t value) noexcept;
-    bool write_half(uint32_t addr, uint16_t value) noexcept;
-    bool write_byte(uint32_t addr, uint8_t value) noexcept;
-
-    // Bulk-load a blob of 32-bit words starting at `addr` (e.g. a program
-    // image). Returns false if it would not fit. Stored little-endian.
-    bool load_words(uint32_t addr, const std::vector<uint32_t>& words) noexcept;
-
-    // Zero the entire address space.
-    void reset() noexcept;
-
-    // Read-only span view of the raw memory buffer
-    [[nodiscard]] gsl::span<const std::uint8_t> raw() const noexcept { return {(data_)}; }
-
-private:
-    [[nodiscard]] bool in_bounds(uint32_t addr, std::size_t n) const noexcept;
-
-    std::vector<uint8_t> data_;
-};
-
+using isa::Memory;
 }  // namespace mips

--- a/include/mips/pipelined_cpu.h
+++ b/include/mips/pipelined_cpu.h
@@ -28,7 +28,7 @@
 
 namespace mips {
 
-class PipelinedCpu final : public IProcessor {
+class PipelinedCpu final : public IMipsProcessor {
 public:
     explicit PipelinedCpu(std::size_t mem_bytes = 1u << 16);
 

--- a/include/mips/processor.h
+++ b/include/mips/processor.h
@@ -1,34 +1,38 @@
 #pragma once
 
-// ─── processor.h ─────────────────────────────────────────────────────────────
-// Abstract processor interface, modelled on the pluggable-backend pattern used
-// by Ripes (Petersen, 2021) and DrMIPS (Nova et al., 2013).
+// ─── mips/processor.h ────────────────────────────────────────────────────────
+// The ISA-agnostic interface now lives in <isa/processor.h>. This header:
+//   • re-exports isa::IProcessor / StepResult / PipelineState / StageSnapshot
+//     into the `mips` namespace so existing callers compile unchanged, and
+//   • adds MIPS-specific control derivation and the `IMipsProcessor`
+//     sub-interface that exposes coprocessor 0 and the HI/LO registers.
 //
-// The TUI visualiser (Stage 2) and tests talk exclusively to IProcessor.
-// Concrete implementations — SingleCycleCpu and PipelinedCpu — slot in without
-// touching caller code.  The key design constraints that flow from the papers:
-//
-//   1. Observable pipeline state is part of the interface (DrMIPS exposes the
-//      datapath graphically; WebRISC-V exposes cycle-by-cycle stage contents).
-//   2. step() advances exactly one clock cycle, regardless of implementation.
-//   3. run() is a default loop over step() so callers never need to change it.
-//   4. Forwarding and stall flags are first-class so the Stage 5 TUI can draw
-//      bypass wires and bubble indicators (Arches, Haydel et al. 2025).
+// A concrete MIPS core derives from IMipsProcessor; a future RISC-V core derives
+// straight from isa::IProcessor (plus its own CSR sub-interface).
 
+#include "isa/processor.h"
 #include "mips/cp0.h"
 #include "mips/decoder.h"
 #include "mips/memory.h"
 #include "mips/registers.h"
 
-#include <cstddef>
 #include <cstdint>
-#include <vector>
 
 namespace mips {
 
+// Re-export the ISA-agnostic vocabulary so `mips::IProcessor`, `mips::StepResult`,
+// `mips::PipelineState`, and `mips::StageSnapshot` keep resolving for callers that
+// only need the generic contract (TUI render helpers, the Qt bridge, tests).
+using isa::IProcessor;
+using isa::PipelineState;
+using isa::StageSnapshot;
+using isa::StepResult;
+
 // ─── Control word ─────────────────────────────────────────────────────────────
-// Derived purely from opcode+funct (H&H Figure 7.11). Both implementations
-// produce one of these per instruction; the TUI can render it per cycle.
+// Derived purely from opcode+funct (H&H Figure 7.11). Both MIPS implementations
+// produce one of these per instruction; the TUI can render it per cycle. This is
+// MIPS-specific (note reg_dst, the R-vs-I destination select MIPS needs and
+// RISC-V does not), so it stays in the `mips` namespace.
 struct Control {
     bool reg_write                              = false;
     bool mem_read                               = false;
@@ -46,92 +50,14 @@ struct Control {
 // it without duplicating the switch table.
 [[nodiscard]] Control derive_control(const DecodedInstr& instr);
 
-// ─── StepResult ───────────────────────────────────────────────────────────────
-enum class StepResult : uint8_t {
-    Ok,         // instruction executed; PC advanced normally
-    Exception,  // CP0 exception raised; EPC/Cause/Status updated; PC = kExceptionVector
-    Fault,      // unrecoverable internal error (should not occur in correct programs)
-    Halt,       // self-targeting jump retired from WB (spin-in-place idiom)
-};
-
-// ─── Pipeline visualisation state ─────────────────────────────────────────────
-// Filled by every implementation; SingleCycleCpu leaves all but EX empty.
-// Directly models the per-stage colour coding in Ripes and WebRISC-V, and the
-// forwarding-wire annotations from Arches (Haydel et al., 2025).
-
-struct StageSnapshot {
-    const char* name    = "";     // "IF", "ID", "EX", "MEM", "WB"
-    bool        valid   = false;  // real instruction present
-    bool        stalled = false;  // bubble from a load-use stall
-    bool        flushed = false;  // bubble from a branch/jump flush
-    uint32_t    pc      = 0;      // PC of the instruction in this stage
-    uint32_t    raw     = 0;      // raw 32-bit word (for mnemonic display)
-};
-
-struct PipelineState {
-    // Index 0 = IF, 1 = ID, 2 = EX, 3 = MEM, 4 = WB
-    std::array<StageSnapshot, 5> stages{};
-
-    // Forwarding indicators (Stage 5 bypass-wire visualisation)
-    bool fwd_ex_to_ex_a  = false;  // EX/MEM → EX input A
-    bool fwd_ex_to_ex_b  = false;
-    bool fwd_mem_to_ex_a = false;  // MEM/WB → EX input A
-    bool fwd_mem_to_ex_b = false;
-
-    // Hazard indicators
-    bool load_stall   = false;
-    bool branch_flush = false;
-
-    std::size_t cycle = 0;
-};
-
-// ─── IProcessor ───────────────────────────────────────────────────────────────
-class IProcessor {
+// ─── IMipsProcessor ───────────────────────────────────────────────────────────
+// The MIPS contract: the ISA-agnostic IProcessor plus the MIPS-only
+// architectural state — coprocessor 0 (Status/Cause/EPC/BadVAddr) and the HI/LO
+// multiply/divide registers, together with the last committed control word.
+class IMipsProcessor : public isa::IProcessor {
 public:
-    virtual ~IProcessor() = default;
-
-    // Load a flat array of 32-bit instruction words at `addr`, reset the PC.
-    [[nodiscard]] virtual bool load_program(const std::vector<uint32_t>& words,
-                                            uint32_t                     addr = 0) = 0;
-
-    // Advance exactly one clock cycle (or one instruction for single-cycle).
-    [[nodiscard]] virtual StepResult step() = 0;
-
-    // Step until Fault/Halt or the step budget is exhausted.
-    // Default implementation simply loops over step(); concrete classes may
-    // override for performance, but the semantics must be identical.
-    virtual StepResult run(std::size_t max_steps = 100'000) {
-        for (std::size_t i = 0; i < max_steps; ++i) {
-            const StepResult r = step();
-            if (r != StepResult::Ok) return r;
-        }
-        return StepResult::Ok;
-    }
-
-    // Reset registers, PC, and control snapshot.
-    // Pass clear_memory=true to also wipe the address space.
-    virtual void reset(bool clear_memory = false) = 0;
-
-    // ── Accessors ──────────────────────────────────────────────────────────────
-
-    [[nodiscard]] virtual uint32_t pc() const noexcept            = 0;
-    virtual void                   set_pc(uint32_t addr) noexcept = 0;
-
-    [[nodiscard]] virtual const RegisterFile& regs() const noexcept = 0;
-    [[nodiscard]] virtual RegisterFile&       regs() noexcept       = 0;
-
-    [[nodiscard]] virtual const Memory& mem() const noexcept = 0;
-    [[nodiscard]] virtual Memory&       mem() noexcept       = 0;
-
     // Control word of the last instruction that committed in WB.
     [[nodiscard]] virtual const Control& last_control() const noexcept = 0;
-
-    // Number of clock cycles elapsed since the last reset().
-    [[nodiscard]] virtual std::size_t cycle_count() const noexcept = 0;
-
-    // Snapshot of all five pipeline stages from the most recent step().
-    // SingleCycleCpu only populates stages[2] (EX); PipelinedCpu fills all five.
-    [[nodiscard]] virtual const PipelineState& pipeline_state() const noexcept = 0;
 
     // ── Coprocessor 0 ─────────────────────────────────────────────────────────
     // Access to Status, Cause, EPC, BadVAddr, and the last exception code.

--- a/include/mips/registers.h
+++ b/include/mips/registers.h
@@ -1,46 +1,21 @@
 #pragma once
 
-#include <array>
-#include <cstdint>
+// ─── mips/registers.h ────────────────────────────────────────────────────────
+// The 32×32 register file is ISA-agnostic and now lives in <isa/registers.h>.
+// This header re-exports it as `mips::RegisterFile` for existing callers and
+// adds the MIPS O32 ABI mnemonic table, which is MIPS-specific and stays here.
+
+#include "isa/registers.h"
+
 #include <string_view>
 
 namespace mips {
-
-// ─── Register file ────────────────────────────────────────────────────────────
-// 32 general-purpose registers, each 32 bits wide (H&H §6.4).
-//
-// Register 0 ($zero) is hardwired to 0: reads always return 0 and writes are
-// silently discarded. This mirrors the hardware and lets the ISA use $zero as
-// both a constant-0 source and a discard sink (e.g. `SLL $zero,$zero,0` is NOP).
-class RegisterFile {
-public:
-    static constexpr std::size_t kCount = 32;
-
-    // Read register `idx`. Index 0 always reads as 0.
-    [[nodiscard]] uint32_t read(uint8_t idx) const noexcept;
-
-    // Write `value` to register `idx`. Writes to index 0 are ignored.
-    void write(uint8_t idx, uint32_t value) noexcept;
-
-    // Index of the most recently written register, or -1 if none since reset.
-    // Exists for the Stage 2 TUI, which highlights the last-changed register.
-    [[nodiscard]] int last_written() const noexcept { return last_written_; }
-
-    // Restore all registers to 0 and clear the last-written marker.
-    void reset() noexcept;
-
-    // Const view for the TUI register panel / test inspection.
-    [[nodiscard]] const std::array<uint32_t, kCount>& raw() const noexcept { return regs_; }
-
-private:
-    std::array<uint32_t, kCount> regs_{};
-    int                          last_written_ = -1;
-};
+using isa::RegisterFile;
 
 // ─── ABI register names ───────────────────────────────────────────────────────
 // MIPS O32 ABI mnemonic for register `idx` (0–31), e.g. 8 → "t0", 31 → "ra".
 // Returns "??" for an out-of-range index. Lives here so the disassembler and
-// the TUI share one source of truth.
+// the TUI share one source of truth. RISC-V provides its own table.
 [[nodiscard]] std::string_view register_abi_name(uint8_t idx) noexcept;
 
 }  // namespace mips

--- a/include/mips/single_cycle_cpu.h
+++ b/include/mips/single_cycle_cpu.h
@@ -5,7 +5,7 @@
 // fetch → decode → control → execute → memory → writeback chain before
 // returning.  This is the straightforward H&H Chapter 7 design.
 //
-// It implements IProcessor so the TUI and tests can treat it identically to
+// It implements IMipsProcessor so the TUI and tests can treat it identically to
 // PipelinedCpu.  The PipelineState it exposes only populates the EX snapshot
 // (the only stage that "exists" in a single-cycle design), matching the DrMIPS
 // "unicycle" display mode.
@@ -16,7 +16,7 @@
 
 namespace mips {
 
-class SingleCycleCpu final : public IProcessor {
+class SingleCycleCpu final : public IMipsProcessor {
 public:
     explicit SingleCycleCpu(std::size_t mem_bytes = 1u << 16);
 

--- a/src/mips/gdb_stub.cpp
+++ b/src/mips/gdb_stub.cpp
@@ -31,7 +31,7 @@ static constexpr int kSIGSYS  = 12;
 
 // ─── Constructor / destructor ─────────────────────────────────────────────────
 
-GdbStub::GdbStub(IProcessor& cpu, uint16_t port) : cpu_(cpu), port_(port) {}
+GdbStub::GdbStub(IMipsProcessor& cpu, uint16_t port) : cpu_(cpu), port_(port) {}
 
 GdbStub::~GdbStub() {
     if (client_fd_ >= 0) ::close(client_fd_);

--- a/src/mips/memory.cpp
+++ b/src/mips/memory.cpp
@@ -1,10 +1,10 @@
-#include "mips/memory.h"
+#include "isa/memory.h"
 
 #include <algorithm>
 #include <gsl/gsl>
 #include <vector>
 
-namespace mips {
+namespace isa {
 
 Memory::Memory(std::size_t size_bytes) : data_(size_bytes, 0u) {}
 
@@ -69,4 +69,4 @@ void Memory::reset() noexcept {
     std::ranges::fill(data_, uint8_t{0});
 }
 
-}  // namespace mips
+}  // namespace isa

--- a/src/mips/registers.cpp
+++ b/src/mips/registers.cpp
@@ -2,7 +2,7 @@
 
 #include <gsl/gsl>
 
-namespace mips {
+namespace isa {
 
 uint32_t RegisterFile::read(uint8_t idx) const noexcept {
     // $zero is hardwired to 0. Mask keeps a malformed index in range.
@@ -19,6 +19,10 @@ void RegisterFile::reset() noexcept {
     regs_.fill(0u);
     last_written_ = -1;
 }
+
+}  // namespace isa
+
+namespace mips {
 
 // ─── ABI register names ───────────────────────────────────────────────────────
 std::string_view register_abi_name(uint8_t idx) noexcept {

--- a/src/nsc/ui.cpp
+++ b/src/nsc/ui.cpp
@@ -956,9 +956,9 @@ int runApp() {
     int  global_mouse_y      = 0;
     bool global_mouse_active = false;
     // ── Core state ────────────────────────────────────────────────────────────
-    Converter                         converter;
-    CpuMode                           cpu_mode = CpuMode::SingleCycle;
-    std::unique_ptr<mips::IProcessor> cpu      = std::make_unique<mips::SingleCycleCpu>();
+    Converter                             converter;
+    CpuMode                               cpu_mode = CpuMode::SingleCycle;
+    std::unique_ptr<mips::IMipsProcessor> cpu      = std::make_unique<mips::SingleCycleCpu>();
 
     // Auto-run: background thread posts Event::Custom; step runs on UI thread
     std::atomic<bool> auto_run{false};


### PR DESCRIPTION
## Summary

Groundwork for adding a second ISA backend (RISC-V / RV32I) alongside MIPS, by extracting the ISA-agnostic pieces of the emulator into a new `isa/` core. **No behavior change** — pure refactor with `using`-shims so existing `mips::` callers are untouched.

Two commits, each independently green:

### Phase 1 — extract shared value types (`9cc1dd1`)
- `Memory` (byte-addressable little-endian RAM) and `RegisterFile` (32×32 GPRs, reg 0 hardwired to zero) move to `include/isa/{memory,registers}.h` under `namespace isa` — both are common to MIPS and RV32I.
- The MIPS O32 ABI mnemonic table (`register_abi_name`) is MIPS-specific and stays in `mips`.
- `mips/memory.h` and `mips/registers.h` keep `using isa::Memory` / `using isa::RegisterFile` shims.

### Phase 2 — split the processor interface (`10e3be4`)
- New `isa::IProcessor` (`include/isa/processor.h`) holds `StepResult`, `StageSnapshot`, `PipelineState` and the generic accessors (`load_program`, `step`, `run`, `reset`, `pc`, `regs`, `mem`, `cycle_count`, `pipeline_state`).
- `mips::IMipsProcessor : isa::IProcessor` adds the MIPS-only bits: `last_control()`, `cp0()`, `hi()/lo()`, `set_hi/lo()`. `Control` (with the MIPS-only `reg_dst`) and `derive_control` stay in `mips`.
- `mips::IProcessor` / `StepResult` / `PipelineState` / `StageSnapshot` are retained as `using` aliases so generic callers are unchanged.
- `SingleCycleCpu` / `PipelinedCpu` derive from `IMipsProcessor`; `GdbStub` and the TUI's owned `cpu` pointer are retyped to `IMipsProcessor` (they use `cp0`/`hi`/`lo`/`last_control`); `SimulatorController` and the `render_*` helpers stay on the agnostic `IProcessor`.

## Why

A RISC-V core can now derive straight from `isa::IProcessor` (plus its own CSR sub-interface) and reuse `isa::Memory`, `isa::RegisterFile`, and `isa::PipelineState`, so the TUI, Qt Widgets, and QML visualizers work with **zero changes**.

## Testing

- Full **debug build** green: TUI, Qt Widgets GUI (`clearCore-gui`), QML GUI (`clearCore-quick`), all libs.
- **22/22 tests pass** (21/21 on `core-only`).

## Next

Phase 3: RV32I decoder + disassembler (`include/riscv/decoder.h`) — a pure, isolated, unit-testable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)