### PR TITLE
Feature/datapath schematic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ if (BUILD_QT6_UI)
             src/nsc_qt/preferences_dialog.cpp
             src/nsc_qt/widgets/code_editor.cpp
             src/nsc_qt/widgets/datapath_widget.cpp
+            src/nsc_qt/widgets/schematic_datapath_widget.cpp
             src/nsc_qt/widgets/register_widget.cpp
             src/nsc_qt/widgets/memory_widget.cpp
             src/nsc_qt/widgets/pipeline_trace_widget.cpp
@@ -374,6 +375,7 @@ if (BUILD_QT6_UI)
             include/nsc_qt/examples.h
             include/nsc_qt/widgets/code_editor.h
             include/nsc_qt/widgets/datapath_widget.h
+            include/nsc_qt/widgets/schematic_datapath_widget.h
             include/nsc_qt/widgets/register_widget.h
             include/nsc_qt/widgets/memory_widget.h
             include/nsc_qt/widgets/pipeline_trace_widget.h

--- a/include/nsc_qt/instr_format.h
+++ b/include/nsc_qt/instr_format.h
@@ -1,0 +1,75 @@
+#pragma once
+
+// ── instr_format.h ──────────────────────────────────────────────────────────
+// Shared "raw word → human-readable assembly" formatter for the datapath
+// visualizers. Moved out of datapath_widget.cpp so the schematic datapath
+// widget can reuse it without duplicating the format switch.
+
+#include "mips/decoder.h"
+#include "mips/registers.h"
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+namespace nsc::qt {
+
+// Format a decoded instruction as a human-readable string. This is assembly
+// notation (mnemonics, register names), not natural-language UI copy, so it
+// intentionally is not routed through tr().
+inline std::string format_instr(uint32_t raw) {
+    using namespace mips;
+    auto decoded = Decoder::decode(raw);
+    if (!decoded) return "(?/?)";
+    const auto&        d  = *decoded;
+    std::string        mn = std::string(Decoder::mnemonic(d));
+    std::ostringstream os;
+    os << mn << " ";
+    switch (d.format) {
+    case InstrFormat::R: {
+        const auto& r = d.r();
+        if (d.opcode == Opcode::SPECIAL) {
+            using F = FunctCode;
+            if (r.funct == F::SLL || r.funct == F::SRL || r.funct == F::SRA) {
+                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rt) << ", "
+                   << +r.shamt;
+            } else if (r.funct == F::JR) {
+                os << "$" << register_abi_name(r.rs);
+            } else if (r.funct == F::JALR) {
+                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs);
+            } else {
+                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs) << ", $"
+                   << register_abi_name(r.rt);
+            }
+        }
+        break;
+    }
+    case InstrFormat::I: {
+        const auto& i = d.i();
+        if (d.opcode == Opcode::LW || d.opcode == Opcode::LBU || d.opcode == Opcode::LHU ||
+            d.opcode == Opcode::SW) {
+            os << "$" << register_abi_name(i.rt) << ", " << static_cast<int16_t>(i.imm) << "($"
+               << register_abi_name(i.rs) << ")";
+        } else if (d.opcode == Opcode::LUI) {
+            os << "$" << register_abi_name(i.rt) << ", 0x" << std::hex << i.imm;
+        } else if (d.opcode == Opcode::BEQ || d.opcode == Opcode::BNE) {
+            os << "$" << register_abi_name(i.rs) << ", $" << register_abi_name(i.rt) << ", "
+               << static_cast<int16_t>(i.imm);
+        } else {
+            os << "$" << register_abi_name(i.rt) << ", $" << register_abi_name(i.rs) << ", "
+               << static_cast<int16_t>(i.imm);
+        }
+        break;
+    }
+    case InstrFormat::J: {
+        const auto& j = d.j();
+        os << "0x" << std::hex << j.target;
+        break;
+    }
+    default:
+        break;
+    }
+    return os.str();
+}
+
+}  // namespace nsc::qt

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -101,14 +101,15 @@ private:
     QLabel*                  asm_status_lbl_  = nullptr;
 
     // Statistics labels
-    QLabel* stat_cycles_lbl_   = nullptr;
-    QLabel* stat_instrs_lbl_   = nullptr;
-    QLabel* stat_cpi_lbl_      = nullptr;
-    QLabel* stat_data_haz_lbl_ = nullptr;
-    QLabel* stat_ctrl_haz_lbl_ = nullptr;
-    QLabel* stat_fwd_lbl_      = nullptr;
-    QLabel* stat_stalls_lbl_   = nullptr;
-    QLabel* stat_flushes_lbl_  = nullptr;
+    QLabel*  stat_cycles_lbl_   = nullptr;
+    QLabel*  stat_instrs_lbl_   = nullptr;
+    QLabel*  stat_cpi_lbl_      = nullptr;
+    QLabel*  stat_data_haz_lbl_ = nullptr;
+    QLabel*  stat_ctrl_haz_lbl_ = nullptr;
+    QLabel*  stat_fwd_lbl_      = nullptr;
+    QLabel*  stat_stalls_lbl_   = nullptr;
+    QLabel*  stat_flushes_lbl_  = nullptr;
+    QWidget* stat_cpi_card_     = nullptr;  // KPI card widget, re-colored by CPI health
 
     // Status bar labels
     QLabel* status_cycles_lbl_ = nullptr;

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -20,7 +20,7 @@ class CDockManager;
 
 namespace nsc::qt {
 
-class DatapathWidget;
+class SchematicDatapathWidget;
 class RegisterWidget;
 class MemoryWidget;
 class PipelineTraceWidget;
@@ -89,16 +89,16 @@ private:
     std::unique_ptr<SimulatorController> controller_;
 
     // Widgets
-    ads::CDockManager*   dock_manager_ = nullptr;
-    QByteArray           default_layout_;             // snapshot of the first-run arrangement
-    QMenu*               panels_menu_     = nullptr;  // View > Panels toggle actions
-    DatapathWidget*      datapath_widget_ = nullptr;
-    RegisterWidget*      register_widget_ = nullptr;
-    MemoryWidget*        memory_widget_   = nullptr;
-    PipelineTraceWidget* trace_widget_    = nullptr;
-    CodeEditor*          code_editor_     = nullptr;
-    QComboBox*           examples_combo_  = nullptr;
-    QLabel*              asm_status_lbl_  = nullptr;
+    ads::CDockManager*       dock_manager_ = nullptr;
+    QByteArray               default_layout_;             // snapshot of the first-run arrangement
+    QMenu*                   panels_menu_     = nullptr;  // View > Panels toggle actions
+    SchematicDatapathWidget* datapath_widget_ = nullptr;
+    RegisterWidget*          register_widget_ = nullptr;
+    MemoryWidget*            memory_widget_   = nullptr;
+    PipelineTraceWidget*     trace_widget_    = nullptr;
+    CodeEditor*              code_editor_     = nullptr;
+    QComboBox*               examples_combo_  = nullptr;
+    QLabel*                  asm_status_lbl_  = nullptr;
 
     // Statistics labels
     QLabel* stat_cycles_lbl_   = nullptr;

--- a/include/nsc_qt/widgets/schematic_datapath_widget.h
+++ b/include/nsc_qt/widgets/schematic_datapath_widget.h
@@ -1,0 +1,97 @@
+#pragma once
+
+// ── schematic_datapath_widget.h ─────────────────────────────────────────────
+// Ripes-style circuit-schematic view of the 5-stage MIPS pipeline, built on
+// QGraphicsView/QGraphicsScene (the same architecture Ripes' VSRTL renderer
+// uses). Functional units (PC, memories, register file, ALU, muxes, adders)
+// are QGraphicsItems laid out in a fixed logical coordinate space; wires are
+// orthogonal painter paths with arrowheads and junction dots.
+//
+// Live state binding (setPipelineState):
+//   • a mnemonic label above each stage column (like Ripes' top labels)
+//   • pipeline-register bars tint red on flush / amber on stall
+//   • forwarding wires light up when the fwd_* flags are set
+//   • the branch-target wire back to the PC mux lights red on branch_flush
+//
+// Public API and signals mirror DatapathWidget exactly so MainWindow can swap
+// between the two with a one-line change.
+
+#include "mips/processor.h"
+
+#include <QGraphicsView>
+#include <array>
+#include <cstdint>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+class QGraphicsScene;
+class QGraphicsEllipseItem;
+class QGraphicsRectItem;
+class QGraphicsSimpleTextItem;
+
+namespace nsc::qt {
+
+class WireItem;
+
+class SchematicDatapathWidget : public QGraphicsView {
+    Q_OBJECT
+
+public:
+    explicit SchematicDatapathWidget(QWidget* parent = nullptr);
+
+    void setPipelineState(const mips::PipelineState& state);
+    void setBreakpoints(const std::unordered_set<uint32_t>& bps);
+    void setDarkMode(bool dark);
+
+signals:
+    void breakpointToggleRequested(uint32_t pc);
+    void stageDetailRequested(int stage_index, uint32_t pc, uint32_t raw_instr);
+
+protected:
+    void wheelEvent(QWheelEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    void contextMenuEvent(QContextMenuEvent* ev) override;
+    void keyPressEvent(QKeyEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void focusInEvent(QFocusEvent* ev) override;
+    void focusOutEvent(QFocusEvent* ev) override;
+
+private:
+    // Scene construction (runs once; items are retained and re-themed).
+    void buildScene();
+    // Push state_ / dark_mode_ / breakpoints_ into the retained items.
+    void applyState();
+    void applyTheme();
+
+    // Stage column index (0–4) at a view position, or -1.
+    int stageAtViewPos(const QPoint& pos) const;
+    // Zoom-to-fit while the user hasn't zoomed manually.
+    void fitSchematic();
+
+    QGraphicsScene* scene_ = nullptr;
+
+    // Retained items updated per cycle / theme change.
+    std::array<QGraphicsSimpleTextItem*, 5> stage_labels_{};  // mnemonics above columns
+    std::array<QGraphicsRectItem*, 5>       stage_tints_{};   // translucent column bands
+    std::array<QGraphicsRectItem*, 4>       pipe_regs_{};     // IF/ID … MEM/WB bars
+    std::vector<WireItem*>                  wires_;           // all wires (for re-theme)
+    WireItem*                               fwd_exmem_wire_ = nullptr;
+    WireItem*          fwd_exmem_stub_ = nullptr;  // mux-B branch of the fwd bus
+    WireItem*          fwd_memwb_wire_ = nullptr;
+    WireItem*          fwd_memwb_stub_ = nullptr;
+    WireItem*          branch_wire_    = nullptr;
+    WireItem*          writeback_wire_ = nullptr;
+    QGraphicsRectItem* focus_ring_     = nullptr;
+    // Per-stage breakpoint bullseye (outer ring, punched-out centre).
+    std::array<std::pair<QGraphicsEllipseItem*, QGraphicsEllipseItem*>, 5> bp_markers_{};
+
+    mips::PipelineState          state_{};
+    std::unordered_set<uint32_t> breakpoints_{};
+    bool                         dark_mode_      = false;
+    bool                         user_zoomed_    = false;
+    int                          selected_stage_ = 0;
+};
+
+}  // namespace nsc::qt

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -6,10 +6,10 @@
 #include "nsc_qt/examples.h"
 #include "nsc_qt/preferences_dialog.h"
 #include "nsc_qt/widgets/code_editor.h"
-#include "nsc_qt/widgets/datapath_widget.h"
 #include "nsc_qt/widgets/memory_widget.h"
 #include "nsc_qt/widgets/pipeline_trace_widget.h"
 #include "nsc_qt/widgets/register_widget.h"
+#include "nsc_qt/widgets/schematic_datapath_widget.h"
 
 #include "mips/decoder.h"
 #include "mips/pipelined_cpu.h"
@@ -159,7 +159,7 @@ void MainWindow::setupCentralWidget() {
     ads::CDockManager::setConfigFlag(ads::CDockManager::DockAreaHasUndockButton, false);
     dock_manager_ = new ads::CDockManager(this);
 
-    datapath_widget_ = new DatapathWidget(this);
+    datapath_widget_ = new SchematicDatapathWidget(this);
     register_widget_ = new RegisterWidget(this);
     memory_widget_   = new MemoryWidget(this);
     trace_widget_    = new PipelineTraceWidget(this);
@@ -415,9 +415,9 @@ void MainWindow::setupConnections() {
         setRunState(false);
     });
 
-    connect(datapath_widget_, &DatapathWidget::breakpointToggleRequested, this,
+    connect(datapath_widget_, &SchematicDatapathWidget::breakpointToggleRequested, this,
             &MainWindow::onBreakpointToggle);
-    connect(datapath_widget_, &DatapathWidget::stageDetailRequested, this,
+    connect(datapath_widget_, &SchematicDatapathWidget::stageDetailRequested, this,
             &MainWindow::onStageDetailRequested);
 }
 

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -285,15 +285,15 @@ QWidget* MainWindow::createCodeEditorTab() {
                                         "#   add  $t2, $t0, $t1\n"));
     vl->addWidget(code_editor_);
 
-    // Separator line above button row
-    auto* sep = new QFrame(w);
-    sep->setFrameShape(QFrame::HLine);
-    sep->setFrameShadow(QFrame::Sunken);
-    vl->addWidget(sep);
-
-    auto* btn_row = new QHBoxLayout;
+    // Button toolbar row — given a named container so the QSS can set its
+    // background independently of the ADS dock area that hosts this panel.
+    auto* btn_bar = new QWidget(w);
+    btn_bar->setObjectName("codeEditorBtnBar");
+    btn_bar->setAutoFillBackground(true);
+    auto* btn_row = new QHBoxLayout(btn_bar);
     btn_row->setContentsMargins(8, 6, 8, 6);
     btn_row->setSpacing(8);
+    vl->addWidget(btn_bar);
 
     auto* asm_btn = new QPushButton(tr("Assemble"), w);
     asm_btn->setObjectName("primaryButton");
@@ -318,7 +318,7 @@ QWidget* MainWindow::createCodeEditorTab() {
     connect(examples_combo_, qOverload<int>(&QComboBox::activated), this,
             &MainWindow::onExampleSelected);
 
-    asm_status_lbl_ = new QLabel(w);
+    asm_status_lbl_ = new QLabel(btn_bar);
     asm_status_lbl_->setFont(scale::monoFont(scale::kFontSizeBody));
     btn_row->addWidget(asm_btn);
     btn_row->addWidget(load_btn);
@@ -327,7 +327,6 @@ QWidget* MainWindow::createCodeEditorTab() {
     btn_row->addSpacing(12);
     btn_row->addWidget(asm_status_lbl_);
     btn_row->addStretch();
-    vl->addLayout(btn_row);
 
     connect(asm_btn, &QPushButton::clicked, this, &MainWindow::onAssemble);
     connect(load_btn, &QPushButton::clicked, this, &MainWindow::onLoad);
@@ -360,39 +359,75 @@ void MainWindow::onExampleSelected(int idx) {
 }
 
 QWidget* MainWindow::createStatisticsTab() {
-    auto* w  = new QWidget;
+    auto* w = new QWidget;
+    w->setAutoFillBackground(true);
     auto* vl = new QVBoxLayout(w);
-    vl->setContentsMargins(16, 16, 16, 16);
+    vl->setContentsMargins(12, 12, 12, 12);
     vl->setSpacing(12);
 
-    auto mkLabel = [&](QFormLayout* fl, const QString& name, QLabel*& ptr) {
-        ptr = new QLabel("—", w);
-        ptr->setFont(scale::monoFont(scale::kFontSizeBody));
-        fl->addRow(name, ptr);
+    // ── KPI card row ──────────────────────────────────────────────────────────
+    // Three headline metrics in large-number "cards" for immediate readability.
+    // The CPI card background is color-coded (green/orange/red) in onStatisticsUpdated()
+    // and stored in stat_cpi_card_ for later updates. Values are mouse-selectable
+    // so students can copy numbers into lab reports without retyping.
+    auto mkCard = [&](const QString& label, QLabel*& val_ptr) -> QFrame* {
+        auto* card = new QFrame(w);
+        card->setFrameShape(QFrame::StyledPanel);
+        card->setObjectName("statCard");
+        auto* cl = new QVBoxLayout(card);
+        cl->setContentsMargins(12, 10, 12, 10);
+        cl->setSpacing(4);
+
+        val_ptr = new QLabel("—", card);
+        val_ptr->setAlignment(Qt::AlignCenter);
+        val_ptr->setFont(scale::monoFont(26, true));
+        val_ptr->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        auto* name_lbl = new QLabel(label, card);
+        name_lbl->setAlignment(Qt::AlignCenter);
+        name_lbl->setObjectName("statCardLabel");
+        name_lbl->setFont(scale::monoFont(scale::kFontSizeDense));
+
+        cl->addWidget(val_ptr);
+        cl->addWidget(name_lbl);
+        return card;
     };
 
-    // ── Performance group ──────────────────────────────────────────────────────
-    auto* perf_box = new QGroupBox(tr("Performance"), w);
-    auto* perf_fl  = new QFormLayout(perf_box);
-    perf_fl->setContentsMargins(12, 8, 12, 8);
-    perf_fl->setSpacing(8);
-    perf_fl->setLabelAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    mkLabel(perf_fl, tr("Cycles executed:"), stat_cycles_lbl_);
-    mkLabel(perf_fl, tr("Instructions retired:"), stat_instrs_lbl_);
-    mkLabel(perf_fl, tr("CPI:"), stat_cpi_lbl_);
-    vl->addWidget(perf_box);
+    auto* kpi_row = new QHBoxLayout;
+    kpi_row->setSpacing(8);
+    kpi_row->addWidget(mkCard(tr("Cycles"), stat_cycles_lbl_), 1);
+    kpi_row->addWidget(mkCard(tr("Instructions"), stat_instrs_lbl_), 1);
+    auto* cpi_card = mkCard(tr("CPI"), stat_cpi_lbl_);
+    cpi_card->setToolTip(tr("Cycles Per Instruction — lower is better\n"
+                            "1.0 = ideal (no stalls)   >2.0 = heavy pipeline overhead"));
+    stat_cpi_card_ = cpi_card;
+    kpi_row->addWidget(cpi_card, 1);
+    vl->addLayout(kpi_row);
 
-    // ── Pipeline events group ──────────────────────────────────────────────────
+    // ── Pipeline events ────────────────────────────────────────────────────────
     auto* pipe_box = new QGroupBox(tr("Pipeline Events"), w);
     auto* pipe_fl  = new QFormLayout(pipe_box);
-    pipe_fl->setContentsMargins(12, 8, 12, 8);
+    pipe_fl->setContentsMargins(12, 8, 12, 12);
     pipe_fl->setSpacing(8);
     pipe_fl->setLabelAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    mkLabel(pipe_fl, tr("Data hazards:"), stat_data_haz_lbl_);
-    mkLabel(pipe_fl, tr("Control hazards:"), stat_ctrl_haz_lbl_);
-    mkLabel(pipe_fl, tr("Forwarding events:"), stat_fwd_lbl_);
-    mkLabel(pipe_fl, tr("Stalls:"), stat_stalls_lbl_);
-    mkLabel(pipe_fl, tr("Flushes:"), stat_flushes_lbl_);
+
+    auto mkRow = [&](const QString& name, QLabel*& ptr, const QString& tip) {
+        ptr = new QLabel("—", pipe_box);
+        ptr->setFont(scale::monoFont(scale::kFontSizeBody));
+        ptr->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        ptr->setToolTip(tip);
+        pipe_fl->addRow(name, ptr);
+    };
+    mkRow(tr("Data hazards:"), stat_data_haz_lbl_,
+          tr("RAW (Read-After-Write) hazards detected in the Decode stage"));
+    mkRow(tr("Control hazards:"), stat_ctrl_haz_lbl_,
+          tr("Hazards from branches and jumps that disrupted the pipeline"));
+    mkRow(tr("Forwarding events:"), stat_fwd_lbl_,
+          tr("Times the forwarding unit bypassed the register file to resolve a data hazard"));
+    mkRow(tr("Stalls:"), stat_stalls_lbl_,
+          tr("Bubble cycles inserted for hazards that could not be resolved by forwarding"));
+    mkRow(tr("Flushes:"), stat_flushes_lbl_,
+          tr("Pipeline flushes caused by branch mispredictions or control hazards"));
     vl->addWidget(pipe_box);
 
     vl->addStretch();
@@ -582,14 +617,35 @@ void MainWindow::onStatisticsUpdated(nsc::qt::SimulatorStatistics stats) {
 
     if (cpi > 0) {
         stat_cpi_lbl_->setText(QString::number(cpi, 'f', 2));
-        const QColor cpi_color = cpi >= 2.0   ? QColor("#F44336")
-                                 : cpi >= 1.5 ? QColor("#FF9800")
-                                              : QColor("#4CAF50");
+        const QColor text_color = cpi >= 2.0   ? QColor("#F44336")
+                                  : cpi >= 1.5 ? QColor("#FF9800")
+                                               : QColor("#4CAF50");
         stat_cpi_lbl_->setStyleSheet(
-            QString("color: %1; font-weight: bold;").arg(cpi_color.name()));
+            QString("color: %1; font-weight: bold;").arg(text_color.name()));
+        // Color the card background to give a glanceable health signal even
+        // when the user isn't reading the exact number.
+        if (stat_cpi_card_) {
+            const QColor bg  = dark_mode_ ? (cpi >= 2.0   ? QColor("#3D1515")
+                                             : cpi >= 1.5 ? QColor("#3D2D10")
+                                                          : QColor("#152D15"))
+                                          : (cpi >= 2.0   ? QColor("#FFEBEE")
+                                             : cpi >= 1.5 ? QColor("#FFF3E0")
+                                                          : QColor("#E8F5E9"));
+            const QColor bdr = dark_mode_ ? (cpi >= 2.0   ? QColor("#7C2020")
+                                             : cpi >= 1.5 ? QColor("#7C5810")
+                                                          : QColor("#1E7C1E"))
+                                          : (cpi >= 2.0   ? QColor("#EF9A9A")
+                                             : cpi >= 1.5 ? QColor("#FFCC80")
+                                                          : QColor("#A5D6A7"));
+            stat_cpi_card_->setStyleSheet(
+                QString(
+                    "QFrame#statCard { background: %1; border: 1px solid %2; border-radius: 6px; }")
+                    .arg(bg.name(), bdr.name()));
+        }
     } else {
         stat_cpi_lbl_->setText("—");
         stat_cpi_lbl_->setStyleSheet("");
+        if (stat_cpi_card_) stat_cpi_card_->setStyleSheet("");
     }
 
     stat_data_haz_lbl_->setText(QString::number(stats.data_hazards));
@@ -715,6 +771,14 @@ void MainWindow::applyColorScheme(bool dark) {
         pal.setColor(QPalette::Button, QColor(0x3C, 0x3C, 0x3C));
         pal.setColor(QPalette::ButtonText, Qt::white);
         pal.setColor(QPalette::BrightText, Qt::red);
+        // 3D/bevel roles — set explicitly so ADS's palette(light/dark/mid) selectors
+        // resolve to our dark-theme values rather than the system palette's defaults.
+        pal.setColor(QPalette::Light, QColor(0x3C, 0x3C, 0x3C));
+        pal.setColor(QPalette::Midlight, QColor(0x2D, 0x2D, 0x2D));
+        pal.setColor(QPalette::Dark, QColor(0x14, 0x14, 0x14));
+        pal.setColor(QPalette::Mid, QColor(0x22, 0x22, 0x22));
+        pal.setColor(QPalette::Shadow, Qt::black);
+        pal.setColor(QPalette::PlaceholderText, QColor(0x66, 0x66, 0x66));
         pal.setColor(QPalette::Highlight, QColor(0x26, 0x4F, 0x78));
         pal.setColor(QPalette::HighlightedText, Qt::white);
     } else {
@@ -727,6 +791,15 @@ void MainWindow::applyColorScheme(bool dark) {
         pal.setColor(QPalette::Text, Qt::black);
         pal.setColor(QPalette::Button, QColor(0xEE, 0xEE, 0xEE));
         pal.setColor(QPalette::ButtonText, Qt::black);
+        // 3D/bevel roles — critical: ADS uses palette(light) as CDockWidget background.
+        // Setting Light=white here means that background resolves to white in light mode
+        // rather than inheriting whatever the system's dark theme has for QPalette::Light.
+        pal.setColor(QPalette::Light, Qt::white);
+        pal.setColor(QPalette::Midlight, QColor(0xF8, 0xF8, 0xF8));
+        pal.setColor(QPalette::Dark, QColor(0xBE, 0xBE, 0xBE));
+        pal.setColor(QPalette::Mid, QColor(0xD0, 0xD0, 0xD0));
+        pal.setColor(QPalette::Shadow, QColor(0x80, 0x80, 0x80));
+        pal.setColor(QPalette::PlaceholderText, QColor(0x99, 0x99, 0x99));
         pal.setColor(QPalette::Highlight, QColor(0x00, 0x78, 0xD4));
         pal.setColor(QPalette::HighlightedText, Qt::white);
     }
@@ -840,8 +913,6 @@ QSpinBox {
     padding: 2px 6px;
 }
 QSpinBox::up-button, QSpinBox::down-button { background: #3C3C3C; border: none; width: 16px; }
-QSpinBox::up-arrow   { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 4px solid #888; }
-QSpinBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top:    4px solid #888; }
 
 QScrollBar:vertical   { background: #1E1E1E; width: 10px; border: none; }
 QScrollBar:horizontal { background: #1E1E1E; height: 10px; border: none; }
@@ -855,6 +926,36 @@ QFrame[frameShape="4"] { color: #444444; }
 QFrame[frameShape="5"] { color: #444444; }
 QWidget#regHeader { background: #252526; border-bottom: 1px solid #3C3C3C; }
 QWidget#regHeader QLabel { color: #9CDCFE; background: transparent; border: none; }
+
+QComboBox {
+    background: #3C3C3C;
+    color: #CCCCCC;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    padding: 4px 8px 4px 10px;
+    min-width: 80px;
+}
+QComboBox:hover { border-color: #777777; }
+QComboBox QAbstractItemView {
+    background: #252526;
+    color: #CCCCCC;
+    border: 1px solid #454545;
+    selection-background-color: #094771;
+    selection-color: white;
+}
+
+QWidget#codeEditorBtnBar {
+    background: #252526;
+    border-top: 1px solid #3C3C3C;
+}
+
+QFrame#statCard {
+    background: #2D2D2D;
+    border: 1px solid #3C3C3C;
+    border-radius: 6px;
+}
+QFrame#statCard QLabel { background: transparent; }
+QLabel#statCardLabel { color: #888888; }
 )"
                              : R"(
 QMainWindow, QDialog { background: #F5F5F5; }
@@ -963,8 +1064,6 @@ QSpinBox {
     padding: 2px 6px;
 }
 QSpinBox::up-button, QSpinBox::down-button { background: #EEEEEE; border: none; width: 16px; }
-QSpinBox::up-arrow   { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 4px solid #666; }
-QSpinBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top:    4px solid #666; }
 
 QScrollBar:vertical   { background: #F5F5F5; width: 10px; border: none; }
 QScrollBar:horizontal { background: #F5F5F5; height: 10px; border: none; }
@@ -978,8 +1077,92 @@ QFrame[frameShape="4"] { color: #DDDDDD; }
 QFrame[frameShape="5"] { color: #DDDDDD; }
 QWidget#regHeader { background: #EBEBEB; border-bottom: 1px solid #DDDDDD; }
 QWidget#regHeader QLabel { color: #0078D4; background: transparent; border: none; }
+
+QComboBox {
+    background: white;
+    color: #333333;
+    border: 1px solid #CCCCCC;
+    border-radius: 3px;
+    padding: 4px 8px 4px 10px;
+    min-width: 80px;
+}
+QComboBox:hover { border-color: #AAAAAA; }
+QComboBox QAbstractItemView {
+    background: white;
+    color: #333333;
+    border: 1px solid #CCCCCC;
+    selection-background-color: #0078D4;
+    selection-color: white;
+}
+
+QWidget#codeEditorBtnBar {
+    background: #F0F0F0;
+    border-top: 1px solid #DDDDDD;
+}
+
+QFrame#statCard {
+    background: white;
+    border: 1px solid #E0E0E0;
+    border-radius: 6px;
+}
+QFrame#statCard QLabel { background: transparent; }
+QLabel#statCardLabel { color: #777777; }
 )";
     qApp->setStyleSheet(qss);
+
+    // ADS calls dock_manager_->setStyleSheet(its_built_in_css) during
+    // construction, which takes precedence over qApp->setStyleSheet() for
+    // all ads--* selectors. The only way to theme ADS elements is to append
+    // our overrides onto its own stylesheet. We cache the ADS base CSS once
+    // on the first call (after dock_manager_ is created) so subsequent
+    // scheme switches always start from the unmodified original.
+    if (dock_manager_) {
+        static const QString ads_base  = dock_manager_->styleSheet();
+        const QString        ads_theme = dark ? R"(
+ads--CDockContainerWidget { background: #1E1E1E; }
+ads--CDockContainerWidget ads--CDockSplitter::handle { background: #3C3C3C; }
+ads--CDockAreaWidget      { background: #1E1E1E; }
+ads--CDockAreaTitleBar    { background: #252526; border-bottom: 1px solid #3C3C3C; }
+ads--CDockWidgetTab {
+    background: #2D2D2D;
+    border-color: #3C3C3C;
+    padding: 4px 16px;
+}
+ads--CDockWidgetTab:hover { background: #383838; }
+ads--CDockWidgetTab[activeTab="true"] {
+    background: #1E1E1E;
+    border-top: 2px solid #007ACC;
+}
+ads--CDockWidgetTab QLabel           { color: #888888; }
+ads--CDockWidgetTab[activeTab="true"] QLabel { color: #FFFFFF; }
+ads--CDockWidget { background: #1E1E1E; border: none; }
+QScrollArea#dockWidgetScrollArea { background: transparent; border: none; }
+)"
+                                              : R"(
+ads--CDockContainerWidget { background: #F5F5F5; }
+ads--CDockContainerWidget ads--CDockSplitter::handle { background: #D5D5D5; }
+ads--CDockAreaWidget      { background: #F5F5F5; }
+ads--CDockAreaTitleBar    { background: #E8E8E8; border-bottom: 1px solid #CCCCCC; }
+ads--CDockWidgetTab {
+    background: #E8E8E8;
+    border-color: #D0D0D0;
+    padding: 4px 16px;
+}
+ads--CDockWidgetTab:hover { background: #DCDCDC; }
+ads--CDockWidgetTab[activeTab="true"] {
+    background: white;
+    border-top: 2px solid #0078D4;
+}
+ads--CDockWidgetTab QLabel           { color: #555555; }
+ads--CDockWidgetTab[activeTab="true"] QLabel { color: #1A1A1A; }
+ads--CDockWidget { background: white; border: none; }
+QScrollArea#dockWidgetScrollArea { background: transparent; border: none; }
+)";
+        dock_manager_->setStyleSheet(ads_base + ads_theme);
+    }
+
+    // Reset the CPI card to the QSS default (color re-applied by onStatisticsUpdated).
+    if (stat_cpi_card_) stat_cpi_card_->setStyleSheet("");
 
     datapath_widget_->setDarkMode(dark);
     register_widget_->setDarkMode(dark);

--- a/src/nsc_qt/widgets/datapath_widget.cpp
+++ b/src/nsc_qt/widgets/datapath_widget.cpp
@@ -1,6 +1,7 @@
 #include "nsc_qt/widgets/datapath_widget.h"
 #include "mips/decoder.h"
 #include "mips/registers.h"
+#include "nsc_qt/instr_format.h"
 #include "nsc_qt/ui_scale.h"
 
 #include <QContextMenuEvent>
@@ -37,64 +38,6 @@ static const QColor STAGE_COLORS_DARK[5] = {
 };
 
 static const char* STAGE_NAMES[5] = {"IF", "ID", "EX", "MEM", "WB"};
-
-// Format a decoded instruction as a human-readable string. This is assembly
-// notation (mnemonics, register names), not natural-language UI copy, so it
-// intentionally is not routed through tr().
-static std::string format_instr(uint32_t raw) {
-    using namespace mips;
-    auto decoded = Decoder::decode(raw);
-    if (!decoded) return "(?/?)";
-    const auto&        d  = *decoded;
-    std::string        mn = std::string(Decoder::mnemonic(d));
-    std::ostringstream os;
-    os << mn << " ";
-    switch (d.format) {
-    case InstrFormat::R: {
-        const auto& r = d.r();
-        if (d.opcode == Opcode::SPECIAL) {
-            using F = FunctCode;
-            if (r.funct == F::SLL || r.funct == F::SRL || r.funct == F::SRA) {
-                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rt) << ", "
-                   << +r.shamt;
-            } else if (r.funct == F::JR) {
-                os << "$" << register_abi_name(r.rs);
-            } else if (r.funct == F::JALR) {
-                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs);
-            } else {
-                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs) << ", $"
-                   << register_abi_name(r.rt);
-            }
-        }
-        break;
-    }
-    case InstrFormat::I: {
-        const auto& i = d.i();
-        if (d.opcode == Opcode::LW || d.opcode == Opcode::LBU || d.opcode == Opcode::LHU ||
-            d.opcode == Opcode::SW) {
-            os << "$" << register_abi_name(i.rt) << ", " << static_cast<int16_t>(i.imm) << "($"
-               << register_abi_name(i.rs) << ")";
-        } else if (d.opcode == Opcode::LUI) {
-            os << "$" << register_abi_name(i.rt) << ", 0x" << std::hex << i.imm;
-        } else if (d.opcode == Opcode::BEQ || d.opcode == Opcode::BNE) {
-            os << "$" << register_abi_name(i.rs) << ", $" << register_abi_name(i.rt) << ", "
-               << static_cast<int16_t>(i.imm);
-        } else {
-            os << "$" << register_abi_name(i.rt) << ", $" << register_abi_name(i.rs) << ", "
-               << static_cast<int16_t>(i.imm);
-        }
-        break;
-    }
-    case InstrFormat::J: {
-        const auto& j = d.j();
-        os << "0x" << std::hex << j.target;
-        break;
-    }
-    default:
-        break;
-    }
-    return os.str();
-}
 
 }  // anonymous namespace
 

--- a/src/nsc_qt/widgets/memory_widget.cpp
+++ b/src/nsc_qt/widgets/memory_widget.cpp
@@ -50,6 +50,18 @@ MemoryWidget::MemoryWidget(QWidget* parent) : QWidget(parent) {
     hex_view_ = new QHexView(this);
     hex_view_->setReadOnly(true);
     hex_view_->setFont(scale::monoFont(scale::kFontSizeDense));
+
+    // Label each section of the hex dump so new users immediately understand
+    // what they are looking at. "Offset" = row start address, hex column keeps
+    // its default byte-position numbers (00–0F), "ASCII" = text view.
+    {
+        auto opts          = hex_view_->options();
+        opts.address_label = tr("Offset");
+        opts.ascii_label   = QStringLiteral("ASCII");
+        opts.flags |= QHexFlags::StyledHeader | QHexFlags::Separators;
+        hex_view_->setOptions(opts);
+    }
+
     vl->addWidget(hex_view_);
 
     connect(addr_spin_, qOverload<int>(&QSpinBox::valueChanged), this,
@@ -92,6 +104,14 @@ void MemoryWidget::onAddressChanged(int value) {
 
 void MemoryWidget::setDarkMode(bool dark) {
     dark_mode_ = dark;
+    // Sync the QHexView header text colour to match the app's accent colour.
+    auto         opts                    = hex_view_->options();
+    const QColor hdr_fg                  = dark ? QColor("#9CDCFE") : QColor("#0078D4");
+    opts.header_format.foreground        = hdr_fg;
+    opts.addressheader_format.foreground = hdr_fg;
+    opts.hexheader_format.foreground     = hdr_fg;
+    opts.asciiheader_format.foreground   = hdr_fg;
+    hex_view_->setOptions(opts);
     if (last_mem_) refreshView(*last_mem_);
 }
 

--- a/src/nsc_qt/widgets/schematic_datapath_widget.cpp
+++ b/src/nsc_qt/widgets/schematic_datapath_widget.cpp
@@ -1,0 +1,649 @@
+#include "nsc_qt/widgets/schematic_datapath_widget.h"
+#include "nsc_qt/instr_format.h"
+#include "nsc_qt/ui_scale.h"
+
+#include <QContextMenuEvent>
+#include <QFocusEvent>
+#include <QGraphicsEllipseItem>
+#include <QGraphicsPathItem>
+#include <QGraphicsPolygonItem>
+#include <QGraphicsRectItem>
+#include <QGraphicsScene>
+#include <QGraphicsSimpleTextItem>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+#include <QPolygonF>
+#include <QWheelEvent>
+#include <algorithm>
+#include <cmath>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace nsc::qt {
+
+namespace {
+
+// ── Logical canvas ──────────────────────────────────────────────────────────
+// All geometry is authored in this fixed coordinate space; QGraphicsView
+// scales it to the widget. Chosen wide enough that the schematic reads at a
+// glance, like Ripes' processor tab.
+constexpr qreal kSceneW = 1400.0;
+constexpr qreal kSceneH = 540.0;
+
+// Stage column x-extents (tint bands + hit testing). Bars live between them.
+struct ColumnSpan {
+    qreal x0, x1;
+};
+constexpr ColumnSpan kColumns[5] = {
+    {8, 270},      // IF
+    {286, 555},    // ID
+    {571, 845},    // EX
+    {861, 1130},   // MEM
+    {1146, 1392},  // WB
+};
+
+constexpr qreal kColTop = 44.0, kColBot = 500.0;
+
+const char* const kStageNames[5]   = {"IF", "ID", "EX", "MEM", "WB"};
+const char* const kPipeRegNames[4] = {"IF/ID", "ID/EX", "EX/MEM", "MEM/WB"};
+
+// Stage tint hues (shared with the old widget's palette).
+const QColor kStageLight[5] = {QColor("#E3F2FD"), QColor("#E0F7FA"), QColor("#E8F5E9"),
+                               QColor("#FFFDE7"), QColor("#FFEBEE")};
+const QColor kStageDark[5]  = {QColor("#0D47A1"), QColor("#006064"), QColor("#1B5E20"),
+                               QColor("#F57F17"), QColor("#B71C1C")};
+
+// Theme palette for schematic chrome.
+struct Theme {
+    QColor bg, comp_fill, comp_border, wire, wire_dim, text, label, flush, stall, fwd_ex, fwd_mem,
+        wb;
+};
+const Theme kLight = {
+    QColor("#F5F5F5"), QColor("#FFFFFF"), QColor("#606060"), QColor("#707070"),
+    QColor("#C4C4C4"), QColor("#1A1A1A"), QColor("#00529B"), QColor("#D32F2F"),
+    QColor("#E65100"), QColor("#FF6F00"), QColor("#7B1FA2"), QColor("#2E7D32"),
+};
+const Theme kDark = {
+    QColor("#1E1E1E"), QColor("#2D2D2D"), QColor("#9A9A9A"), QColor("#A0A0A0"),
+    QColor("#4A4A4A"), QColor("#E0E0E0"), QColor("#9CDCFE"), QColor("#FF5252"),
+    QColor("#FFB74D"), QColor("#FFA726"), QColor("#CE93D8"), QColor("#81C784"),
+};
+inline const Theme& theme(bool dark) {
+    return dark ? kDark : kLight;
+}
+
+}  // anonymous namespace
+
+// ── WireItem ────────────────────────────────────────────────────────────────
+// An orthogonal signal wire: an arbitrary painter path plus arrowheads at the
+// stated tips and junction dots where a bus splits. `setActive()` switches
+// between the dim resting look and a bright highlighted one — that's how
+// forwarding paths, the branch flush path, and the write-back loop light up.
+class WireItem : public QGraphicsItem {
+public:
+    struct Tip {
+        QPointF at;
+        // Unit direction the arrow points: (1,0)=right, (0,1)=down, …
+        QPointF dir;
+    };
+
+    WireItem(QPainterPath path, std::vector<Tip> tips, std::vector<QPointF> junctions,
+             QGraphicsItem* parent = nullptr)
+        : QGraphicsItem(parent), path_(std::move(path)), tips_(std::move(tips)),
+          junctions_(std::move(junctions)) {
+        setZValue(-1);  // wires under components
+    }
+
+    void setColors(const QColor& rest, const QColor& lit) {
+        rest_ = rest;
+        lit_  = lit;
+        update();
+    }
+
+    void setActive(bool on) {
+        if (active_ == on) return;
+        active_ = on;
+        update();
+    }
+
+    // Thin dashed rendering for control-signal wires.
+    void setControlStyle(bool on) {
+        control_ = on;
+        update();
+    }
+
+    QRectF boundingRect() const override { return path_.boundingRect().adjusted(-8, -8, 8, 8); }
+
+    void paint(QPainter* p, const QStyleOptionGraphicsItem*, QWidget*) override {
+        const QColor& c = active_ ? lit_ : rest_;
+        const qreal   w = active_ ? 3.0 : (control_ ? 1.0 : 1.6);
+
+        QPen pen(c, w);
+        if (control_ && !active_) pen.setStyle(Qt::DashLine);
+        pen.setJoinStyle(Qt::MiterJoin);
+        p->setRenderHint(QPainter::Antialiasing);
+
+        if (active_) {  // soft glow pass under the lit wire
+            QPen glow(QColor(c.red(), c.green(), c.blue(), 70), w + 4, Qt::SolidLine, Qt::RoundCap);
+            p->setPen(glow);
+            p->setBrush(Qt::NoBrush);
+            p->drawPath(path_);
+        }
+        p->setPen(pen);
+        p->setBrush(Qt::NoBrush);
+        p->drawPath(path_);
+
+        p->setPen(Qt::NoPen);
+        p->setBrush(c);
+        for (const Tip& t : tips_) {
+            const QPointF d = t.dir;
+            const QPointF n(-d.y(), d.x());  // normal
+            const qreal   len = 7.0, half = 4.0;
+            const QPointF base   = t.at - d * len;
+            const QPointF tri[3] = {t.at, base + n * half, base - n * half};
+            p->drawPolygon(tri, 3);
+        }
+        for (const QPointF& j : junctions_)
+            p->drawEllipse(j, 3.0, 3.0);
+    }
+
+private:
+    QPainterPath         path_;
+    std::vector<Tip>     tips_;
+    std::vector<QPointF> junctions_;
+    QColor               rest_ = Qt::gray, lit_ = Qt::red;
+    bool                 active_ = false, control_ = false;
+};
+
+namespace {
+
+// ── Component construction helpers ──────────────────────────────────────────
+// Components are plain QGraphicsItems tagged with data(0)="comp" so the theme
+// pass can restyle fill/border/text without keeping a pointer to each one.
+
+QGraphicsRectItem* addBox(QGraphicsScene* s, const QRectF& r, const QString& label,
+                          int font_px = scale::kFontSizeDense) {
+    auto* box = s->addRect(r);
+    box->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(label, box);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(font_px));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    return box;
+}
+
+QGraphicsEllipseItem* addEllipse(QGraphicsScene* s, const QRectF& r, const QString& label) {
+    auto* el = s->addEllipse(r);
+    el->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(label, el);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(scale::kFontSizeDense - 2));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    return el;
+}
+
+// Classic ALU / adder pentagon with the input notch on the left.
+QGraphicsPolygonItem* addAlu(QGraphicsScene* s, const QRectF& r, const QString& label) {
+    const qreal x = r.x(), y = r.y(), w = r.width(), h = r.height();
+    QPolygonF   poly;
+    poly << QPointF(x, y) << QPointF(x + w, y + h * 0.30) << QPointF(x + w, y + h * 0.70)
+         << QPointF(x, y + h) << QPointF(x, y + h * 0.62) << QPointF(x + w * 0.18, y + h * 0.50)
+         << QPointF(x, y + h * 0.38);
+    auto* item = s->addPolygon(poly);
+    item->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(label, item);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(scale::kFontSizeDense, true));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(x + w * 0.52 - tb.width() / 2, y + h / 2 - tb.height() / 2);
+    return item;
+}
+
+// Vertical capsule mux.
+QGraphicsRectItem* addMux(QGraphicsScene* s, const QRectF& r) {
+    auto* mux = s->addRect(r);  // rounded corners drawn via pen radius below
+    mux->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(QStringLiteral("M"), mux);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(scale::kFontSizeDense - 2, true));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    return mux;
+}
+
+// Build an orthogonal path through the given points.
+QPainterPath ortho(std::initializer_list<QPointF> pts) {
+    QPainterPath p;
+    bool         first = true;
+    for (const QPointF& pt : pts) {
+        if (first) {
+            p.moveTo(pt);
+            first = false;
+        } else {
+            p.lineTo(pt);
+        }
+    }
+    return p;
+}
+
+}  // anonymous namespace
+
+// ── SchematicDatapathWidget ─────────────────────────────────────────────────
+
+SchematicDatapathWidget::SchematicDatapathWidget(QWidget* parent) : QGraphicsView(parent) {
+    scene_ = new QGraphicsScene(0, 0, kSceneW, kSceneH, this);
+    setScene(scene_);
+
+    setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+    setDragMode(QGraphicsView::ScrollHandDrag);
+    setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
+    setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
+    setFocusPolicy(Qt::StrongFocus);
+    setMinimumSize(560, 260);
+
+    buildScene();
+    applyTheme();
+    applyState();
+}
+
+void SchematicDatapathWidget::buildScene() {
+    // ── Stage tint bands + mnemonic labels ──────────────────────────────────
+    for (int i = 0; i < 5; ++i) {
+        const auto& c = kColumns[i];
+        stage_tints_[static_cast<std::size_t>(i)] =
+            scene_->addRect(QRectF(c.x0, kColTop, c.x1 - c.x0, kColBot - kColTop));
+        stage_tints_[static_cast<std::size_t>(i)]->setZValue(-10);
+        stage_tints_[static_cast<std::size_t>(i)]->setPen(Qt::NoPen);
+
+        auto* name = scene_->addSimpleText(QString::fromLatin1(kStageNames[i]),
+                                           scale::monoFont(scale::kFontSizeBody, true));
+        name->setData(0, QStringLiteral("stage-name"));
+        name->setPos((c.x0 + c.x1) / 2 - name->boundingRect().width() / 2, kColBot + 8);
+
+        stage_labels_[static_cast<std::size_t>(i)] =
+            scene_->addSimpleText(QString(), scale::monoFont(scale::kFontSizeDense));
+        stage_labels_[static_cast<std::size_t>(i)]->setPos((c.x0 + c.x1) / 2, 16);
+    }
+
+    // ── Pipeline register bars ───────────────────────────────────────────────
+    const qreal bar_xs[4] = {270, 555, 845, 1130};
+    for (int i = 0; i < 4; ++i) {
+        auto* bar = scene_->addRect(QRectF(bar_xs[i], 70, 16, 420));
+        bar->setZValue(1);
+        pipe_regs_[static_cast<std::size_t>(i)] = bar;
+        auto* lbl = new QGraphicsSimpleTextItem(QString::fromLatin1(kPipeRegNames[i]), bar);
+        lbl->setData(0, QStringLiteral("comp-label"));
+        lbl->setFont(scale::monoFont(scale::kFontSizeDense - 3, true));
+        lbl->setRotation(-90);
+        lbl->setPos(bar_xs[i] + 13.5, 280 + lbl->boundingRect().width() / 2);
+    }
+
+    // ── IF stage ─────────────────────────────────────────────────────────────
+    addMux(scene_, QRectF(16, 250, 20, 60));  // PC-source mux
+    addBox(scene_, QRectF(52, 255, 42, 50), QStringLiteral("PC"));
+    addAlu(scene_, QRectF(120, 100, 44, 56), QStringLiteral("+4"));  // PC+4 adder
+    addBox(scene_, QRectF(120, 235, 116, 105), QStringLiteral("Instr.\nmemory"));
+
+    auto addWire = [&](QPainterPath p, std::vector<WireItem::Tip> tips,
+                       std::vector<QPointF> junctions = {}) -> WireItem* {
+        auto* w = new WireItem(std::move(p), std::move(tips), std::move(junctions));
+        scene_->addItem(w);
+        wires_.push_back(w);
+        return w;
+    };
+
+    // mux → PC → I-Mem, with a tap up to the +4 adder
+    addWire(ortho({{36, 280}, {52, 280}}), {{{52, 280}, {1, 0}}});
+    addWire(ortho({{94, 280}, {120, 280}}), {{{120, 280}, {1, 0}}});
+    addWire(ortho({{104, 280}, {104, 120}, {120, 120}}), {{{120, 120}, {1, 0}}}, {{104, 280}});
+    // +4 adder → over the top → PC mux input 0
+    addWire(ortho({{164, 128}, {178, 128}, {178, 56}, {10, 56}, {10, 262}, {16, 262}}),
+            {{{16, 262}, {1, 0}}});
+    // I-Mem → IF/ID
+    addWire(ortho({{236, 280}, {270, 280}}), {{{270, 280}, {1, 0}}});
+
+    // ── ID stage ─────────────────────────────────────────────────────────────
+    addBox(scene_, QRectF(320, 74, 96, 40), QStringLiteral("Control"));
+    addBox(scene_, QRectF(320, 210, 130, 125), QStringLiteral("Registers"));
+    addEllipse(scene_, QRectF(340, 380, 84, 42), QStringLiteral("Sign-\nextend"));
+
+    // Instruction bus out of IF/ID: vertical spine at x=305 feeding Control,
+    // both register read ports, and sign-extend.
+    {
+        QPainterPath p = ortho({{286, 280}, {305, 280}});
+        p.moveTo(305, 94);
+        p.lineTo(305, 401);
+        p.moveTo(305, 94);
+        p.lineTo(320, 94);
+        p.moveTo(305, 240);
+        p.lineTo(320, 240);
+        p.moveTo(305, 290);
+        p.lineTo(320, 290);
+        p.moveTo(305, 401);
+        p.lineTo(340, 401);
+        addWire(
+            std::move(p),
+            {{{320, 94}, {1, 0}}, {{320, 240}, {1, 0}}, {{320, 290}, {1, 0}}, {{340, 401}, {1, 0}}},
+            {{305, 280}, {305, 240}, {305, 290}});
+    }
+
+    // Register file outputs / sign-extend / control word → ID/EX
+    addWire(ortho({{450, 240}, {555, 240}}), {{{555, 240}, {1, 0}}});
+    addWire(ortho({{450, 290}, {555, 290}}), {{{555, 290}, {1, 0}}});
+    addWire(ortho({{424, 401}, {555, 401}}), {{{555, 401}, {1, 0}}});
+    addWire(ortho({{416, 94}, {555, 94}}), {{{555, 94}, {1, 0}}})->setControlStyle(true);
+
+    // ── EX stage ─────────────────────────────────────────────────────────────
+    addMux(scene_, QRectF(600, 210, 20, 56));  // forwarding mux A
+    addMux(scene_, QRectF(600, 280, 20, 56));  // forwarding mux B
+    addAlu(scene_, QRectF(680, 210, 84, 130), QStringLiteral("ALU"));
+    addAlu(scene_, QRectF(690, 92, 44, 56), QStringLiteral("+"));  // branch-target adder
+
+    // ID/EX → forwarding muxes → ALU
+    addWire(ortho({{571, 240}, {585, 240}, {585, 222}, {600, 222}}), {{{600, 222}, {1, 0}}});
+    addWire(ortho({{620, 238}, {650, 238}, {650, 242}, {680, 242}}), {{{680, 242}, {1, 0}}});
+    addWire(ortho({{571, 290}, {585, 290}, {585, 292}, {600, 292}}), {{{600, 292}, {1, 0}}});
+    addWire(ortho({{620, 308}, {680, 308}}), {{{680, 308}, {1, 0}}});
+    // PC + shifted immediate → branch-target adder
+    addWire(ortho({{571, 106}, {690, 106}}), {{{690, 106}, {1, 0}}});
+    addWire(ortho({{571, 401}, {660, 401}, {660, 134}, {690, 134}}), {{{690, 134}, {1, 0}}});
+    // Control word continues along the top
+    addWire(ortho({{571, 94}, {680, 94}}), {})->setControlStyle(true);
+    // ALU result / branch target → EX/MEM
+    addWire(ortho({{764, 275}, {845, 275}}), {{{845, 275}, {1, 0}}});
+    addWire(ortho({{734, 120}, {845, 120}}), {{{845, 120}, {1, 0}}});
+    // Store-data pass-through: mux B output also runs to EX/MEM
+    addWire(ortho({{650, 308}, {650, 370}, {845, 370}}), {{{845, 370}, {1, 0}}}, {{650, 308}});
+
+    // Forwarding wires (always visible, lit when the hazard unit forwards)
+    fwd_exmem_wire_ = addWire(ortho({{845, 420}, {590, 420}, {590, 238}, {600, 238}}),
+                              {{{600, 238}, {1, 0}}}, {{590, 308}});
+    {
+        QPainterPath p = ortho({{590, 308}, {600, 308}});
+        // stub drawn as part of the same wire so it lights together
+        // (append to fwd wire path is not possible post-hoc; use second wire)
+        auto* stub = addWire(std::move(p), {{{600, 308}, {1, 0}}});
+        stub->setControlStyle(false);
+        // Keep the stub in sync by treating it as part of the EX/MEM wire:
+        // applyState() lights both via fwd_exmem_wire_ and this stub pointer.
+        fwd_exmem_stub_ = stub;
+    }
+    fwd_memwb_wire_ = addWire(ortho({{1130, 455}, {578, 455}, {578, 254}, {600, 254}}),
+                              {{{600, 254}, {1, 0}}}, {{578, 324}});
+    {
+        auto* stub      = addWire(ortho({{578, 324}, {600, 324}}), {{{600, 324}, {1, 0}}});
+        fwd_memwb_stub_ = stub;
+    }
+
+    // ── MEM stage ────────────────────────────────────────────────────────────
+    addBox(scene_, QRectF(910, 230, 125, 125), QStringLiteral("Data\nmemory"));
+    addBox(scene_, QRectF(910, 96, 80, 44), QStringLiteral("Branch"));
+
+    addWire(ortho({{861, 275}, {910, 275}}), {{{910, 275}, {1, 0}}}, {{885, 275}});
+    addWire(ortho({{861, 370}, {895, 370}, {895, 320}, {910, 320}}), {{{910, 320}, {1, 0}}});
+    addWire(ortho({{861, 120}, {910, 120}}), {{{910, 120}, {1, 0}}});
+    // ALU-result bypass to MEM/WB (non-load write-back)
+    addWire(ortho({{885, 275}, {885, 415}, {1130, 415}}), {{{1130, 415}, {1, 0}}});
+    // D-Mem read data → MEM/WB
+    addWire(ortho({{1035, 275}, {1130, 275}}), {{{1130, 275}, {1, 0}}});
+    // Branch decision → PC mux (the flush path; lights red on branch_flush)
+    branch_wire_ =
+        addWire(ortho({{990, 118}, {1056, 118}, {1056, 44}, {4, 44}, {4, 298}, {16, 298}}),
+                {{{16, 298}, {1, 0}}});
+
+    // ── WB stage ─────────────────────────────────────────────────────────────
+    addMux(scene_, QRectF(1180, 250, 22, 70));  // MemToReg mux
+    addWire(ortho({{1146, 275}, {1165, 275}, {1165, 272}, {1180, 272}}), {{{1180, 272}, {1, 0}}});
+    addWire(ortho({{1146, 415}, {1172, 415}, {1172, 298}, {1180, 298}}), {{{1180, 298}, {1, 0}}});
+    // Write-back loop to the register file write port
+    writeback_wire_ =
+        addWire(ortho({{1202, 285}, {1230, 285}, {1230, 510}, {300, 510}, {300, 325}, {320, 325}}),
+                {{{320, 325}, {1, 0}}});
+
+    // ── Breakpoint markers (bullseye per stage column) ───────────────────────
+    for (int i = 0; i < 5; ++i) {
+        const auto& c     = kColumns[i];
+        auto*       outer = scene_->addEllipse(QRectF(c.x1 - 24, kColTop + 6, 14, 14),
+                                               QPen(QColor("#AA0000"), 1), QColor("#E53935"));
+        auto*       inner =
+            scene_->addEllipse(QRectF(c.x1 - 20, kColTop + 10, 6, 6), Qt::NoPen, QColor("#FFFFFF"));
+        outer->setZValue(5);
+        inner->setZValue(6);
+        bp_markers_[static_cast<std::size_t>(i)] = {outer, inner};
+    }
+
+    // ── Keyboard focus ring ──────────────────────────────────────────────────
+    focus_ring_ = scene_->addRect(QRectF());
+    focus_ring_->setZValue(10);
+    focus_ring_->setBrush(Qt::NoBrush);
+    focus_ring_->setVisible(false);
+}
+
+void SchematicDatapathWidget::applyTheme() {
+    const Theme& t = theme(dark_mode_);
+    scene_->setBackgroundBrush(t.bg);
+
+    // Restyle every tagged component / label.
+    const QList<QGraphicsItem*> items = scene_->items();
+    for (QGraphicsItem* it : items) {
+        const QString tag = it->data(0).toString();
+        if (tag == QLatin1String("comp")) {
+            if (auto* shape = dynamic_cast<QAbstractGraphicsShapeItem*>(it)) {
+                shape->setBrush(t.comp_fill);
+                shape->setPen(QPen(t.comp_border, 1.4));
+            }
+        } else if (tag == QLatin1String("comp-label")) {
+            if (auto* txt = dynamic_cast<QGraphicsSimpleTextItem*>(it)) txt->setBrush(t.text);
+        } else if (tag == QLatin1String("stage-name")) {
+            if (auto* txt = dynamic_cast<QGraphicsSimpleTextItem*>(it)) txt->setBrush(t.label);
+        }
+    }
+
+    for (WireItem* w : wires_)
+        w->setColors(t.wire, t.label);
+    // Special wires get their own lit colors.
+    fwd_exmem_wire_->setColors(t.wire_dim, t.fwd_ex);
+    fwd_exmem_stub_->setColors(t.wire_dim, t.fwd_ex);
+    fwd_memwb_wire_->setColors(t.wire_dim, t.fwd_mem);
+    fwd_memwb_stub_->setColors(t.wire_dim, t.fwd_mem);
+    branch_wire_->setColors(t.wire_dim, t.flush);
+    writeback_wire_->setColors(t.wire_dim, t.wb);
+
+    focus_ring_->setPen(QPen(dark_mode_ ? QColor("#4FC3F7") : QColor("#0078D4"), 2, Qt::DashLine));
+
+    applyState();  // re-derives state-dependent tints for the new theme
+}
+
+void SchematicDatapathWidget::applyState() {
+    const Theme& t = theme(dark_mode_);
+
+    for (int i = 0; i < 5; ++i) {
+        const auto&  snap = state_.stages[static_cast<std::size_t>(i)];
+        const QColor tint = dark_mode_ ? kStageDark[i] : kStageLight[i];
+        QColor       band = tint;
+        band.setAlpha(snap.valid ? (dark_mode_ ? 70 : 120) : (dark_mode_ ? 25 : 45));
+        stage_tints_[static_cast<std::size_t>(i)]->setBrush(band);
+
+        // Mnemonic label above the column (Ripes-style).
+        auto*   lbl = stage_labels_[static_cast<std::size_t>(i)];
+        QString text;
+        QColor  color = t.text;
+        if (snap.flushed) {
+            text  = QStringLiteral("nop (flush)");
+            color = t.flush;
+        } else if (snap.stalled) {
+            text  = QStringLiteral("nop (stall)");
+            color = t.stall;
+        } else if (snap.valid) {
+            text = QString::fromStdString(format_instr(snap.raw));
+        } else {
+            text  = QStringLiteral("—");
+            color = t.wire_dim;
+        }
+        lbl->setText(text);
+        lbl->setBrush(color);
+        const auto& c = kColumns[i];
+        lbl->setPos((c.x0 + c.x1) / 2 - lbl->boundingRect().width() / 2, 16);
+
+        // Breakpoint bullseye visibility.
+        const bool bp = snap.valid && breakpoints_.count(snap.pc) > 0;
+        bp_markers_[static_cast<std::size_t>(i)].first->setVisible(bp);
+        bp_markers_[static_cast<std::size_t>(i)].second->setVisible(bp);
+    }
+
+    // Pipeline-register bars: red = flushing, amber = stalled, else neutral.
+    for (int i = 0; i < 4; ++i) {
+        const auto& snap = state_.stages[static_cast<std::size_t>(i + 1)];
+        QColor      fill = t.comp_fill;
+        if (snap.flushed)
+            fill = t.flush;
+        else if (snap.stalled)
+            fill = t.stall;
+        pipe_regs_[static_cast<std::size_t>(i)]->setBrush(fill);
+        pipe_regs_[static_cast<std::size_t>(i)]->setPen(QPen(t.comp_border, 1.4));
+    }
+
+    fwd_exmem_wire_->setActive(state_.fwd_ex_to_ex_a || state_.fwd_ex_to_ex_b);
+    fwd_exmem_stub_->setActive(state_.fwd_ex_to_ex_b);
+    fwd_memwb_wire_->setActive(state_.fwd_mem_to_ex_a || state_.fwd_mem_to_ex_b);
+    fwd_memwb_stub_->setActive(state_.fwd_mem_to_ex_b);
+    branch_wire_->setActive(state_.branch_flush);
+    writeback_wire_->setActive(state_.stages[4].valid);
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+void SchematicDatapathWidget::setPipelineState(const mips::PipelineState& state) {
+    state_ = state;
+    applyState();
+}
+
+void SchematicDatapathWidget::setBreakpoints(const std::unordered_set<uint32_t>& bps) {
+    breakpoints_ = bps;
+    applyState();
+}
+
+void SchematicDatapathWidget::setDarkMode(bool dark) {
+    dark_mode_ = dark;
+    applyTheme();
+}
+
+// ── Interaction ─────────────────────────────────────────────────────────────
+
+int SchematicDatapathWidget::stageAtViewPos(const QPoint& pos) const {
+    const QPointF sp = mapToScene(pos);
+    if (sp.y() < kColTop || sp.y() > kColBot) return -1;
+    for (int i = 0; i < 5; ++i)
+        if (sp.x() >= kColumns[i].x0 && sp.x() <= kColumns[i].x1) return i;
+    return -1;
+}
+
+void SchematicDatapathWidget::fitSchematic() {
+    if (!user_zoomed_) fitInView(scene_->sceneRect(), Qt::KeepAspectRatio);
+}
+
+void SchematicDatapathWidget::wheelEvent(QWheelEvent* ev) {
+    // Ctrl+wheel zooms around the cursor; plain wheel scrolls as usual.
+    if (ev->modifiers() & Qt::ControlModifier) {
+        user_zoomed_       = true;
+        const qreal step   = std::pow(1.15, ev->angleDelta().y() / 120.0);
+        const qreal cur    = transform().m11();
+        const qreal target = std::clamp(cur * step, 0.3, 4.0);
+        scale(target / cur, target / cur);
+        ev->accept();
+        return;
+    }
+    QGraphicsView::wheelEvent(ev);
+}
+
+void SchematicDatapathWidget::mousePressEvent(QMouseEvent* ev) {
+    setFocus(Qt::MouseFocusReason);
+    const int idx = stageAtViewPos(ev->pos());
+    if (idx >= 0) {
+        selected_stage_ = idx;
+        if (hasFocus()) focusInEvent(nullptr);  // refresh ring position
+    }
+    QGraphicsView::mousePressEvent(ev);
+}
+
+void SchematicDatapathWidget::mouseDoubleClickEvent(QMouseEvent* ev) {
+    const int idx = stageAtViewPos(ev->pos());
+    if (idx < 0) return;
+    const auto& snap = state_.stages[static_cast<std::size_t>(idx)];
+    if (snap.valid) emit stageDetailRequested(idx, snap.pc, snap.raw);
+}
+
+void SchematicDatapathWidget::contextMenuEvent(QContextMenuEvent* ev) {
+    const int idx = stageAtViewPos(ev->pos());
+    if (idx < 0) return;
+    const auto& snap = state_.stages[static_cast<std::size_t>(idx)];
+    if (!snap.valid) return;
+
+    QMenu      menu(this);
+    const bool has_bp = breakpoints_.count(snap.pc) > 0;
+    QAction*   act    = menu.addAction(has_bp ? tr("Clear Breakpoint") : tr("Set Breakpoint"));
+    QAction*   fit    = menu.addAction(tr("Zoom to Fit"));
+    QAction*   chosen = menu.exec(ev->globalPos());
+    if (chosen == act) emit breakpointToggleRequested(snap.pc);
+    if (chosen == fit) {
+        user_zoomed_ = false;
+        fitSchematic();
+    }
+}
+
+void SchematicDatapathWidget::keyPressEvent(QKeyEvent* ev) {
+    switch (ev->key()) {
+    case Qt::Key_Left:
+        selected_stage_ = (selected_stage_ + 4) % 5;
+        focusInEvent(nullptr);
+        ev->accept();
+        return;
+    case Qt::Key_Right:
+        selected_stage_ = (selected_stage_ + 1) % 5;
+        focusInEvent(nullptr);
+        ev->accept();
+        return;
+    case Qt::Key_Return:
+    case Qt::Key_Enter: {
+        const auto& snap = state_.stages[static_cast<std::size_t>(selected_stage_)];
+        if (snap.valid) emit stageDetailRequested(selected_stage_, snap.pc, snap.raw);
+        ev->accept();
+        return;
+    }
+    case Qt::Key_Space:
+    case Qt::Key_B: {
+        const auto& snap = state_.stages[static_cast<std::size_t>(selected_stage_)];
+        if (snap.valid) emit breakpointToggleRequested(snap.pc);
+        ev->accept();
+        return;
+    }
+    default:
+        QGraphicsView::keyPressEvent(ev);
+    }
+}
+
+void SchematicDatapathWidget::resizeEvent(QResizeEvent* ev) {
+    QGraphicsView::resizeEvent(ev);
+    fitSchematic();
+}
+
+void SchematicDatapathWidget::focusInEvent(QFocusEvent* ev) {
+    if (ev) QGraphicsView::focusInEvent(ev);
+    const auto& c = kColumns[selected_stage_];
+    focus_ring_->setRect(QRectF(c.x0 - 3, kColTop - 3, (c.x1 - c.x0) + 6, (kColBot - kColTop) + 6));
+    focus_ring_->setVisible(true);
+}
+
+void SchematicDatapathWidget::focusOutEvent(QFocusEvent* ev) {
+    QGraphicsView::focusOutEvent(ev);
+    focus_ring_->setVisible(false);
+}
+
+}  // namespace nsc::qt


### PR DESCRIPTION
This pull request introduces a major refactor and UI upgrade for the Qt6 application, replacing the old datapath widget with a new schematic-style pipeline visualizer and enhancing the statistics panel. It also improves palette handling for better dark/light theme support and modularizes instruction formatting logic for reuse. Below are the most significant changes:

### UI Refactor and Feature Additions

* Replaces the old `DatapathWidget` with a new `SchematicDatapathWidget`, which provides a Ripes-style schematic pipeline visualization using `QGraphicsView/QGraphicsScene`. This includes live state binding, color-coded pipeline registers, and interactive features. (`CMakeLists.txt`, `include/nsc_qt/main_window.h`, `src/nsc_qt/main_window.cpp`, `include/nsc_qt/widgets/schematic_datapath_widget.h`, [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR365) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR378) [[3]](diffhunk://#diff-207ce70d51ac34b8b40c4a02e4d40a2441e76c8cd50eafaf4470d2aed2e3b478L23-R23) [[4]](diffhunk://#diff-207ce70d51ac34b8b40c4a02e4d40a2441e76c8cd50eafaf4470d2aed2e3b478L95-R95) [[5]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abL9-R12) [[6]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abL162-R162) [[7]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abL418-R455) [[8]](diffhunk://#diff-373e8b4a37df7ca51dba70a4390ffd64d8411e769149379ba0009426b2b92e95R1-R97)
* Modernizes the statistics tab by introducing KPI cards for cycles, instructions, and CPI, with CPI card background color-coded for quick health assessment. Cards are selectable for easy copying, and tooltips provide additional context. (`src/nsc_qt/main_window.cpp`, `include/nsc_qt/main_window.h`, [[1]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abR363-R430) [[2]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abL585-R648) [[3]](diffhunk://#diff-207ce70d51ac34b8b40c4a02e4d40a2441e76c8cd50eafaf4470d2aed2e3b478R112)

### Code Structure and Reusability

* Extracts the instruction formatting logic from `datapath_widget.cpp` into a new shared header, `instr_format.h`, so both datapath visualizers can reuse the same "raw word → assembly" formatter. (`include/nsc_qt/instr_format.h`, [include/nsc_qt/instr_format.hR1-R75](diffhunk://#diff-fa7ef52cf7266a0c1f87142beabae84b64939dbb7aae003c54955241695ff6ebR1-R75))

### UI/UX and Theming Enhancements

* Improves palette and color scheme handling for both dark and light modes, explicitly setting all relevant palette roles (including 3D/bevel effects and placeholder text) to ensure consistent appearance and proper integration with the docking system. (`src/nsc_qt/main_window.cpp`, [[1]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abR774-R781) [[2]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abR794-R802)
* Refactors the code editor tab's button row to use a dedicated container (`codeEditorBtnBar`) for more flexible QSS theming, and makes status labels children of this container for better style scoping. (`src/nsc_qt/main_window.cpp`, [[1]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abL288-R296) [[2]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abL321-R321) [[3]](diffhunk://#diff-8bb3e3abc0db7af4996e847bfc2f8428c7c95687c2db9df2c31c59168b86c6abL330)

These changes collectively modernize the UI, improve maintainability, and set the stage for further extensibility and theming improvements.