### PR TITLE
release: promote develop → main (v0.1.2 — docs reframe + changelog automation)

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,61 @@
+name: Release PR (develop → main)
+
+# Keeps a standing release-promotion PR from develop into main. On each push to
+# develop it opens the PR if none is open; an existing PR tracks new commits
+# automatically, so you just merge it when you're ready to cut a release.
+#
+# Requires: Settings → Actions → General → Workflow permissions →
+# "Allow GitHub Actions to create and approve pull requests" (same as update-changelog.yml).
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Open or refresh the develop → main release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main develop
+
+          if [ -z "$(git log origin/main..origin/develop --oneline)" ]; then
+            echo "develop is not ahead of main; nothing to promote."
+            exit 0
+          fi
+
+          existing=$(gh pr list --base main --head develop --state open \
+                       --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Release PR #$existing already open; it tracks new commits automatically."
+            exit 0
+          fi
+
+          # Suggested next version from the current draft release (release-drafter).
+          version=$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
+                      --jq 'map(select(.draft)) | .[0].tag_name // ""' 2>/dev/null || true)
+
+          # List the merged PRs that would ship.
+          included=$(git log origin/main..origin/develop --merges \
+                       --pretty='- %s' | sed -E 's/Merge pull request (#[0-9]+) from .*/\1/')
+
+          gh pr create \
+            --base main --head develop \
+            --title "release: promote develop → main${version:+ (${version})}" \
+            --label skip-changelog \
+            --body "$(printf 'Automated release-promotion PR from `develop` into `main`, opened by `release-pr.yml`.\n\n## Included\n%s\n\nReview, confirm the version bump, and merge to cut a release — release-drafter updates the draft on merge to `main`, and you publish the draft when ready.' "$included")"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -58,11 +59,28 @@ jobs:
           print(f"Promoted [Unreleased] -> [{tag}] - {date}")
           EOF
 
-      - name: Commit and push to develop
+      - name: Open a pull request with the CHANGELOG promotion
+        # The develop branch ruleset forbids direct pushes ("changes must be made
+        # through a pull request"), so open a PR instead of pushing to develop.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No CHANGELOG changes to commit"; exit 0
+          fi
+          branch="chore/changelog-${RELEASE_TAG}"
+          git switch -c "$branch"
           git add CHANGELOG.md
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: promote [Unreleased] to ${{ github.event.release.tag_name }} in CHANGELOG"
-          git push origin develop
+          git commit -m "chore: promote [Unreleased] to ${RELEASE_TAG} in CHANGELOG"
+          git push --force-with-lease origin "$branch"
+          # skip-changelog: this promotion PR should not appear in the next release's notes.
+          gh pr create \
+            --base develop \
+            --head "$branch" \
+            --title "chore: promote CHANGELOG for ${RELEASE_TAG}" \
+            --body "Automated CHANGELOG promotion for the ${RELEASE_TAG} release, opened by \`update-changelog.yml\` (direct pushes to \`develop\` are blocked by the branch ruleset). Review and merge to record the release in CHANGELOG.md." \
+            --label skip-changelog \
+            || echo "PR already exists for $branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `update-changelog.yml` now opens a pull request into `develop` instead of pushing directly, so the CHANGELOG
   promotion is no longer rejected by the `develop` branch ruleset (`GH013: Changes must be made through a pull
   request`).
+- Added `release-pr.yml`: keeps a standing `develop → main` release-promotion PR open automatically on each push
+  to `develop`, so cutting a release is a single merge.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,34 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Documentation
+- README and `CITATION.cff` reframed as a multi-ISA CPU-architecture simulator that foreshadows the RISC-V
+  backend (was described as MIPS-only). (#61)
+
+### CI / Internal
+- `update-changelog.yml` now opens a pull request into `develop` instead of pushing directly, so the CHANGELOG
+  promotion is no longer rejected by the `develop` branch ruleset (`GH013: Changes must be made through a pull
+  request`).
+
+---
+
+## [0.1.1] - 2026-07-04
+
+Internal refactor release: carves the ISA-agnostic `isa::` core out of the MIPS backend so a future RISC-V (RV32I)
+backend can reuse the memory, register file, pipeline state, and processor interface. No user-facing behavior change.
+
+### Changed
+- Split the simulation core into an ISA-agnostic `isa::` layer: `Memory`, `RegisterFile`, and `IProcessor` (with
+  `PipelineState`/`StepResult`/`StageSnapshot`) moved to `include/isa/`; `IProcessor` split into `isa::IProcessor`
+  (agnostic) + `mips::IMipsProcessor` (adds CP0, HI/LO, and the MIPS `Control` word). `mips::` `using`-shims keep
+  every existing caller and all three UIs unchanged. (#57)
+
+### Documentation
+- Wiki (Architecture, Roadmap, GDB-Stub) documents the `isa::` core split and the phased RISC-V roadmap. (#59)
+
 ### CI / Internal
 - Fixed `update-changelog.yml`: corrected the `harden-runner` commit SHA (previously unresolvable, which failed the
-  job at startup) and rewrote the malformed promote step so the CHANGELOG auto-promotes on each published release.
+  job at startup) and rewrote the malformed promote step.
 
 ---
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: >-
-  clearCore: An educational MIPS CPU simulator with
+  clearCore: An educational CPU-architecture simulator with
   live 5-stage pipeline visualization
 message: >-
   If you use clearCore in your research, teaching, or a
@@ -15,15 +15,17 @@ authors:
 repository-code: 'https://github.com/khenderson20/clearCore'
 url: 'https://github.com/khenderson20/clearCore'
 abstract: >-
-  clearCore is a C++20 MIPS CPU simulator built for seeing
-  how a processor works. It provides two interchangeable
-  execution engines — a single-cycle datapath and a 5-stage
-  pipeline sharing one IProcessor interface — and three
-  front ends (a terminal UI, a Qt6 Widgets GUI, and a Qt
-  Quick/QML GUI) that render pipeline state, hazards,
-  stalls, forwarding paths, CP0 exceptions, and an ELF
-  loader. A built-in GDB remote stub lets real GDB attach
-  to the running emulator.
+  clearCore is a C++20 CPU-architecture simulator built for
+  seeing how a processor works. It currently implements MIPS
+  on an ISA-agnostic core designed to host additional
+  instruction sets (RISC-V planned). It provides two
+  interchangeable execution engines — a single-cycle datapath
+  and a 5-stage pipeline sharing one processor interface — and
+  three front ends (a terminal UI, a Qt6 Widgets GUI, and a Qt
+  Quick/QML GUI) that render pipeline state, hazards, stalls,
+  forwarding paths, CP0 exceptions, and an ELF loader. A
+  built-in GDB remote stub lets real GDB attach to the running
+  emulator.
 keywords:
   - computer-architecture
   - mips

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <p align="center">
   Write MIPS assembly, watch it flow through a 5-stage pipeline cycle by cycle,<br>
-  and attach real GDB to the running emulator — in your terminal or a Qt6 desktop GUI.
+  and attach real GDB to the running emulator — in your terminal or a Qt6 desktop GUI.<br>
+  <b>MIPS today, RISC-V next</b> — on one shared, ISA-agnostic core.
 </p>
 
 <p align="center">
@@ -40,16 +41,23 @@
 
 ## What is clearCore?
 
-clearCore is a C++20 MIPS CPU simulator built for *seeing* how a processor works. Type assembly into the built-in
-editor, step the CPU, and watch every instruction move through IF/ID/EX/MEM/WB — stalls, flushes, and forwarding
-paths highlighted as they happen. When you outgrow hand-typed programs, load a real `mipsel` ELF binary and debug
-it with actual GDB through the built-in remote stub.
+clearCore is a C++20 CPU-architecture simulator built for *seeing* how a processor works. Today it speaks MIPS:
+type assembly into the built-in editor, step the CPU, and watch every instruction move through IF/ID/EX/MEM/WB —
+stalls, flushes, and forwarding paths highlighted as they happen. When you outgrow hand-typed programs, load a real
+`mipsel` ELF binary and debug it with actual GDB through the built-in remote stub.
 
-Two execution engines — a single-cycle datapath and a 5-stage pipeline — implement the same `IProcessor` interface
+Two execution engines — a single-cycle datapath and a 5-stage pipeline — implement the same processor interface
 and swap at runtime, no rebuild required (the pluggable-backend pattern from Ripes/DrMIPS). Three front ends — a
 keyboard-driven terminal UI, a Qt6 Widgets GUI, and a Qt Quick/QML GUI — drive the same core libraries, so pipeline
 behavior is identical everywhere. The design follows Harris & Harris (*Digital Design and Computer Architecture*)
 and Patterson & Hennessy (*Computer Organization and Design*).
+
+**Why the name — and why not just MIPS.** MIPS originally stood for *Microprocessor without Interlocked Pipeline
+Stages*: the hardware dropped the interlocks and left the compiler to schedule around hazards. clearCore puts them
+back and lights them up, so you can watch every stall, forward, and flush the real silicon hid. And it isn't
+MIPS-only by design — the simulation core was recently split into an ISA-agnostic `isa::` layer (shared memory,
+register file, pipeline state, and processor interface), so a **RISC-V (RV32I) backend is next**, reusing all three
+front ends and every visualizer unchanged.
 
 *(clearCore began life as a live number-system converter — that converter is still the first tab of the terminal UI.)*
 
@@ -205,14 +213,16 @@ the same interfaces directly. Module-by-module breakdown, design pillars, and ac
 |------------------|-----------------------|--------------------|-----------------|------------------|-------------------|
 | **Language**     | C++20                 | C++/Qt             | Java            | Java             | C++/Qt            |
 | **UI**           | TUI + Qt6 GUI         | Qt GUI             | Swing GUI       | Swing GUI        | Qt GUI            |
-| **ISA**          | MIPS                  | RISC-V             | MIPS            | MIPS64           | MIPS              |
+| **ISA**          | MIPS (RISC-V planned) | RISC-V             | MIPS            | MIPS64           | MIPS              |
 | **Backends**     | 2 (SC / 5-stage)      | 5+ models          | ~2              | ~1               | ~1                |
 | **Pipeline viz** | Stage state + hazards | Datapath schematic | Visual datapath | Registers/memory | Datapath + memory |
 
 ## Roadmap
 
-Stages 1–2.6 (converter core → pipelined CPU → Qt6 GUIs → CP0/ELF/GDB) are complete. Up next:
+Stages 1–2.6 (converter core → pipelined CPU → Qt6 GUIs → CP0/ELF/GDB) are complete — including the recent split
+into an **ISA-agnostic core** that clears the way for a second instruction set. Up next:
 
+- [ ] **RISC-V (RV32I)** — a second ISA backend on the shared `isa::` core: decoder → single-cycle → 5-stage pipeline → ELF → GDB, reusing every existing front end and visualizer
 - [ ] **Stage 3** — Two-pass assembler with full symbol table and pseudo-instruction expansion
 - [ ] **Stage 4** — Per-stage TUI telemetry and CPI analysis, matching the GUI's Pipeline Trace and Statistics tabs
 - [ ] **Stage 5** — Branch prediction and speculative execution
@@ -244,7 +254,7 @@ GitHub's **"Cite this repository"** button (top-right sidebar) generates APA and
 ```bibtex
 @software{henderson_clearcore,
   author  = {Henderson, Kevin},
-  title   = {{clearCore}: An educational {MIPS} {CPU} simulator with live pipeline visualization},
+  title   = {{clearCore}: An educational {CPU}-architecture simulator with live 5-stage pipeline visualization},
   year    = {2026},
   version = {0.1.0},
   doi     = {10.5281/zenodo.21194876},


### PR DESCRIPTION
## Summary

Promote `develop` into `main`. Docs/CI only → **v0.1.2 (patch)**. Notably, this also lands the correct **`[0.1.1]` CHANGELOG entry** on `main` (backfilled after the release automation failed on the v0.1.1 publish).

Bundled PRs:
- **#61** — README + `CITATION.cff` reframed as a multi-ISA CPU-architecture simulator that foreshadows the RISC-V backend
- **#62** — `update-changelog.yml` now opens a PR instead of direct-pushing to `develop`; backfills the missing `[0.1.1]` CHANGELOG entry

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation / wiki
- [x] Build / CI / tooling

## How was this verified?

Docs/CI only — no build or test impact. Both bundled PRs passed their checks before merge.

## Checklist

- [x] Targets the correct base — release PR (`develop → main`)
- [x] `clang-format`-clean (n/a — Markdown/YAML)
- [x] Core libraries include no UI headers (n/a — no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)