### PR TITLE
feat(ci): Windows installer and universal macOS .dmg release assets

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -27,9 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: windows-x64, os: windows-latest, arch: x86_64 }
-          - { name: macos-intel, os: macos-13,       arch: x86_64 }
-          - { name: macos-arm64, os: macos-14,       arch: arm64  }
+          - { name: windows-x64, os: windows-latest }
+          # One universal (arm64 + x86_64) macOS build on Apple Silicon. Qt's
+          # official macOS binaries are universal (since 6.2), so a single Qt
+          # install covers both slices — no scarce Intel (macos-13) runner needed.
+          - { name: macos-universal, os: macos-14 }
     env:
       # macOS minimum: std::format's to_chars backend is only available in
       # libc++ from macOS 13.3 onward. CMake reads this to seed the deployment
@@ -65,8 +67,16 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install ninja
 
-      - name: Configure
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
         run: cmake --preset release -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
+
+      - name: Configure (macOS, universal)
+        if: runner.os == 'macOS'
+        run: >
+          cmake --preset release
+          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
+          "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
 
       - name: Build
         run: cmake --build --preset release

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,81 @@
+name: Cross-platform build
+
+# Builds and tests clearCore on Windows and macOS (Intel + Apple Silicon), the
+# groundwork for shipping Windows/macOS release assets. Nyxstone (LLVM) and the
+# golden tests (JRE) are disabled — they are Linux-oriented dev/test tooling, not
+# user-facing, and painful to provision off-Linux.
+#
+# Triggers: pushes to the packaging branch (for iteration) and manual dispatch.
+# Packaging + release-asset upload are layered on in later steps.
+on:
+  push:
+    branches: [ci/windows-macos-packaging]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: windows-x64,    os: windows-latest, arch: x86_64 }
+          - { name: macos-intel,    os: macos-13,       arch: x86_64 }
+          - { name: macos-arm64,    os: macos-14,       arch: arm64  }
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Qt 6
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
+        with:
+          version: '6.8.*'
+          cache: true
+
+      - name: Install Ninja (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ninja
+
+      # ── Configure ──────────────────────────────────────────────────────────
+      - name: Configure (Windows / MSVC)
+        if: runner.os == 'Windows'
+        run: >
+          cmake -S . -B build/release -G "Visual Studio 17 2022" -A x64
+          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
+
+      - name: Configure (macOS)
+        if: runner.os == 'macOS'
+        run: >
+          cmake --preset release
+          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+
+      # ── Build ──────────────────────────────────────────────────────────────
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --build build/release --config Release
+
+      - name: Build (macOS)
+        if: runner.os == 'macOS'
+        run: cmake --build --preset release
+
+      # ── Test ───────────────────────────────────────────────────────────────
+      - name: Test (Windows)
+        if: runner.os == 'Windows'
+        run: ctest --test-dir build/release -C Release --output-on-failure
+
+      - name: Test (macOS)
+        if: runner.os == 'macOS'
+        run: ctest --test-dir build/release --output-on-failure

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -8,8 +8,6 @@ name: Cross-platform build
 # Triggers: pushes to the packaging branch (for iteration) and manual dispatch.
 # Packaging + release-asset upload are layered on in later steps.
 on:
-  push:
-    branches: [ci/windows-macos-packaging]
   workflow_dispatch:
   release:
     types: [published]

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -42,6 +42,12 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history + tags: the Qt Advanced Docking System's CMake runs
+          # `git describe --tags` in this repo to stamp its Windows version
+          # resource. A shallow, tagless checkout yields an empty version and a
+          # malformed FILEVERSION that the resource compiler rejects (RC2127).
+          fetch-depth: 0
 
       - name: Install Qt 6
         uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -74,7 +74,20 @@ jobs:
 
       - name: Ensure NSIS (Windows)
         if: runner.os == 'Windows'
-        run: choco install nsis --no-progress -y
+        shell: bash
+        run: |
+          # choco can return exit 0 even when the community feed is down (503),
+          # leaving NSIS uninstalled and cpack unable to find makensis. Retry
+          # until makensis actually exists on disk.
+          makensis="/c/Program Files (x86)/NSIS/makensis.exe"
+          for attempt in 1 2 3 4 5; do
+            [ -f "$makensis" ] && { echo "NSIS present"; exit 0; }
+            echo "Installing NSIS (attempt $attempt)…"
+            choco install nsis --no-progress -y || true
+            [ -f "$makensis" ] && { echo "NSIS installed"; exit 0; }
+            sleep 20
+          done
+          echo "::error::NSIS could not be installed"; exit 1
 
       - name: Configure (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches: [ci/windows-macos-packaging]
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -23,6 +25,9 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write  # attach installers to the release
+
     strategy:
       fail-fast: false
       matrix:
@@ -91,17 +96,31 @@ jobs:
         run: ctest --test-dir build/release --output-on-failure
 
       # ── Package (bundles Qt via windeployqt/macdeployqt at install time) ─────
-      - name: Package installer (Windows / NSIS)
-        if: runner.os == 'Windows'
+      # Versioned, arch-labelled filenames; version comes from the release tag
+      # (published release) or a dev placeholder (push / manual dispatch).
+      - name: Package installer
+        id: package
+        shell: bash
         working-directory: build/release
-        run: cpack -G NSIS -V
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            version="${{ github.event.release.tag_name }}"; version="${version#v}"
+          else
+            version="0.0.0-dev"
+          fi
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            generator="NSIS";      name="clearCore-${version}-windows-x64"
+          else
+            generator="DragNDrop"; name="clearCore-${version}-macOS-universal"
+          fi
+          cpack -G "$generator" \
+                -D CPACK_PACKAGE_VERSION="$version" \
+                -D CPACK_PACKAGE_FILE_NAME="$name" -V
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          ls -la "$name".* || true
 
-      - name: Package installer (macOS / .dmg)
-        if: runner.os == 'macOS'
-        working-directory: build/release
-        run: cpack -G DragNDrop -V
-
-      - name: Upload installer
+      - name: Upload installer artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: clearCore-${{ matrix.name }}
@@ -109,3 +128,13 @@ jobs:
             build/release/*.exe
             build/release/*.dmg
           if-no-files-found: error
+
+      - name: Attach installer to the release
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "build/release/${{ steps.package.outputs.name }}".* \
+            --clobber --repo "${{ github.repository }}"

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -92,6 +92,19 @@ jobs:
       - name: Build
         run: cmake --build --preset release
 
+      - name: Verify universal binary (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          bin=$(find build/release -path '*clearCore-gui.app/Contents/MacOS/clearCore-gui' | head -1)
+          echo "binary: $bin"
+          file "$bin"
+          archs=$(lipo -archs "$bin")
+          echo "architectures: $archs"
+          echo "$archs" | grep -qw arm64  || { echo "::error::missing arm64 slice";  exit 1; }
+          echo "$archs" | grep -qw x86_64 || { echo "::error::missing x86_64 slice"; exit 1; }
+          echo "✓ universal (arm64 + x86_64)"
+
       - name: Test
         run: ctest --test-dir build/release --output-on-failure
 

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -27,9 +27,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: windows-x64,    os: windows-latest, arch: x86_64 }
-          - { name: macos-intel,    os: macos-13,       arch: x86_64 }
-          - { name: macos-arm64,    os: macos-14,       arch: arm64  }
+          - { name: windows-x64, os: windows-latest, arch: x86_64 }
+          - { name: macos-intel, os: macos-13,       arch: x86_64 }
+          - { name: macos-arm64, os: macos-14,       arch: arm64  }
+    env:
+      # macOS minimum: std::format's to_chars backend is only available in
+      # libc++ from macOS 13.3 onward. CMake reads this to seed the deployment
+      # target; it is ignored on Windows.
+      MACOSX_DEPLOYMENT_TARGET: '13.3'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -44,38 +49,21 @@ jobs:
           version: '6.8.*'
           cache: true
 
+      # Puts cl.exe / the MSVC toolchain on PATH so the Ninja-based preset works
+      # on Windows without relying on the Visual Studio generator's discovery.
+      - name: Set up MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
       - name: Install Ninja (macOS)
         if: runner.os == 'macOS'
         run: brew install ninja
 
-      # ── Configure ──────────────────────────────────────────────────────────
-      - name: Configure (Windows / MSVC)
-        if: runner.os == 'Windows'
-        run: >
-          cmake -S . -B build/release -G "Visual Studio 17 2022" -A x64
-          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
+      - name: Configure
+        run: cmake --preset release -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
 
-      - name: Configure (macOS)
-        if: runner.os == 'macOS'
-        run: >
-          cmake --preset release
-          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
-          -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
-
-      # ── Build ──────────────────────────────────────────────────────────────
-      - name: Build (Windows)
-        if: runner.os == 'Windows'
-        run: cmake --build build/release --config Release
-
-      - name: Build (macOS)
-        if: runner.os == 'macOS'
+      - name: Build
         run: cmake --build --preset release
 
-      # ── Test ───────────────────────────────────────────────────────────────
-      - name: Test (Windows)
-        if: runner.os == 'Windows'
-        run: ctest --test-dir build/release -C Release --output-on-failure
-
-      - name: Test (macOS)
-        if: runner.os == 'macOS'
+      - name: Test
         run: ctest --test-dir build/release --output-on-failure

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -67,15 +67,21 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install ninja
 
+      - name: Ensure NSIS (Windows)
+        if: runner.os == 'Windows'
+        run: choco install nsis --no-progress -y
+
       - name: Configure (Windows)
         if: runner.os == 'Windows'
-        run: cmake --preset release -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
+        run: >
+          cmake --preset release
+          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF -DCLEARCORE_BUNDLE_QT=ON
 
       - name: Configure (macOS, universal)
         if: runner.os == 'macOS'
         run: >
           cmake --preset release
-          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF
+          -DBUILD_NYXSTONE=OFF -DGOLDEN_TESTS=OFF -DCLEARCORE_BUNDLE_QT=ON
           "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
 
       - name: Build
@@ -83,3 +89,23 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build/release --output-on-failure
+
+      # ── Package (bundles Qt via windeployqt/macdeployqt at install time) ─────
+      - name: Package installer (Windows / NSIS)
+        if: runner.os == 'Windows'
+        working-directory: build/release
+        run: cpack -G NSIS -V
+
+      - name: Package installer (macOS / .dmg)
+        if: runner.os == 'macOS'
+        working-directory: build/release
+        run: cpack -G DragNDrop -V
+
+      - name: Upload installer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: clearCore-${{ matrix.name }}
+          path: |
+            build/release/*.exe
+            build/release/*.dmg
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,17 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Windows and macOS release assets**: published releases now attach a Windows NSIS installer
+  (`clearCore-<ver>-windows-x64.exe`) and a universal macOS `.dmg` (`clearCore-<ver>-macOS-universal.dmg`,
+  arm64 + x86_64), each with the Qt runtime bundled, alongside the existing Linux `.tar.gz`/AppImage. Built by a
+  new cross-platform workflow. Installers are currently unsigned (see the README Download section).
+
 ### Documentation
 - README and `CITATION.cff` reframed as a multi-ISA CPU-architecture simulator that foreshadows the RISC-V
   backend (was described as MIPS-only). (#61)
+- README gains a Download section listing per-platform assets and how to clear the Gatekeeper/SmartScreen
+  warnings on the unsigned builds.
 
 ### CI / Internal
 - `update-changelog.yml` now opens a pull request into `develop` instead of pushing directly, so the CHANGELOG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,53 @@ install(FILES
 )
 
 # ============================================================================
+# SELF-CONTAINED BUNDLING (Windows / macOS installers)
+# ============================================================================
+# For standalone Windows/macOS installers the Qt runtime must ship inside the
+# package so the app launches on a machine with no system Qt. OFF by default so
+# Linux DEB/RPM (which declare Qt as a package dependency), the AppImage flow,
+# and plain developer installs are unaffected; the cross-platform release
+# workflow turns it ON.
+option(CLEARCORE_BUNDLE_QT "Bundle the Qt runtime into the install tree / installers" OFF)
+
+if (CLEARCORE_BUNDLE_QT AND (BUILD_QT6_UI OR BUILD_QT6_QUICK_UI))
+    # On macOS the GUI apps must be .app bundles for macdeployqt and the .dmg.
+    if (APPLE)
+        foreach (gui_target clearCore-gui clearCore-quick)
+            if (TARGET ${gui_target})
+                set_target_properties(${gui_target} PROPERTIES MACOSX_BUNDLE ON)
+            endif ()
+        endforeach ()
+    endif ()
+
+    # On Windows, also drag in the MSVC runtime redistributable DLLs.
+    if (WIN32)
+        set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ${CMAKE_INSTALL_BINDIR})
+        include(InstallRequiredSystemLibraries)
+    endif ()
+
+    # qt_generate_deploy_app_script hooks windeployqt/macdeployqt into
+    # `cmake --install`, so CPack automatically gathers Qt (and, for the QML
+    # app, its QML imports) next to the executables.
+    if (TARGET clearCore-gui)
+        qt_generate_deploy_app_script(
+                TARGET clearCore-gui
+                OUTPUT_SCRIPT deploy_clearcore_gui
+                NO_UNSUPPORTED_PLATFORM_ERROR
+        )
+        install(SCRIPT ${deploy_clearcore_gui})
+    endif ()
+    if (TARGET clearCore-quick)
+        qt_generate_deploy_app_script(
+                TARGET clearCore-quick
+                OUTPUT_SCRIPT deploy_clearcore_quick
+                NO_UNSUPPORTED_PLATFORM_ERROR
+        )
+        install(SCRIPT ${deploy_clearcore_quick})
+    endif ()
+endif ()
+
+# ============================================================================
 # PACKAGING (CPack)
 # ============================================================================
 #
@@ -714,10 +761,36 @@ set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 
-# Portable compressed archive by default; DEB/RPM are opt-in via `cpack -G`.
+# Default generator per platform (overridable with `cpack -G`): a native
+# installer on Windows/macOS, a portable archive elsewhere.
 if (NOT CPACK_GENERATOR)
-    set(CPACK_GENERATOR "TGZ")
+    if (WIN32)
+        set(CPACK_GENERATOR "NSIS")
+    elseif (APPLE)
+        set(CPACK_GENERATOR "DragNDrop")
+    else ()
+        set(CPACK_GENERATOR "TGZ")
+    endif ()
 endif ()
+
+# ── Windows NSIS installer ──────────────────────────────────────────────────
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "clearCore")
+set(CPACK_NSIS_PACKAGE_NAME "clearCore")
+set(CPACK_NSIS_DISPLAY_NAME "clearCore")
+set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+set(CPACK_NSIS_URL_INFO_ABOUT "${CPACK_PACKAGE_HOMEPAGE_URL}")
+# Start-menu / desktop shortcuts. Pairs of <exe-without-extension> ; <label>.
+# The TUI is a console program, so it gets no GUI shortcut.
+set(CPACK_PACKAGE_EXECUTABLES
+        "clearCore-gui"   "clearCore (Qt Widgets)"
+        "clearCore-quick" "clearCore (QML)"
+)
+set(CPACK_NSIS_CREATE_ICONS_EXTRA
+        "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\clearCore (Qt Widgets).lnk' '$INSTDIR\\\\${CMAKE_INSTALL_BINDIR}\\\\clearCore-gui.exe'"
+)
+
+# ── macOS drag-and-drop .dmg ────────────────────────────────────────────────
+set(CPACK_DMG_VOLUME_NAME "clearCore ${PROJECT_VERSION}")
 
 # Source packages (`cpack --config CPackSourceConfig.cmake`) exclude build
 # output, VCS, and IDE metadata.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ front ends and every visualizer unchanged.
 
 *(clearCore began life as a live number-system converter — that converter is still the first tab of the terminal UI.)*
 
+## Download
+
+Prebuilt binaries are attached to every [release](https://github.com/khenderson20/clearCore/releases/latest):
+
+| Platform | Asset | Notes |
+|----------|-------|-------|
+| **Windows** | `clearCore-<ver>-windows-x64.exe` | NSIS installer, Qt bundled |
+| **macOS** (Intel + Apple Silicon) | `clearCore-<ver>-macOS-universal.dmg` | Universal binary, Qt bundled |
+| **Linux** | `clearCore-<ver>-Linux-x86_64.tar.gz`, `.AppImage`, `.deb`/`.rpm` | AppImage is self-contained |
+
+> **These builds are unsigned**, so the OS will warn on first launch — this is expected, not a problem with the download:
+> - **macOS**: right-click the app → **Open** → **Open** (clears Gatekeeper once). Or *System Settings → Privacy & Security → Open Anyway*.
+> - **Windows**: on the SmartScreen prompt, click **More info** → **Run anyway**.
+
+Prefer to build it yourself? Read on.
+
 ## Quick Start
 
 You need a **C++20 compiler** (GCC 13+ / Clang 16+) and **CMake 3.25+**. The terminal UI's FTXUI library is fetched


### PR DESCRIPTION
## Summary

Ship **Windows and macOS binaries** with each release, alongside the existing Linux `.tar.gz`/AppImage. A new `cross-platform.yml` workflow builds, tests, packages, and (on a published release) attaches:

- **Windows**: `clearCore-<ver>-windows-x64.exe` — NSIS installer, MSVC build, Qt bundled via `windeployqt`
- **macOS**: `clearCore-<ver>-macOS-universal.dmg` — **universal** (arm64 + x86_64), Qt bundled via `macdeployqt`

**No source changes** — the app already compiled cross-platform (only `gdb_stub.cpp` is POSIX-specific and CMake auto-disables it on Windows). Everything here is CI + CMake packaging.

## How it works

- `CLEARCORE_BUNDLE_QT` (default **OFF**) marks the GUIs as macOS `.app` bundles, pulls in the MSVC runtime, and runs `qt_generate_deploy_app_script` so `cmake --install`/CPack bundle the Qt runtime + QML imports. Linux DEB/RPM/AppImage and dev installs are unaffected.
- CPack per-platform defaults: **NSIS** (Windows), **DragNDrop/.dmg** (macOS).
- macOS is built once on Apple Silicon with `CMAKE_OSX_ARCHITECTURES=arm64;x86_64` (Qt's macOS binaries are universal), avoiding the scarce/deprecating Intel runner. A `lipo` step asserts the result is genuinely fat.

## Fixes made along the way (all CI/build)

- Windows: use `msvc-dev-cmd` + Ninja (the VS generator failed to discover VS 18 on the runner).
- macOS: `MACOSX_DEPLOYMENT_TARGET=13.3` (libc++'s `std::format`/`to_chars` floor).
- `fetch-depth: 0` so QADS's `git describe`-based Windows version resource compiles (was `RC2127`).
- NSIS install hardened with retries + presence check (survived a Chocolatey 503).

## Verification

- ✅ Windows + universal macOS build **and pass the test suite**
- ✅ `lipo` confirms the macOS binary is arm64 + x86_64
- ✅ Installers produced as artifacts: `.exe` (48 MB) and `.dmg` (53 MB), Qt bundled
- The release-upload path mirrors the proven Linux `release.yml`; it runs on the next published release.

## Notes

- **Unsigned** installers → Gatekeeper/SmartScreen warnings; the README **Download** section documents the "right-click → Open" / "More info → Run anyway" steps. Paid-cert signing/notarization is a future follow-up.
- Workflow triggers: `workflow_dispatch` + `release: published` (the iteration-only branch push trigger was removed).

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build / CI / tooling

## Checklist

- [x] Branch is based on and targets `develop`
- [x] Core libraries include no UI headers (n/a — no code change)
- [x] Docs / CHANGELOG updated (README Download section + CHANGELOG Added entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)