### PR TITLE
fix(tui): signed-overflow UB in splash hashf hung -O3 release builds at launch

### DIFF
--- a/src/nsc/ui.cpp
+++ b/src/nsc/ui.cpp
@@ -552,8 +552,19 @@ static void runSplash() {
 
     // Small deterministic hash used to vary trace geometry per pin without
     // pulling in <random> or reseeding anything.
+    //
+    // The multiplies MUST be unsigned: `a * 374761393` overflows int for any
+    // a ≥ 6, which is undefined behaviour. GCC's -O3 exploited that UB to
+    // miscompile the trace-generator loops below into an infinite spin, so
+    // the packaged Release binary hung on a blank screen at launch while
+    // -O0/-O2 builds (which happen to wrap) ran fine. Casting the operands
+    // first makes the wraparound defined and the hash identical to what the
+    // lower optimisation levels always produced. (UBSan-trap pinpointed the
+    // overflow; the index guard in put() below was an earlier, incomplete
+    // attempt at fixing this same launch failure.)
     auto hashf = [](int a, int b) -> uint32_t {
-        uint32_t h = static_cast<uint32_t>(a * 374761393 + b * 668265263 + 0x9E3779B9u);
+        uint32_t h = static_cast<uint32_t>(a) * 374761393u + static_cast<uint32_t>(b) * 668265263u +
+                     0x9E3779B9u;
         h          = (h ^ (h >> 13)) * 1274126177u;
         return h ^ (h >> 16);
     };


### PR DESCRIPTION
## Problem

`./number_system_converter` from the `Linux-x86_64` release asset hangs on a blank screen at launch (reported against v0.2.2; reproducible with any plain `-O3` Release build). Local debug/`-O2` builds run fine, which made it look packaging-related.

## Diagnosis

- GDB attach to the hung asset binary: stuck in `nsc::runSplash()` **before the event loop**, endlessly constructing the one-glyph `std::string`s emitted by the splash's PCB-trace loops.
- Rebuilt `ui.cpp` with `-O3 -fsanitize=undefined -fsanitize-undefined-trap-on-error`: trapped at the first `hashf` call (`ui.cpp:616`).
- Root cause: `hashf` computes `a * 374761393 + b * 668265263` in **signed int**, overflowing for any coordinate ≥ 6 — UB. GCC `-O3` assumes signed arithmetic can't overflow and miscompiles the dependent trace-generator loops into an infinite spin. `-O0`/`-O2` happen to wrap, so the bug stayed invisible locally.
- The index-bound guard from #71 addressed a symptom of this same launch failure, not the overflow — the v0.2.2 asset contains that guard and still hangs.

## Fix

Perform the hash mixing multiplies in `uint32_t` (defined wraparound). Bit-identical hashes to what working builds computed, so the splash art is unchanged.

## Verification

- UBSan-trap build at `-O3`: runs clean, splash renders, Enter dismisses it.
- Plain `-O3` Release build under a pty harness: renders ~1 MB of splash frames and reaches the event loop (previously 0 bytes, infinite hang — same signature as the v0.2.2 asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)