### PR TITLE
fix: GUI renders empty/squished — restore dock panel content + harden layout restore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,7 @@ if (BUILD_QT6_UI)
             src/nsc_qt/examples.cpp
             src/nsc_qt/simulator_controller.cpp
             src/nsc_qt/main_window.cpp
+            src/nsc_qt/dock_panels.cpp
             src/nsc_qt/preferences_dialog.cpp
             src/nsc_qt/widgets/code_editor.cpp
             src/nsc_qt/widgets/datapath_widget.cpp
@@ -576,6 +577,7 @@ if (BUILD_QT6_UI)
             tests/qt_ui/qt_ui_test.cpp
             src/nsc_qt/assembler.cpp
             src/nsc_qt/simulator_controller.cpp
+            src/nsc_qt/dock_panels.cpp                       # dock-content invariant under test
             src/nsc_qt/widgets/register_widget.cpp
             src/nsc_qt/widgets/memory_widget.cpp
             src/nsc_qt/widgets/pipeline_trace_widget.cpp
@@ -590,6 +592,7 @@ if (BUILD_QT6_UI)
             Qt6::Widgets
             mips_core
             QHexView  # memory_widget.cpp is compiled into the test
+            ads::qtadvanceddocking-qt6  # dock_panels.cpp exercises the docking API
             clearcore_warnings
     )
     target_compile_features(qt_ui_test PUBLIC cxx_std_20)

--- a/include/nsc_qt/dock_panels.h
+++ b/include/nsc_qt/dock_panels.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QString>
+
+namespace ads {
+class CDockManager;
+class CDockAreaWidget;
+class CDockWidget;
+}  // namespace ads
+
+class QWidget;
+
+namespace nsc::qt {
+
+// Creates a dock named `title` that holds `contents`, tabbed into `area` (or, if
+// `area` is null, starting a new central dock area and assigning it to `area`).
+// Returns the created dock.
+//
+// This centralizes the "a panel is a dock that carries its content widget"
+// invariant in one tested place. A regression here (e.g. dropping setWidget)
+// once shipped an all-panels-empty GUI, because the content widgets were left
+// orphaned in the QMainWindow instead of placed inside their docks — see
+// qt_ui_test's dock-content check.
+ads::CDockWidget* addDockPanel(ads::CDockManager* manager, ads::CDockAreaWidget*& area,
+                               const QString& title, QWidget* contents);
+
+}  // namespace nsc::qt

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -2,8 +2,10 @@
 
 #include "mips/processor.h"
 #include "nsc_qt/simulator_controller.h"
+#include <QByteArray>
 #include <QMainWindow>
 #include <memory>
+#include <vector>
 
 class QLabel;
 class QComboBox;
@@ -58,6 +60,13 @@ private:
     void setupConnections();
     void applyColorScheme(bool dark);
 
+    // Restore the default (first-run) dock arrangement — backs View > Reset
+    // Layout and the corrupt-state fallback in setupCentralWidget().
+    void resetLayout();
+    // True if at least one dock panel is open; a restored layout with none is
+    // degenerate (an empty window) and must be discarded.
+    bool hasOpenPanel() const;
+
     QWidget* createCodeEditorTab();
     QWidget* createStatisticsTab();
 
@@ -77,7 +86,8 @@ private:
     std::unique_ptr<SimulatorController> controller_;
 
     // Widgets
-    ads::CDockManager*   dock_manager_    = nullptr;
+    ads::CDockManager*   dock_manager_ = nullptr;
+    QByteArray           default_layout_;             // snapshot of the first-run arrangement
     QMenu*               panels_menu_     = nullptr;  // View > Panels toggle actions
     DatapathWidget*      datapath_widget_ = nullptr;
     RegisterWidget*      register_widget_ = nullptr;

--- a/src/nsc_qt/dock_panels.cpp
+++ b/src/nsc_qt/dock_panels.cpp
@@ -1,0 +1,22 @@
+#include "nsc_qt/dock_panels.h"
+
+#include <DockAreaWidget.h>
+#include <DockManager.h>
+#include <DockWidget.h>
+
+namespace nsc::qt {
+
+ads::CDockWidget* addDockPanel(ads::CDockManager* manager, ads::CDockAreaWidget*& area,
+                               const QString& title, QWidget* contents) {
+    auto* dock = new ads::CDockWidget(manager, title);
+    dock->setObjectName(title);
+    dock->setWidget(contents);  // the content must live inside the dock; without
+                                // this the panel renders empty (orphaned widget)
+    if (area == nullptr)
+        area = manager->addDockWidget(ads::CenterDockWidgetArea, dock);
+    else
+        manager->addDockWidgetTabToArea(dock, area);
+    return dock;
+}
+
+}  // namespace nsc::qt

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -2,6 +2,7 @@
 #include "nsc_qt/ui_scale.h"
 
 #include "nsc_qt/assembler.h"
+#include "nsc_qt/dock_panels.h"
 #include "nsc_qt/examples.h"
 #include "nsc_qt/preferences_dialog.h"
 #include "nsc_qt/widgets/code_editor.h"
@@ -44,6 +45,14 @@
 #include <DockWidget.h>
 
 namespace nsc::qt {
+
+namespace {
+// Schema version for the persisted dock layout. Bump this whenever the set of
+// docks or the default arrangement changes: ADS restoreState() rejects a saved
+// state tagged with a different version, so stale/incompatible layouts are
+// dropped instead of being rebuilt into a broken window.
+constexpr int kLayoutVersion = 1;
+}  // namespace
 
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent),
@@ -93,6 +102,7 @@ void MainWindow::setupMenuBar() {
     // Filled with per-dock toggle actions once the docks exist
     // (setupCentralWidget runs after this).
     panels_menu_ = view_menu->addMenu(tr("P&anels"));
+    view_menu->addAction(tr("&Reset Layout"), this, &MainWindow::resetLayout);
     view_menu->addSeparator();
     view_menu->addAction(tr("&Preferences…"), QKeySequence("Ctrl+,"), this,
                          &MainWindow::onShowPreferences);
@@ -143,12 +153,7 @@ void MainWindow::setupCentralWidget() {
 
     ads::CDockAreaWidget* area      = nullptr;
     const auto            add_panel = [&](const QString& title, QWidget* contents) {
-        auto* dock = new ads::CDockWidget(dock_manager_, title);
-        dock->setObjectName(title);
-        if (area == nullptr)
-            area = dock_manager_->addDockWidget(ads::CenterDockWidgetArea, dock);
-        else
-            dock_manager_->addDockWidgetTabToArea(dock, area);
+        auto* dock = addDockPanel(dock_manager_, area, title, contents);
         panels_menu_->addAction(dock->toggleViewAction());
     };
 
@@ -160,12 +165,20 @@ void MainWindow::setupCentralWidget() {
     add_panel(tr("Statistics"), createStatisticsTab());
     area->setCurrentIndex(0);  // Datapath in front, as before
 
-    // Restore the dock arrangement from the previous session, if any.
-    // restoreState() only touches docks it can match by objectName, so a
-    // stale entry from an older version is ignored harmlessly.
+    // Snapshot the freshly-built default arrangement so we can fall back to it
+    // (and power View > Reset Layout) without reconstructing the docks.
+    default_layout_ = dock_manager_->saveState(kLayoutVersion);
+
+    // Restore the previous session's arrangement — defensively. ADS applies a
+    // saved state wholesale, so a stale (different kLayoutVersion) or corrupt
+    // one must not be trusted: version-gate it, and if the restore still leaves
+    // no panel open (e.g. every dock Closed with a zero-size central area — an
+    // empty window), discard it and reinstate the default.
     const QSettings s("nsc-qt", "clearCore-gui");
-    if (const auto state = s.value("dockLayout").toByteArray(); !state.isEmpty())
-        dock_manager_->restoreState(state);
+    if (const auto state = s.value("dockLayout").toByteArray(); !state.isEmpty()) {
+        if (!dock_manager_->restoreState(state, kLayoutVersion) || !hasOpenPanel())
+            dock_manager_->restoreState(default_layout_, kLayoutVersion);
+    }
 
     // Status bar
     status_cycles_lbl_ = new QLabel(tr("Cycles: 0"));
@@ -180,8 +193,20 @@ void MainWindow::setupCentralWidget() {
 
 void MainWindow::closeEvent(QCloseEvent* event) {
     QSettings s("nsc-qt", "clearCore-gui");
-    s.setValue("dockLayout", dock_manager_->saveState());
+    s.setValue("dockLayout", dock_manager_->saveState(kLayoutVersion));
     QMainWindow::closeEvent(event);
+}
+
+// View > Reset Layout: restore the default arrangement captured on first build.
+void MainWindow::resetLayout() {
+    if (!default_layout_.isEmpty()) dock_manager_->restoreState(default_layout_, kLayoutVersion);
+}
+
+bool MainWindow::hasOpenPanel() const {
+    const auto docks = dock_manager_->dockWidgetsMap();
+    for (auto* dock : docks)
+        if (dock != nullptr && !dock->isClosed()) return true;
+    return false;
 }
 
 QWidget* MainWindow::createCodeEditorTab() {

--- a/src/nsc_qt/widgets/code_editor.cpp
+++ b/src/nsc_qt/widgets/code_editor.cpp
@@ -3,6 +3,7 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QTextBlock>
+#include <algorithm>
 
 #ifdef HAVE_KSYNTAXHIGHLIGHTING
 #include <KSyntaxHighlighting/Definition>
@@ -44,7 +45,7 @@ CodeEditor::CodeEditor(QWidget* parent) : QPlainTextEdit(parent) {
 
 int CodeEditor::lineNumberAreaWidth() const {
     int digits    = 1;
-    int max_block = qMax(1, blockCount());
+    int max_block = (std::max)(1, blockCount());
     while (max_block >= 10) {
         max_block /= 10;
         ++digits;

--- a/src/nsc_qt/widgets/datapath_widget.cpp
+++ b/src/nsc_qt/widgets/datapath_widget.cpp
@@ -18,6 +18,8 @@
 #include <QVBoxLayout>
 #include <algorithm>
 #include <sstream>
+#include <string>
+#include <unordered_set>
 
 namespace nsc::qt {
 
@@ -187,9 +189,9 @@ QRect DatapathWidget::stageRect(int idx) const {
     const int avail_h = height() - TITLE_H - BOTTOM_H;
 
     // Gap scales: ~4.5% of available width per gap, min 16px
-    const int gap = std::max(GAP_MIN, avail_w / 22);
+    const int gap = (std::max)(GAP_MIN, avail_w / 22);
     // Box width fills remaining space equally across 5 stages
-    const int box_w = std::max(BOX_W_MIN, (avail_w - 4 * gap) / 5);
+    const int box_w = (std::max)(BOX_W_MIN, (avail_w - 4 * gap) / 5);
     // Height: 80% of box width, clamped so it fits vertically
     const int box_h = std::clamp(box_w * 4 / 5, BOX_H_MIN, avail_h);
 
@@ -251,7 +253,7 @@ void DatapathWidget::drawStageBox(QPainter& p, int idx, const mips::StageSnapsho
     p.drawRoundedRect(r, 6, 6);
 
     // ── Header band ────────────────────────────────────────────────────────────
-    const int   header_h = std::max(24, r.height() / 4);
+    const int   header_h = (std::max)(24, r.height() / 4);
     const QRect header_r(r.x(), r.y(), r.width(), header_h);
 
     // Clip to box so rounded corners at top are preserved
@@ -267,7 +269,7 @@ void DatapathWidget::drawStageBox(QPainter& p, int idx, const mips::StageSnapsho
 
     // Stage name -- clamped to the shared scale rather than an ad hoc
     // width-derived size (audit Warning: no modular scale / too-small text).
-    const int name_font_size = std::max(scale::kFontSizeBody, r.width() / 14);
+    const int name_font_size = (std::max)(scale::kFontSizeBody, r.width() / 14);
     p.setPen(dark_mode_ ? Qt::white : Qt::black);
     p.setFont(scale::monoFont(name_font_size, true));
     p.drawText(header_r, Qt::AlignCenter, QString(STAGE_NAMES[idx]));
@@ -275,7 +277,7 @@ void DatapathWidget::drawStageBox(QPainter& p, int idx, const mips::StageSnapsho
     // ── Inactive state ─────────────────────────────────────────────────────────
     if (!snap.valid) {
         p.setPen(dark_mode_ ? QColor(0x66, 0x66, 0x66) : QColor(0xAA, 0xAA, 0xAA));
-        p.setFont(scale::monoFont(std::max(scale::kFontSizeDense, r.width() / 18)));
+        p.setFont(scale::monoFont((std::max)(scale::kFontSizeDense, r.width() / 18)));
         p.drawText(r.adjusted(0, header_h, 0, 0), Qt::AlignCenter,
                    snap.stalled   ? tr("STALL")
                    : snap.flushed ? tr("FLUSH")
@@ -285,8 +287,8 @@ void DatapathWidget::drawStageBox(QPainter& p, int idx, const mips::StageSnapsho
 
     // ── Content area ───────────────────────────────────────────────────────────
     const int content_top  = r.y() + header_h + 4;
-    const int content_pad  = std::max(4, r.width() / 30);
-    const int body_font_sz = std::max(scale::kFontSizeDense, r.width() / 18);
+    const int content_pad  = (std::max)(4, r.width() / 30);
+    const int body_font_sz = (std::max)(scale::kFontSizeDense, r.width() / 18);
 
     // PC label
     p.setPen(dark_mode_ ? QColor(0x9C, 0xDC, 0xFE) : QColor(0x00, 0x52, 0x9B));
@@ -336,7 +338,7 @@ void DatapathWidget::drawForwardingArrows(QPainter& p) const {
         const int    arc_y  = from_r.top() - 10;
         const QPoint start(from_r.center().x(), arc_y);
         const QPoint end(to_r.center().x(), arc_y);
-        const int    lift = std::max(20, (from_r.top() - 34) / 2);
+        const int    lift = (std::max)(20, (from_r.top() - 34) / 2);
 
         QPainterPath path;
         path.moveTo(start);

--- a/tests/qt_ui/qt_ui_test.cpp
+++ b/tests/qt_ui/qt_ui_test.cpp
@@ -1,4 +1,5 @@
 #include "nsc_qt/assembler.h"
+#include "nsc_qt/dock_panels.h"
 #include "nsc_qt/simulator_controller.h"
 #include "nsc_qt/widgets/memory_widget.h"
 #include "nsc_qt/widgets/pipeline_trace_widget.h"
@@ -6,10 +7,17 @@
 
 #include "mips/pipelined_cpu.h"
 
+#include <DockAreaWidget.h>
+#include <DockManager.h>
+#include <DockWidget.h>
 #include <QApplication>
+#include <QLabel>
+#include <QMainWindow>
 #include <cassert>
 #include <cstdio>
 #include <memory>
+#include <string>
+#include <utility>
 
 // ── Minimal test harness ──────────────────────────────────────────────────────
 
@@ -195,6 +203,33 @@ static void test_trace_widget_clear() {
     CHECK(true);
 }
 
+// ── Dock panels ───────────────────────────────────────────────────────────────
+
+// Regression guard: every panel added via addDockPanel() must actually carry
+// its content widget. A dropped setWidget() once shipped a GUI where all panels
+// rendered empty (the content widgets were orphaned in the QMainWindow), and
+// nothing caught it because the smoke test only checked that the app launched.
+static void test_dock_panels_carry_content() {
+    using namespace nsc::qt;
+
+    auto  main_window = std::make_unique<QMainWindow>();
+    auto* manager     = new ads::CDockManager(main_window.get());
+
+    ads::CDockAreaWidget* area  = nullptr;
+    auto*                 first = new QLabel("first");
+    auto*                 tab   = new QLabel("tab");
+
+    auto* dock_a = addDockPanel(manager, area, "First", first);
+    auto* dock_b = addDockPanel(manager, area, "Tabbed", tab);
+
+    // The content must be inside the dock, not orphaned.
+    CHECK(dock_a->widget() == first);
+    CHECK(dock_b->widget() == tab);
+    // First call opens a central area; the second tabs into the same one.
+    CHECK(area != nullptr);
+    CHECK(manager->dockWidgetsMap().size() == 2);
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 int main(int argc, char* argv[]) {
@@ -209,6 +244,7 @@ int main(int argc, char* argv[]) {
     test_register_widget_clear();
     test_memory_widget_construct();
     test_trace_widget_clear();
+    test_dock_panels_carry_content();
 
     std::printf("%d passed, %d failed\n", g_pass, g_fail);
     return (g_fail == 0) ? 0 : 1;


### PR DESCRIPTION
## Symptom
clearCore-gui (and the AppImage) render as a broken/squished window: the Datapath appears as a short strip at top-left over a large empty area, with no working panels. Present in **every release** (v0.2.0–v0.2.2), on both the tarball (system Qt) and AppImage (bundled Qt).

![broken](https://user-images.githubusercontent.com/placeholder) <!-- see issue screenshot -->

## Root cause
Commit **`2c4d802`** ("Potential fix for pull request finding") deleted `dock->setWidget(contents)` from the panel-building code. Each ADS dock was then created **empty**, and the panel widgets (`datapath_widget_`, `register_widget_`, …) were left **orphaned as direct children of the `QMainWindow`**, painting at (0,0). The datapath, a `QOpenGLWidget`, composites its native surface on top — exactly the observed frame.

CI never caught it because the smoke test only verifies the app **launches**, not that it **renders**.

## Fix
- **Restore the content attachment**, extracted into `addDockPanel()` (`nsc_qt/dock_panels`), and cover it with a **qt_ui_test regression check** — verified it *fails* without `setWidget` and *passes* with it (constructs a real `CDockManager` under the offscreen platform, no GL needed).
- **Version-gate** the persisted layout (`kLayoutVersion`): a stale/incompatible saved state is now ignored rather than rebuilt into a broken window. This also **auto-recovers** users whose config was corrupted by the broken builds (their old `UserVersion=0` layout is rejected).
- **Validate after `restoreState()`**: if no panel is open (degenerate all-closed / zero-size layout), fall back to the default arrangement.
- **View → Reset Layout** menu action for manual recovery.

## Verification
- Launched the fixed build on a real display and screenshotted it: the intended six-panel tabbed layout renders correctly (Datapath fills the central area). Confirmed with the corrupt config still in place, proving the version-gate ignores it.
- `qt_ui_test` green; the new dock-content test fails if `setWidget` is dropped.

## Note on process
This is the class of bug the whole recent smoke-test effort was meant to prevent, but a launch-only smoke can't see rendering. The added unit test closes that specific gap at the source (the dock-content invariant), which is more reliable than screenshot diffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)