### PR TITLE
fix: make packaged Linux binaries runnable

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -122,6 +122,29 @@ jobs:
             exit 1
           fi
 
+      # The AppImage's default entry point is the GUI, but the TUI
+      # (number_system_converter) ships inside it too — and it was the binary
+      # hit by the -O3 startup crash. Extract the AppImage and launch the bundled
+      # TUI directly so that class of bug is caught on this artifact as well. It
+      # needs no display; feed EOF on stdin and treat a timeout (still running)
+      # or a clean exit as healthy, any crash signal as failure.
+      - name: Smoke test the bundled TUI
+        run: |
+          APPIMAGE="clearCore-${{ steps.ver.outputs.version }}-x86_64.AppImage"
+          "./$APPIMAGE" --appimage-extract >/dev/null
+          tui="squashfs-root/usr/bin/number_system_converter"
+          [ -x "$tui" ] || { echo "::error::number_system_converter not bundled in the AppImage"; exit 1; }
+          set +e
+          timeout 20 "$tui" </dev/null >tui.log 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -ge 128 ] && [ "$rc" -ne 124 ]; then
+            echo "::error::number_system_converter crashed on launch (signal $((rc - 128)))"
+            cat tui.log || true
+            exit 1
+          fi
+          echo "✓ number_system_converter launched without crashing (exit $rc)"
+
       - name: Upload workflow artifact (always)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -153,6 +153,58 @@ jobs:
             build/release/*.dmg
           if-no-files-found: error
 
+      # Launch both binaries from the *deployed install tree* — the bundled
+      # layout CPack packages, with the Qt runtime copied in by windeployqt/
+      # macdeployqt at install time — so a missing bundled dependency or an
+      # optimizer-only crash fails the release instead of shipping. This is the
+      # Windows/macOS counterpart to the Linux release job's tarball smoke test.
+      # Runs after the artifact upload (broken build still downloadable) but
+      # before the release attach, so broken binaries are never published.
+      - name: Smoke-test packaged binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          stage="$PWD/smoke-stage"
+          cmake --install build/release --prefix "$stage"
+          echo "── install tree ──"; find "$stage" -maxdepth 3 -type f | sort
+
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            gui="$stage/bin/clearCore-gui.exe"
+            tui="$stage/bin/number_system_converter.exe"
+          else
+            gui="$(find "$stage" -type f -path '*clearCore-gui.app/Contents/MacOS/clearCore-gui' | head -1)"
+            tui="$stage/bin/number_system_converter"
+          fi
+
+          # Launch each binary and watch it for a few seconds. A crash or a
+          # failure to start (missing DLL / framework / plugin) exits early with
+          # a nonzero code; a healthy GUI or TUI stays in its event loop until we
+          # stop it. No display is forced — deployqt bundles the native platform
+          # plugin (cocoa/qwindows), not offscreen, so the app runs on the
+          # runner's own session.
+          smoke() {
+            local name="$1" bin="$2"
+            [ -x "$bin" ] || { echo "::error::$name missing at $bin"; return 1; }
+            "$bin" </dev/null >"$name.log" 2>&1 &
+            local pid=$! i=0
+            while kill -0 "$pid" 2>/dev/null; do
+              sleep 1; i=$((i + 1))
+              if [ "$i" -ge 12 ]; then
+                kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+                echo "✓ $name survived ${i}s without crashing"; return 0
+              fi
+            done
+            local rc=0; wait "$pid" || rc=$?
+            if [ "$rc" -eq 0 ]; then echo "✓ $name exited cleanly"; return 0; fi
+            echo "::error::$name exited early with code $rc (crash or missing dependency)"
+            cat "$name.log" || true; return 1
+          }
+
+          fail=0
+          smoke number_system_converter "$tui" || fail=1
+          smoke clearCore-gui "$gui" || fail=1
+          exit "$fail"
+
       - name: Attach installer to the release
         if: github.event_name == 'release'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,55 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
+      # Launch both binaries from the *extracted package* — not the build tree —
+      # so runtime breakage that only appears in the shipped layout fails the
+      # release instead of reaching users. Runs after the artifact upload (so a
+      # broken build is still downloadable for debugging) but before the release
+      # attach, so broken binaries are never published. Regression guard for two
+      # v0.2.0 bugs: clearCore-gui shipped with no RUNPATH to bundled
+      # libqtadvanceddocking (unresolved only from the installed layout), and an
+      # -O3-only out-of-bounds write that segfaulted the TUI on launch.
+      - name: Smoke-test packaged binaries
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          tar -xzf "${{ github.workspace }}"/dist/*.tar.gz -C "$workdir"
+          root="$(cd "$(dirname "$(find "$workdir" -type f -name number_system_converter)")/.." && pwd)"
+          echo "Package root: $root"; find "$root" -maxdepth 2 -type f | sort
+
+          fail=0
+
+          # 1) Every dynamic dependency must resolve from the packaged layout —
+          #    catches a missing or wrong RPATH to a bundled shared library.
+          for bin in "$root"/bin/*; do
+            echo "── ldd $(basename "$bin") ──"
+            if ldd "$bin" 2>&1 | tee /tmp/ldd.txt | grep -i 'not found'; then
+              echo "::error::$(basename "$bin") has unresolved shared libraries"
+              fail=1
+            fi
+          done
+
+          # 2) Each binary must survive launch (the -O3 TUI bug crashed during
+          #    startup, before any input). Run headless with a timeout: a crash
+          #    exits 128+signal; a timeout (124) or clean exit is healthy. Qt uses
+          #    the offscreen platform so the GUI needs no display.
+          smoke() {
+            local bin="$1"; shift
+            local rc=0
+            QT_QPA_PLATFORM=offscreen timeout -s TERM 15s "$bin" "$@" \
+              </dev/null >/tmp/run.log 2>&1 || rc=$?
+            if [ "$rc" -ge 128 ] && [ "$rc" -ne 124 ]; then
+              echo "::error::$(basename "$bin") crashed on launch (signal $((rc - 128)))"
+              cat /tmp/run.log || true
+              return 1
+            fi
+            echo "✓ $(basename "$bin") launched without crashing (exit $rc)"
+          }
+          smoke "$root/bin/number_system_converter" || fail=1
+          smoke "$root/bin/clearCore-gui"           || fail=1
+
+          exit "$fail"
+
       - name: Attach to the GitHub release
         if: github.event_name == 'release'
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,18 @@ if (BUILD_QT6_UI)
             MACOSX_BUNDLE ON          # Create .app bundle on macOS
     )
 
+    # The Qt Advanced Docking System is a shared library; CPack installs it to
+    # lib/ next to the bin/ binary. Without an install RPATH the packaged
+    # clearCore-gui has no way to find libqtadvanceddocking-qt6.so.4 at runtime
+    # ("cannot open shared object file"). Point it at ../lib relative to the
+    # executable so the plain .tar.gz runs without LD_LIBRARY_PATH. (lib64 is
+    # covered too for distros/GNUInstallDirs that use it.)
+    if (UNIX AND NOT APPLE)
+        set_target_properties(clearCore-gui PROPERTIES
+                INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../lib64"
+        )
+    endif ()
+
     target_include_directories(clearCore-gui PRIVATE include)
     target_compile_features(clearCore-gui PUBLIC cxx_std_20)
     target_link_libraries(clearCore-gui

--- a/src/nsc/ui.cpp
+++ b/src/nsc/ui.cpp
@@ -529,10 +529,19 @@ static void runSplash() {
     std::vector<Kind>        kind(static_cast<size_t>(kRows) * kCols, Kind::Empty);
 
     auto idx = [&](int x, int y) { return y * kCols + x; };
+    // The trace generators below intentionally draw past the grid (a via or bend
+    // can land a row or two outside kRows/kCols) and rely on put() to clip those
+    // writes. The coordinate guard alone is enough at -O0/-O2, but in the -O3
+    // Release build an out-of-grid coordinate slips past it and reaches the
+    // vector write, corrupting the heap (segfault on launch in the packaged
+    // binary; a Debug build is unaffected). Bounding the linear index against the
+    // actual buffer size closes the hole and keeps the clip effective at -O3.
     auto put = [&](int x, int y, const std::string& ch, Kind k) {
         if (x < 0 || x >= kCols || y < 0 || y >= kRows) return;
-        glyph[idx(x, y)] = ch;
-        kind[idx(x, y)]  = k;
+        const size_t i = static_cast<size_t>(idx(x, y));
+        if (i >= glyph.size()) return;
+        glyph[i] = ch;
+        kind[i]  = k;
     };
     auto putStr = [&](int x0, int y, const std::string& s, Kind k) {
         for (size_t i = 0; i < s.size(); ++i) {


### PR DESCRIPTION
## Problem

The published **v0.2.0 Linux `.tar.gz` shipped two binaries that fail immediately** when run from the extracted package:

```
$ ./clearCore-gui
error while loading shared libraries: libqtadvanceddocking-qt6.so.4: cannot open shared object file
$ ./number_system_converter
Segmentation fault (core dumped)
```

## Root causes

**1. `clearCore-gui` — no RUNPATH.** The Qt Advanced Docking System is a shared lib and *is* shipped (in `lib/`), but the binary was linked with no RUNPATH, so the loader never looks in `../lib`. `LD_LIBRARY_PATH=lib ./clearCore-gui` resolves fine.

**2. `number_system_converter` — `-O3`-only out-of-bounds heap write.** `runSplash()`'s trace generators (`traceDown`/`traceUp`) intentionally draw a row or two past the grid and rely on `put()`'s coordinate guard to clip. Under `-O3` an out-of-grid coordinate (e.g. `y=29` → index 2747 into a 2632-element buffer) reaches the vector write and corrupts the heap. Debug and `-O2`/RelWithDebInfo are unaffected — which is exactly why it passed CI and shipped. Pinned with an `-O3 -g` build under gdb:
```
#14 put(...) at src/nsc/ui.cpp:534   x=21, y=29   ← OOB write
```

## Fixes

- **CMake:** `INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../lib64"` on `clearCore-gui` (Linux). Both paths because the release runner installs to `lib/` and some distros use `lib64/`.
- **TUI:** bound the linear index against `glyph.size()` in `put()` so the clip holds under `-O3`. No-op whenever the original guard was already correct, so rendering is unchanged.

## CI regression guard (all platforms)

New *Smoke-test packaged binaries* step that launches both binaries and fails the release if either can't resolve its dependencies or crashes on launch. Runs after the artifact upload (broken build still downloadable) but before the release attach, so **broken binaries are never published**.

- **Linux (`release.yml`):** extracts the CPack `.tar.gz`, runs `ldd` on each binary (fails on any unresolved lib) and launches each headless (`QT_QPA_PLATFORM=offscreen`, timeout) checking for crash signals.
- **Windows + macOS (`cross-platform.yml`):** installs the Release build to a staging prefix — the deployed, Qt-bundled layout CPack packages via windeployqt/macdeployqt — and launches both binaries. A crash or failed start (missing DLL/framework) exits early with a nonzero code; a healthy GUI/TUI stays in its event loop until stopped.

## Verification

Against the real v0.2.0 vs fixed binaries:

| Check | Buggy v0.2.0 | Fixed |
|-------|--------------|-------|
| `ldd` clearCore-gui | `libqtadvanceddocking… not found` | all resolved |
| launch number_system_converter | SIGSEGV (rc 139) | runs, timeout / survives |

Both smoke mechanisms (the Linux `timeout`-based one and the cross-platform background-poll one) were validated locally against the crashing release binary and the fixed build.

**Caveat:** both `release.yml` and `cross-platform.yml` only run on `release: published` / `workflow_dispatch`, so these smoke steps don't execute on this PR's checks — they gate the next release. The Linux logic is locally validated; the Windows/macOS steps couldn't be exercised locally and will get their first real run on dispatch/release.

## Follow-up

The v0.2.0 assets are broken; these fixes warrant a **v0.2.1 PATCH** and a re-run of `release.yml` + `cross-platform.yml` to regenerate assets — which will also be the first live exercise of the new smoke steps.