### PR TITLE
ci: automate the develop → main release-promotion PR

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,61 @@
+name: Release PR (develop → main)
+
+# Keeps a standing release-promotion PR from develop into main. On each push to
+# develop it opens the PR if none is open; an existing PR tracks new commits
+# automatically, so you just merge it when you're ready to cut a release.
+#
+# Requires: Settings → Actions → General → Workflow permissions →
+# "Allow GitHub Actions to create and approve pull requests" (same as update-changelog.yml).
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Open or refresh the develop → main release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main develop
+
+          if [ -z "$(git log origin/main..origin/develop --oneline)" ]; then
+            echo "develop is not ahead of main; nothing to promote."
+            exit 0
+          fi
+
+          existing=$(gh pr list --base main --head develop --state open \
+                       --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Release PR #$existing already open; it tracks new commits automatically."
+            exit 0
+          fi
+
+          # Suggested next version from the current draft release (release-drafter).
+          version=$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
+                      --jq 'map(select(.draft)) | .[0].tag_name // ""' 2>/dev/null || true)
+
+          # List the merged PRs that would ship.
+          included=$(git log origin/main..origin/develop --merges \
+                       --pretty='- %s' | sed -E 's/Merge pull request (#[0-9]+) from .*/\1/')
+
+          gh pr create \
+            --base main --head develop \
+            --title "release: promote develop → main${version:+ (${version})}" \
+            --label skip-changelog \
+            --body "$(printf 'Automated release-promotion PR from `develop` into `main`, opened by `release-pr.yml`.\n\n## Included\n%s\n\nReview, confirm the version bump, and merge to cut a release — release-drafter updates the draft on merge to `main`, and you publish the draft when ready.' "$included")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `update-changelog.yml` now opens a pull request into `develop` instead of pushing directly, so the CHANGELOG
   promotion is no longer rejected by the `develop` branch ruleset (`GH013: Changes must be made through a pull
   request`).
+- Added `release-pr.yml`: keeps a standing `develop → main` release-promotion PR open automatically on each push
+  to `develop`, so cutting a release is a single merge.
 
 ---
 


### PR DESCRIPTION
## Summary

Add `release-pr.yml` — a workflow that keeps a standing **`develop → main` release-promotion PR** open automatically, so cutting a release is a single merge instead of a hand-crafted PR each time.

**Behavior:**
- On each push to `develop` (and `workflow_dispatch`), if `develop` is ahead of `main` and no `develop → main` PR is open, it opens one — labeled `skip-changelog`, with the drafted next version (from release-drafter) in the title and the merged PRs listed in the body.
- If a release PR is already open, it does nothing (GitHub keeps the PR's diff current), so the "release train" just accumulates until you merge it.

This complements #62: both `update-changelog.yml` and now `release-pr.yml` create PRs instead of pushing, working within the `develop`/`main` branch rulesets.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / wiki
- [x] Build / CI / tooling

## How was this verified?

YAML validated by pre-commit (`check yaml` passed). The PR-creation path runs on the next push to `develop` after merge.

> ⚠️ **Repo setting required:** **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** must be enabled (same prerequisite as #62). If it's already on, no action needed.

## Checklist

- [x] Branch is based on and targets `develop`
- [x] `clang-format`-clean (n/a — YAML/Markdown)
- [x] Core libraries include no UI headers (n/a — no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)