### PR TITLE
fix(ci): open a PR for CHANGELOG promotion + record v0.1.1

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -58,11 +59,28 @@ jobs:
           print(f"Promoted [Unreleased] -> [{tag}] - {date}")
           EOF
 
-      - name: Commit and push to develop
+      - name: Open a pull request with the CHANGELOG promotion
+        # The develop branch ruleset forbids direct pushes ("changes must be made
+        # through a pull request"), so open a PR instead of pushing to develop.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No CHANGELOG changes to commit"; exit 0
+          fi
+          branch="chore/changelog-${RELEASE_TAG}"
+          git switch -c "$branch"
           git add CHANGELOG.md
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: promote [Unreleased] to ${{ github.event.release.tag_name }} in CHANGELOG"
-          git push origin develop
+          git commit -m "chore: promote [Unreleased] to ${RELEASE_TAG} in CHANGELOG"
+          git push --force-with-lease origin "$branch"
+          # skip-changelog: this promotion PR should not appear in the next release's notes.
+          gh pr create \
+            --base develop \
+            --head "$branch" \
+            --title "chore: promote CHANGELOG for ${RELEASE_TAG}" \
+            --body "Automated CHANGELOG promotion for the ${RELEASE_TAG} release, opened by \`update-changelog.yml\` (direct pushes to \`develop\` are blocked by the branch ruleset). Review and merge to record the release in CHANGELOG.md." \
+            --label skip-changelog \
+            || echo "PR already exists for $branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,34 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Documentation
+- README and `CITATION.cff` reframed as a multi-ISA CPU-architecture simulator that foreshadows the RISC-V
+  backend (was described as MIPS-only). (#61)
+
+### CI / Internal
+- `update-changelog.yml` now opens a pull request into `develop` instead of pushing directly, so the CHANGELOG
+  promotion is no longer rejected by the `develop` branch ruleset (`GH013: Changes must be made through a pull
+  request`).
+
+---
+
+## [0.1.1] - 2026-07-04
+
+Internal refactor release: carves the ISA-agnostic `isa::` core out of the MIPS backend so a future RISC-V (RV32I)
+backend can reuse the memory, register file, pipeline state, and processor interface. No user-facing behavior change.
+
+### Changed
+- Split the simulation core into an ISA-agnostic `isa::` layer: `Memory`, `RegisterFile`, and `IProcessor` (with
+  `PipelineState`/`StepResult`/`StageSnapshot`) moved to `include/isa/`; `IProcessor` split into `isa::IProcessor`
+  (agnostic) + `mips::IMipsProcessor` (adds CP0, HI/LO, and the MIPS `Control` word). `mips::` `using`-shims keep
+  every existing caller and all three UIs unchanged. (#57)
+
+### Documentation
+- Wiki (Architecture, Roadmap, GDB-Stub) documents the `isa::` core split and the phased RISC-V roadmap. (#59)
+
 ### CI / Internal
 - Fixed `update-changelog.yml`: corrected the `harden-runner` commit SHA (previously unresolvable, which failed the
-  job at startup) and rewrote the malformed promote step so the CHANGELOG auto-promotes on each published release.
+  job at startup) and rewrote the malformed promote step.
 
 ---
 


### PR DESCRIPTION
## Summary

The `v0.1.1` release published fine, but its **CHANGELOG automation failed**: `update-changelog.yml` pushed the promotion commit straight to `develop`, which the branch ruleset rejects:

```
remote: error: GH013: Repository rule violations found for refs/heads/develop.
  - Changes must be made through a pull request.
```

The promotion commit was created in the runner and discarded on push, so the `[0.1.1]` entry was never recorded. This PR fixes the workflow and backfills the missing entry.

### Workflow fix (`update-changelog.yml`)
- Replaces `git push origin develop` with a **branch + `gh pr create` into `develop`** (labeled `skip-changelog`), so it works within the ruleset.
- Adds `pull-requests: write` permission.

### CHANGELOG backfill
- Authors the missing **`[0.1.1]`** entry — the `isa::` core split (#57) and wiki docs (#59) that the failed run should have recorded. (The old `[Unreleased]` only held a stale CI note, so an auto-promote alone would have produced a thin/wrong entry.)
- Moves pending, not-yet-released items — the README/CITATION reframe (#61) and this workflow fix — under a fresh `[Unreleased]`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / wiki
- [x] Build / CI / tooling

## How was this verified?

YAML validated by pre-commit (`check yaml` passed). The PR-creation path will be exercised on the next published release.

> ⚠️ **Repo setting required:** for the workflow's `gh pr create` to succeed, **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** must be enabled. If it isn't, the next release will fail at PR creation instead of push.

## Checklist

- [x] Branch is based on and targets `develop`
- [x] Code is `clang-format`-clean (n/a — YAML/Markdown)
- [x] Core libraries include no UI headers (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)