### PR TITLE
docs(wiki): document ISA-agnostic core split and RISC-V roadmap

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -14,8 +14,11 @@ clearCore is organized into independent libraries and interface layers that shar
            ▼                        ▼                        ▼
 ┌───────────────────────────────────────────────────────────────────────┐
 │                               mips_core                               │
-│   IProcessor ◄── SingleCycleCpu / PipelinedCpu                        │
-│   Decoder · ALU · RegisterFile · Memory · Disassembler · trace (spdlog)│
+│  ┌─────────────────────────── isa:: (ISA-agnostic core) ────────────┐ │
+│  │  IProcessor · Memory · RegisterFile · PipelineState · StepResult │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+│   mips::IMipsProcessor ◄── SingleCycleCpu / PipelinedCpu (adds CP0/HI/LO)│
+│   Decoder · ALU · Control · CP0 · Disassembler · trace (spdlog)        │
 │   (optional) NyxstoneBackend (LLVM-based assembler/disassembler)      │
 └──────────────────────────────┬────────────────────────────────────────┘
                                 │
@@ -30,7 +33,7 @@ clearCore is organized into independent libraries and interface layers that shar
 | Library / target | Responsibility                                                                     |
 |-------------------|-------------------------------------------------------------------------------------|
 | `nsc_core`        | Real-time binary/hex/decimal conversion around a `uint64_t` value                   |
-| `mips_core`       | CPU simulation: decoder, ALU, register file, memory, disassembler, both CPU backends |
+| `mips_core`       | CPU simulation: the ISA-agnostic `isa::` core (`IProcessor`, `Memory`, `RegisterFile`, `PipelineState`) plus the MIPS backend — decoder, ALU, disassembler, both CPU models |
 | `nsc_ui`          | FTXUI terminal interface (`number_system_converter` binary) — depends only on public `mips_core` headers |
 | `nsc_qt`          | Qt6 Widgets layer (`clearCore-gui` binary) — `SimulatorController` bridges CPU state to Qt signals, plus an in-app MIPS assembler |
 | `nsc_quick`       | Qt Quick / QML layer (`clearCore-quick` binary) — same `IProcessor` backend, declarative UI in `qml/ClearCore/` |
@@ -49,21 +52,37 @@ Each library is independently unit-testable. You can run the decoder, ALU, and b
 
 ### 2. Pluggable-backend pattern
 
+The processor contract is split in two so a second ISA can reuse the whole stack. `isa::IProcessor` is the **ISA-agnostic** contract every backend implements; `mips::IMipsProcessor` layers the MIPS-only architectural state (coprocessor 0, HI/LO, the MIPS `Control` word) on top.
+
 ```cpp
+namespace isa {
+// ISA-agnostic — any backend (MIPS today, RISC-V next) implements this.
 class IProcessor {
 public:
-    virtual StepResult step() = 0;
-    virtual void       load(std::vector<uint32_t> program) = 0;
-    virtual void       reset() = 0;
-    virtual PipelineState pipeline_state() const = 0;
-    // ...
+    virtual StepResult step()                                            = 0;
+    virtual bool       load_program(const std::vector<uint32_t>&,
+                                    uint32_t addr = 0)                    = 0;
+    virtual void       reset(bool clear_memory = false)                  = 0;
+    virtual const PipelineState& pipeline_state() const noexcept         = 0;
+    // pc(), regs(), mem(), cycle_count() ...
+};
+}  // namespace isa
+
+namespace mips {
+// MIPS adds coprocessor 0, HI/LO, and the last committed Control word.
+class IMipsProcessor : public isa::IProcessor {
+public:
+    virtual const Control& last_control() const noexcept = 0;
+    virtual Cp0&           cp0() noexcept                 = 0;
+    virtual uint32_t       hi() const noexcept            = 0;  // ... lo(), set_hi/lo()
 };
 
-class SingleCycleCpu : public IProcessor { /* ... */ };
-class PipelinedCpu   : public IProcessor { /* ... */ };
+class SingleCycleCpu : public IMipsProcessor { /* ... */ };
+class PipelinedCpu   : public IMipsProcessor { /* ... */ };
+}  // namespace mips
 ```
 
-Every UI holds an `IProcessor*`. Switching between single-cycle and pipelined mode at runtime is a pointer swap — no UI changes. This pattern is inspired by [Ripes](https://github.com/mortbopet/Ripes) and [DrMIPS](https://brunonova.github.io/drmips/).
+Every UI holds an `isa::IProcessor*` (re-exported as `mips::IProcessor` for existing callers). Switching between single-cycle and pipelined mode at runtime is a pointer swap — no UI changes. A future RISC-V core derives straight from `isa::IProcessor` (plus its own CSR sub-interface) and reuses `isa::Memory`, `isa::RegisterFile`, and `isa::PipelineState`, so all three visualizers work unchanged. This pattern is inspired by [Ripes](https://github.com/mortbopet/Ripes) and [DrMIPS](https://brunonova.github.io/drmips/).
 
 ### 3. Observable pipeline state
 
@@ -77,14 +96,24 @@ A single `derive_control()` free function maps an opcode/funct pair to the full 
 
 ---
 
+## ISA-agnostic core (`isa::`)
+
+These types carry nothing MIPS-specific and live in `include/isa/`, ready to be shared by a second ISA backend (RISC-V). The `mips` headers re-export them with `using`-shims (`mips::Memory`, `mips::RegisterFile`, `mips::IProcessor`, …) so existing callers compile unchanged.
+
+| Component        | File(s)                   | Role                                                        |
+|-------------------|----------------------------|---------------------------------------------------------------|
+| `isa::IProcessor`  | `include/isa/processor.h` | ISA-agnostic processor contract + `PipelineState` / `StepResult` / `StageSnapshot` |
+| `isa::RegisterFile`| `include/isa/registers.h` | 32 × `uint32_t`, register 0 hardwired                         |
+| `isa::Memory`      | `include/isa/memory.h`    | Byte-addressable, word/half/byte access, alignment checks     |
+
 ## `mips_core` internals
 
-| Component        | File(s)                          | Role                                                        |
-|-------------------|-----------------------------------|---------------------------------------------------------------|
-| `Decoder`         | `include/mips/decoder.h`         | 32-bit word → instruction fields + mnemonic                   |
-| `ALU`             | `include/mips/alu.h`             | Arithmetic, logic, shifts, overflow flags                     |
-| `RegisterFile`    | `include/mips/registers.h`       | 32 × `uint32_t`, `$zero` hardwired                             |
-| `Memory`          | `include/mips/memory.h`          | Byte-addressable, word/half/byte access, alignment checks     |
+| Component            | File(s)                     | Role                                                        |
+|-----------------------|------------------------------|---------------------------------------------------------------|
+| `mips::IMipsProcessor`| `include/mips/processor.h`  | Extends `isa::IProcessor` with CP0, HI/LO, and the MIPS `Control` word |
+| `Decoder`             | `include/mips/decoder.h`    | 32-bit word → instruction fields + mnemonic                   |
+| `ALU`                 | `include/mips/alu.h`        | Arithmetic, logic, shifts, overflow flags                     |
+| `register_abi_name`   | `include/mips/registers.h`  | MIPS O32 ABI mnemonic table (the ISA-specific part left in `mips`) |
 | `Disassembler`    | `include/mips/disassembler.h`    | Machine code → assembly text; hex program loader              |
 | `SingleCycleCpu`  | `src/mips/single_cycle_cpu.cpp`  | Simulates all five stages in one `step()` call                |
 | `PipelinedCpu`    | `src/mips/pipelined_cpu.cpp`     | Concurrent pipeline with five pipeline registers               |

--- a/wiki/GDB-Stub.md
+++ b/wiki/GDB-Stub.md
@@ -62,13 +62,15 @@ GDB addresses 38 registers by number in the `g`/`G`/`p`/`P` commands:
 
 | GDB register | MIPS name | Source |
 |---|---|---|
-| 0–31 | $zero, $at, $v0–$v1, $a0–$a3, $t0–$t9, $s0–$s7, $k0, $k1, $gp, $sp, $fp, $ra | `IProcessor::regs()` |
-| 32 | CP0 Status | `IProcessor::cp0().status()` |
-| 33 | LO | `IProcessor::lo()` |
-| 34 | HI | `IProcessor::hi()` |
-| 35 | CP0 BadVAddr | `IProcessor::cp0().bad_vaddr()` |
-| 36 | CP0 Cause | `IProcessor::cp0().cause()` |
-| 37 | PC | `IProcessor::pc()` |
+| 0–31 | $zero, $at, $v0–$v1, $a0–$a3, $t0–$t9, $s0–$s7, $k0, $k1, $gp, $sp, $fp, $ra | `isa::IProcessor::regs()` |
+| 32 | CP0 Status | `IMipsProcessor::cp0().status()` |
+| 33 | LO | `IMipsProcessor::lo()` |
+| 34 | HI | `IMipsProcessor::hi()` |
+| 35 | CP0 BadVAddr | `IMipsProcessor::cp0().bad_vaddr()` |
+| 36 | CP0 Cause | `IMipsProcessor::cp0().cause()` |
+| 37 | PC | `isa::IProcessor::pc()` |
+
+The stub holds a `mips::IMipsProcessor&` — the MIPS-specific interface — since it reads CP0, HI, and LO. The general-purpose registers, PC, and memory come from the ISA-agnostic `isa::IProcessor` base.
 
 ## Software breakpoints
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -63,6 +63,15 @@ The project follows a staged development plan. Each stage builds on the previous
 - **Instruction/pipeline trace logging** (`mips::trace`, spdlog) — fetch/decode, stall/flush/hazard events, exception raises, and memory faults; quiet by default, enable at runtime with `CLEARCORE_LOG_LEVEL`
 - **MARS differential ("golden") test suite** (`tests/golden/`) — cross-checks both CPU models against MARS, the classroom-standard reference MIPS simulator, on seven corpus programs
 
+### Stage 2.6 — ISA-agnostic core (RISC-V groundwork) · `v0.1.1`
+
+Refactor-only step (no user-facing change) that carves the ISA-neutral parts of the emulator out of the `mips` namespace so a second ISA backend can reuse them. See [Architecture § Pluggable-backend pattern](Architecture#2-pluggable-backend-pattern).
+
+- New `isa::` core in `include/isa/`: `Memory`, `RegisterFile`, and `IProcessor` (with `PipelineState` / `StepResult` / `StageSnapshot`) — everything common to MIPS and RV32I
+- `IProcessor` split into agnostic `isa::IProcessor` + `mips::IMipsProcessor` (the latter adds CP0, HI/LO, and the MIPS `Control` word); both CPU models now derive from `IMipsProcessor`
+- `mips::Memory` / `mips::RegisterFile` / `mips::IProcessor` retained as `using`-shims, so all existing callers and the three UIs are untouched
+- Verified: full debug build (TUI + Qt Widgets + QML) and all tests green
+
 ---
 
 ## In progress / upcoming
@@ -111,7 +120,13 @@ The Qt6 GUI's Pipeline Trace and Statistics tabs already deliver most of this fo
 
 ### Core extensibility
 
-- [ ] RISC-V backend (implements `IProcessor`; reuses all existing visualizers)
+- [~] **RISC-V (RV32I) backend** — derives from `isa::IProcessor`, reuses `isa::Memory` / `RegisterFile` / `PipelineState`, so all existing visualizers work unchanged. Groundwork (the `isa::` core split, Stage 2.6) shipped in `v0.1.1`. Remaining phased plan:
+  - [x] ISA-agnostic core extraction + `IProcessor` split (`v0.1.1`)
+  - [ ] RV32I decoder + disassembler (`include/riscv/decoder.h`) — pure, unit-testable
+  - [ ] `RiscvSingleCycleCpu` implementing `isa::IProcessor`
+  - [ ] `RiscvPipelinedCpu` (5-stage; populates the shared `PipelineState`)
+  - [ ] ELF loader for `EM_RISCV` (`riscv32` binaries)
+  - [ ] GDB stub register map + CSR/trap model
 - [ ] Configurable datapath — load processor config from JSON/YAML to swap components
 - [ ] Cache simulator — configurable L1/L2, replacement policies, coherence (EduMIPS64 + Dinero pattern)
 - [ ] Extend the ISA subset — `SRAV`, `LB`/`SB`/`LH`/`SH`, `BGTZ`/`BLEZ`/`BGEZ`/`BLTZ` are not yet decoded (see [MIPS CPU Simulator](MIPS-CPU-Emulator#supported-isa-subset))


### PR DESCRIPTION
## Summary

Update the wiki to match the **v0.1.1** `isa/` core refactor (the wiki still described the pre-refactor, MIPS-only structure). Docs only — no code change.

- **Architecture.md** — module diagram now shows the `isa::` core nested inside `mips_core`; the pluggable-backend section documents the `isa::IProcessor` / `mips::IMipsProcessor` split with a code snippet; internals tables move `Memory`/`RegisterFile` to `include/isa/` and add the `IMipsProcessor` row. Notes that a RISC-V core derives straight from `isa::IProcessor` and reuses the shared visualizer state.
- **Roadmap.md** — adds **Stage 2.6 — ISA-agnostic core (RISC-V groundwork) · v0.1.1** to Completed, and expands the RISC-V backend stretch goal into the phased RV32I plan (decoder → single-cycle → pipelined → ELF → GDB) with the groundwork phase checked off.
- **GDB-Stub.md** — register-map accessors reading CP0/HI/LO now reference `IMipsProcessor`; GPRs/PC come from the agnostic `isa::IProcessor` base.

## Related issues

_None._

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / wiki
- [ ] Build / CI / tooling

## How was this verified?

Docs-only change; pre-commit hooks (end-of-file, trailing-whitespace, secret scan) passed. No build or test impact.

## Checklist

- [x] Branch is based on and targets `develop`
- [x] Code is `clang-format`-clean (n/a — Markdown only)
- [x] Core libraries include no UI headers (n/a — no code change)
- [x] Docs / CHANGELOG updated if the change is user-facing (this **is** the docs update; CHANGELOG is label-driven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)