### PR TITLE
chore: sync develop with main + CHANGELOG [Unreleased] for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Ripes-style schematic datapath**: the Datapath panel is now a full circuit schematic of the 5-stage
+  pipeline (QGraphicsScene) — PC, instruction memory, register file, control, sign-extend, forwarding muxes,
+  ALU, branch logic, data memory, and the four pipeline registers, connected by routed wires. Live per cycle:
+  forwarding buses light orange/purple, the branch-flush path lights red, the write-back loop lights green
+  (only when the retiring instruction actually writes a register), mux select-input dots show the chosen input,
+  mnemonic + PC labels sit above each stage column, and value labels pin the fetch PC, ID immediate, and WB
+  result to their wires. Educational hover tooltips on every unit explain what it does and what it is doing
+  this cycle (control-signal breakdown included). Step animation glides an instruction token between columns
+  each clock edge. A hazard explainer chip names each stall/flush in plain language the moment it happens.
+  Ctrl+wheel / overlay buttons zoom; right-click exports a 2x PNG (`datapath-cycle-N.png`). (#83, #84)
+- **Pipeline Events panel**: scrolling, colour-coded log of every forward, stall, and flush (with the
+  instruction responsible), plus program milestones (load, breakpoints, halt, fault). Consecutive-cycle
+  repeats collapse into one entry; colours match the schematic wires. (#84)
+- **2-column IDE layout** (Qt Advanced Docking System): Code Editor left; Datapath centre; Registers, Memory,
+  Pipeline Trace, Statistics, and Pipeline Events tabbed below. Panels dock, float, and persist; View ▸ Panels
+  toggles and View ▸ Reset Layout restore them. (#80, #82)
+- **Statistics redesign**: Cycles / Instructions / CPI as large KPI cards, with the CPI card colour-coded
+  green/orange/red by pipeline health; pipeline-event counters gained explanatory tooltips. (#82)
+- Execution-speed slider in the main toolbar (10–1000 ms per cycle), synced with Preferences. (#84)
+
+### Fixed
+- **TUI froze on a blank screen at launch in packaged Linux builds** (`number_system_converter` from the
+  release archive): signed-integer-overflow UB in the startup splash's coordinate hash let GCC `-O3`
+  miscompile the splash setup into an infinite loop. Hash arithmetic now uses unsigned math; `-O0`/`-O2`
+  builds were never affected, which is why local builds ran fine. (#87)
+- Light/dark theming: ADS dock chrome no longer inherits the system palette (dark tab bars in light mode),
+  dropdown/spinbox arrows render again, dark-mode schematic stage tints no longer drown the wiring, and the
+  memory hex view labels its Offset/ASCII columns. (#82, #84)
+
 ---
 
 ## [0.2.1] - 2026-07-05

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ if (BUILD_QT6_UI)
             src/nsc_qt/preferences_dialog.cpp
             src/nsc_qt/widgets/code_editor.cpp
             src/nsc_qt/widgets/datapath_widget.cpp
+            src/nsc_qt/widgets/schematic_datapath_widget.cpp
             src/nsc_qt/widgets/register_widget.cpp
             src/nsc_qt/widgets/memory_widget.cpp
             src/nsc_qt/widgets/pipeline_trace_widget.cpp
@@ -374,6 +375,7 @@ if (BUILD_QT6_UI)
             include/nsc_qt/examples.h
             include/nsc_qt/widgets/code_editor.h
             include/nsc_qt/widgets/datapath_widget.h
+            include/nsc_qt/widgets/schematic_datapath_widget.h
             include/nsc_qt/widgets/register_widget.h
             include/nsc_qt/widgets/memory_widget.h
             include/nsc_qt/widgets/pipeline_trace_widget.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,7 @@ if (BUILD_QT6_UI)
             src/nsc_qt/widgets/register_widget.cpp
             src/nsc_qt/widgets/memory_widget.cpp
             src/nsc_qt/widgets/pipeline_trace_widget.cpp
+            src/nsc_qt/widgets/pipeline_events_widget.cpp
 
             # Headers listed so AUTOMOC picks up Q_OBJECT classes
             include/nsc_qt/simulator_controller.h
@@ -379,6 +380,7 @@ if (BUILD_QT6_UI)
             include/nsc_qt/widgets/register_widget.h
             include/nsc_qt/widgets/memory_widget.h
             include/nsc_qt/widgets/pipeline_trace_widget.h
+            include/nsc_qt/widgets/pipeline_events_widget.h
     )
 
     set_target_properties(clearCore-gui PROPERTIES
@@ -583,10 +585,12 @@ if (BUILD_QT6_UI)
             src/nsc_qt/widgets/register_widget.cpp
             src/nsc_qt/widgets/memory_widget.cpp
             src/nsc_qt/widgets/pipeline_trace_widget.cpp
+            src/nsc_qt/widgets/pipeline_events_widget.cpp
             include/nsc_qt/simulator_controller.h            # (moc)
             include/nsc_qt/widgets/register_widget.h         # (moc)
             include/nsc_qt/widgets/memory_widget.h           # (moc)
             include/nsc_qt/widgets/pipeline_trace_widget.h   # (moc)
+            include/nsc_qt/widgets/pipeline_events_widget.h  # (moc)
     )
     set_target_properties(qt_ui_test PROPERTIES AUTOMOC ON)
     target_include_directories(qt_ui_test PRIVATE include)

--- a/include/nsc_qt/instr_format.h
+++ b/include/nsc_qt/instr_format.h
@@ -1,0 +1,75 @@
+#pragma once
+
+// ── instr_format.h ──────────────────────────────────────────────────────────
+// Shared "raw word → human-readable assembly" formatter for the datapath
+// visualizers. Moved out of datapath_widget.cpp so the schematic datapath
+// widget can reuse it without duplicating the format switch.
+
+#include "mips/decoder.h"
+#include "mips/registers.h"
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+namespace nsc::qt {
+
+// Format a decoded instruction as a human-readable string. This is assembly
+// notation (mnemonics, register names), not natural-language UI copy, so it
+// intentionally is not routed through tr().
+inline std::string format_instr(uint32_t raw) {
+    using namespace mips;
+    auto decoded = Decoder::decode(raw);
+    if (!decoded) return "(?/?)";
+    const auto&        d  = *decoded;
+    std::string        mn = std::string(Decoder::mnemonic(d));
+    std::ostringstream os;
+    os << mn << " ";
+    switch (d.format) {
+    case InstrFormat::R: {
+        const auto& r = d.r();
+        if (d.opcode == Opcode::SPECIAL) {
+            using F = FunctCode;
+            if (r.funct == F::SLL || r.funct == F::SRL || r.funct == F::SRA) {
+                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rt) << ", "
+                   << +r.shamt;
+            } else if (r.funct == F::JR) {
+                os << "$" << register_abi_name(r.rs);
+            } else if (r.funct == F::JALR) {
+                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs);
+            } else {
+                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs) << ", $"
+                   << register_abi_name(r.rt);
+            }
+        }
+        break;
+    }
+    case InstrFormat::I: {
+        const auto& i = d.i();
+        if (d.opcode == Opcode::LW || d.opcode == Opcode::LBU || d.opcode == Opcode::LHU ||
+            d.opcode == Opcode::SW) {
+            os << "$" << register_abi_name(i.rt) << ", " << static_cast<int16_t>(i.imm) << "($"
+               << register_abi_name(i.rs) << ")";
+        } else if (d.opcode == Opcode::LUI) {
+            os << "$" << register_abi_name(i.rt) << ", 0x" << std::hex << i.imm;
+        } else if (d.opcode == Opcode::BEQ || d.opcode == Opcode::BNE) {
+            os << "$" << register_abi_name(i.rs) << ", $" << register_abi_name(i.rt) << ", "
+               << static_cast<int16_t>(i.imm);
+        } else {
+            os << "$" << register_abi_name(i.rt) << ", $" << register_abi_name(i.rs) << ", "
+               << static_cast<int16_t>(i.imm);
+        }
+        break;
+    }
+    case InstrFormat::J: {
+        const auto& j = d.j();
+        os << "0x" << std::hex << j.target;
+        break;
+    }
+    default:
+        break;
+    }
+    return os.str();
+}
+
+}  // namespace nsc::qt

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -25,6 +25,7 @@ class SchematicDatapathWidget;
 class RegisterWidget;
 class MemoryWidget;
 class PipelineTraceWidget;
+class PipelineEventsWidget;
 class CodeEditor;
 
 class MainWindow : public QMainWindow {
@@ -97,6 +98,7 @@ private:
     RegisterWidget*          register_widget_ = nullptr;
     MemoryWidget*            memory_widget_   = nullptr;
     PipelineTraceWidget*     trace_widget_    = nullptr;
+    PipelineEventsWidget*    events_widget_   = nullptr;
     CodeEditor*              code_editor_     = nullptr;
     QComboBox*               examples_combo_  = nullptr;
     QLabel*                  asm_status_lbl_  = nullptr;

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -101,14 +101,15 @@ private:
     QLabel*                  asm_status_lbl_  = nullptr;
 
     // Statistics labels
-    QLabel* stat_cycles_lbl_   = nullptr;
-    QLabel* stat_instrs_lbl_   = nullptr;
-    QLabel* stat_cpi_lbl_      = nullptr;
-    QLabel* stat_data_haz_lbl_ = nullptr;
-    QLabel* stat_ctrl_haz_lbl_ = nullptr;
-    QLabel* stat_fwd_lbl_      = nullptr;
-    QLabel* stat_stalls_lbl_   = nullptr;
-    QLabel* stat_flushes_lbl_  = nullptr;
+    QLabel*  stat_cycles_lbl_   = nullptr;
+    QLabel*  stat_instrs_lbl_   = nullptr;
+    QLabel*  stat_cpi_lbl_      = nullptr;
+    QLabel*  stat_data_haz_lbl_ = nullptr;
+    QLabel*  stat_ctrl_haz_lbl_ = nullptr;
+    QLabel*  stat_fwd_lbl_      = nullptr;
+    QLabel*  stat_stalls_lbl_   = nullptr;
+    QLabel*  stat_flushes_lbl_  = nullptr;
+    QWidget* stat_cpi_card_     = nullptr;  // KPI card widget, re-colored by CPI health
 
     // Status bar labels
     QLabel* status_cycles_lbl_ = nullptr;

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -101,14 +101,15 @@ private:
     QLabel*              asm_status_lbl_  = nullptr;
 
     // Statistics labels
-    QLabel* stat_cycles_lbl_   = nullptr;
-    QLabel* stat_instrs_lbl_   = nullptr;
-    QLabel* stat_cpi_lbl_      = nullptr;
-    QLabel* stat_data_haz_lbl_ = nullptr;
-    QLabel* stat_ctrl_haz_lbl_ = nullptr;
-    QLabel* stat_fwd_lbl_      = nullptr;
-    QLabel* stat_stalls_lbl_   = nullptr;
-    QLabel* stat_flushes_lbl_  = nullptr;
+    QLabel*  stat_cycles_lbl_   = nullptr;
+    QLabel*  stat_instrs_lbl_   = nullptr;
+    QLabel*  stat_cpi_lbl_      = nullptr;
+    QLabel*  stat_data_haz_lbl_ = nullptr;
+    QLabel*  stat_ctrl_haz_lbl_ = nullptr;
+    QLabel*  stat_fwd_lbl_      = nullptr;
+    QLabel*  stat_stalls_lbl_   = nullptr;
+    QLabel*  stat_flushes_lbl_  = nullptr;
+    QWidget* stat_cpi_card_     = nullptr;  // KPI card widget, re-colored by CPI health
 
     // Status bar labels
     QLabel* status_cycles_lbl_ = nullptr;

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -13,6 +13,7 @@ class QAction;
 class QToolBar;
 class QMenu;
 class QCloseEvent;
+class QSlider;
 
 namespace ads {
 class CDockManager;
@@ -115,6 +116,9 @@ private:
     QLabel* status_cycles_lbl_ = nullptr;
     QLabel* status_instrs_lbl_ = nullptr;
     QLabel* status_cpi_lbl_    = nullptr;
+
+    // Toolbar execution-speed slider (mirrors the Preferences setting)
+    QSlider* speed_slider_ = nullptr;
 
     // Actions
     QAction* act_step_      = nullptr;

--- a/include/nsc_qt/main_window.h
+++ b/include/nsc_qt/main_window.h
@@ -20,7 +20,7 @@ class CDockManager;
 
 namespace nsc::qt {
 
-class DatapathWidget;
+class SchematicDatapathWidget;
 class RegisterWidget;
 class MemoryWidget;
 class PipelineTraceWidget;
@@ -89,16 +89,16 @@ private:
     std::unique_ptr<SimulatorController> controller_;
 
     // Widgets
-    ads::CDockManager*   dock_manager_ = nullptr;
-    QByteArray           default_layout_;             // snapshot of the first-run arrangement
-    QMenu*               panels_menu_     = nullptr;  // View > Panels toggle actions
-    DatapathWidget*      datapath_widget_ = nullptr;
-    RegisterWidget*      register_widget_ = nullptr;
-    MemoryWidget*        memory_widget_   = nullptr;
-    PipelineTraceWidget* trace_widget_    = nullptr;
-    CodeEditor*          code_editor_     = nullptr;
-    QComboBox*           examples_combo_  = nullptr;
-    QLabel*              asm_status_lbl_  = nullptr;
+    ads::CDockManager*       dock_manager_ = nullptr;
+    QByteArray               default_layout_;             // snapshot of the first-run arrangement
+    QMenu*                   panels_menu_     = nullptr;  // View > Panels toggle actions
+    SchematicDatapathWidget* datapath_widget_ = nullptr;
+    RegisterWidget*          register_widget_ = nullptr;
+    MemoryWidget*            memory_widget_   = nullptr;
+    PipelineTraceWidget*     trace_widget_    = nullptr;
+    CodeEditor*              code_editor_     = nullptr;
+    QComboBox*               examples_combo_  = nullptr;
+    QLabel*                  asm_status_lbl_  = nullptr;
 
     // Statistics labels
     QLabel* stat_cycles_lbl_   = nullptr;

--- a/include/nsc_qt/widgets/pipeline_events_widget.h
+++ b/include/nsc_qt/widgets/pipeline_events_widget.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// ── pipeline_events_widget.h ────────────────────────────────────────────────
+// Scrolling, colour-coded log of pipeline events: every forward, stall, and
+// flush as it happens, plus program-level milestones (load, reset, halt,
+// fault, breakpoints). Complements the schematic's in-place highlights with
+// a persistent history a student can read back after a run — "what happened
+// while I wasn't looking" — and pairs with the Statistics counters by
+// showing the individual events behind each total.
+
+#include "mips/processor.h"
+#include <QColor>
+#include <QHash>
+#include <QString>
+#include <QWidget>
+#include <cstdint>
+
+class QListWidget;
+class QLabel;
+
+namespace nsc::qt {
+
+class PipelineEventsWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    // Event categories, colour-coded to match the schematic's wire palette
+    // (forwarding orange/purple, stall amber, flush red).
+    enum class Kind : uint8_t { FwdExMem, FwdMemWb, Stall, Flush, Info, Success, Error };
+
+    explicit PipelineEventsWidget(QWidget* parent = nullptr);
+
+    // Derives and logs the hazard events visible in `state` (forwards,
+    // load-use stall, branch flush). Consecutive-cycle repeats of the same
+    // event are suppressed so a multi-cycle stall reads as one entry.
+    void updateCycle(const mips::PipelineState& state);
+
+    // Appends one entry. `cycle` prefixes the message; pass the current
+    // cycle count for program-level events.
+    void logEvent(Kind kind, uint64_t cycle, const QString& text);
+
+    void clear();
+    void setDarkMode(bool dark);
+
+    // Number of entries currently in the log (for tests).
+    int eventCount() const;
+
+private:
+    QColor kindColor(Kind kind) const;
+
+    static constexpr int kMaxEntries = 500;
+
+    QListWidget* list_      = nullptr;
+    QLabel*      count_lbl_ = nullptr;
+    bool         dark_mode_ = false;
+
+    // Rising-edge suppression: text → cycle it was last logged for.
+    QHash<QString, quint64> recent_;
+};
+
+}  // namespace nsc::qt

--- a/include/nsc_qt/widgets/schematic_datapath_widget.h
+++ b/include/nsc_qt/widgets/schematic_datapath_widget.h
@@ -1,0 +1,97 @@
+#pragma once
+
+// ── schematic_datapath_widget.h ─────────────────────────────────────────────
+// Ripes-style circuit-schematic view of the 5-stage MIPS pipeline, built on
+// QGraphicsView/QGraphicsScene (the same architecture Ripes' VSRTL renderer
+// uses). Functional units (PC, memories, register file, ALU, muxes, adders)
+// are QGraphicsItems laid out in a fixed logical coordinate space; wires are
+// orthogonal painter paths with arrowheads and junction dots.
+//
+// Live state binding (setPipelineState):
+//   • a mnemonic label above each stage column (like Ripes' top labels)
+//   • pipeline-register bars tint red on flush / amber on stall
+//   • forwarding wires light up when the fwd_* flags are set
+//   • the branch-target wire back to the PC mux lights red on branch_flush
+//
+// Public API and signals mirror DatapathWidget exactly so MainWindow can swap
+// between the two with a one-line change.
+
+#include "mips/processor.h"
+
+#include <QGraphicsView>
+#include <array>
+#include <cstdint>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+class QGraphicsScene;
+class QGraphicsEllipseItem;
+class QGraphicsRectItem;
+class QGraphicsSimpleTextItem;
+
+namespace nsc::qt {
+
+class WireItem;
+
+class SchematicDatapathWidget : public QGraphicsView {
+    Q_OBJECT
+
+public:
+    explicit SchematicDatapathWidget(QWidget* parent = nullptr);
+
+    void setPipelineState(const mips::PipelineState& state);
+    void setBreakpoints(const std::unordered_set<uint32_t>& bps);
+    void setDarkMode(bool dark);
+
+signals:
+    void breakpointToggleRequested(uint32_t pc);
+    void stageDetailRequested(int stage_index, uint32_t pc, uint32_t raw_instr);
+
+protected:
+    void wheelEvent(QWheelEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    void contextMenuEvent(QContextMenuEvent* ev) override;
+    void keyPressEvent(QKeyEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void focusInEvent(QFocusEvent* ev) override;
+    void focusOutEvent(QFocusEvent* ev) override;
+
+private:
+    // Scene construction (runs once; items are retained and re-themed).
+    void buildScene();
+    // Push state_ / dark_mode_ / breakpoints_ into the retained items.
+    void applyState();
+    void applyTheme();
+
+    // Stage column index (0–4) at a view position, or -1.
+    int stageAtViewPos(const QPoint& pos) const;
+    // Zoom-to-fit while the user hasn't zoomed manually.
+    void fitSchematic();
+
+    QGraphicsScene* scene_ = nullptr;
+
+    // Retained items updated per cycle / theme change.
+    std::array<QGraphicsSimpleTextItem*, 5> stage_labels_{};  // mnemonics above columns
+    std::array<QGraphicsRectItem*, 5>       stage_tints_{};   // translucent column bands
+    std::array<QGraphicsRectItem*, 4>       pipe_regs_{};     // IF/ID … MEM/WB bars
+    std::vector<WireItem*>                  wires_;           // all wires (for re-theme)
+    WireItem*                               fwd_exmem_wire_ = nullptr;
+    WireItem*          fwd_exmem_stub_ = nullptr;  // mux-B branch of the fwd bus
+    WireItem*          fwd_memwb_wire_ = nullptr;
+    WireItem*          fwd_memwb_stub_ = nullptr;
+    WireItem*          branch_wire_    = nullptr;
+    WireItem*          writeback_wire_ = nullptr;
+    QGraphicsRectItem* focus_ring_     = nullptr;
+    // Per-stage breakpoint bullseye (outer ring, punched-out centre).
+    std::array<std::pair<QGraphicsEllipseItem*, QGraphicsEllipseItem*>, 5> bp_markers_{};
+
+    mips::PipelineState          state_{};
+    std::unordered_set<uint32_t> breakpoints_{};
+    bool                         dark_mode_      = false;
+    bool                         user_zoomed_    = false;
+    int                          selected_stage_ = 0;
+};
+
+}  // namespace nsc::qt

--- a/include/nsc_qt/widgets/schematic_datapath_widget.h
+++ b/include/nsc_qt/widgets/schematic_datapath_widget.h
@@ -31,6 +31,7 @@ class QGraphicsEllipseItem;
 class QGraphicsLineItem;
 class QGraphicsRectItem;
 class QGraphicsSimpleTextItem;
+class QToolButton;
 class QVariantAnimation;
 
 namespace nsc::qt {
@@ -77,6 +78,8 @@ private:
     void fitSchematic();
     // Refresh the live parts of the educational component tooltips.
     void updateTooltips();
+    // Multiply the current view scale by `factor`, clamped; marks user zoom.
+    void zoomBy(qreal factor);
     // Render the scene to a 2x PNG chosen via a save dialog (lab reports).
     void exportImage();
     // Slide a token from each stage column to the next for instructions that
@@ -126,6 +129,16 @@ private:
     // Step-animation tokens gliding between stage columns on each clock edge.
     std::array<QGraphicsRectItem*, 5> tokens_{};
     QVariantAnimation*                token_anim_ = nullptr;
+
+    // Hazard explainer chip: names and explains the stall/flush the moment
+    // it happens, in the hazard's colour.
+    QGraphicsRectItem*       hazard_chip_ = nullptr;
+    QGraphicsSimpleTextItem* hazard_text_ = nullptr;
+
+    // Zoom controls overlaid on the view (discoverable alternative to Ctrl+wheel).
+    QToolButton* btn_zoom_in_  = nullptr;
+    QToolButton* btn_zoom_out_ = nullptr;
+    QToolButton* btn_zoom_fit_ = nullptr;
 
     mips::PipelineState          state_{};
     std::unordered_set<uint32_t> breakpoints_{};

--- a/include/nsc_qt/widgets/schematic_datapath_widget.h
+++ b/include/nsc_qt/widgets/schematic_datapath_widget.h
@@ -31,6 +31,7 @@ class QGraphicsEllipseItem;
 class QGraphicsLineItem;
 class QGraphicsRectItem;
 class QGraphicsSimpleTextItem;
+class QVariantAnimation;
 
 namespace nsc::qt {
 
@@ -78,6 +79,9 @@ private:
     void updateTooltips();
     // Render the scene to a 2x PNG chosen via a save dialog (lab reports).
     void exportImage();
+    // Slide a token from each stage column to the next for instructions that
+    // advanced between `old_state` and the current state_ (one clock edge).
+    void startTokenAnimation(const mips::PipelineState& old_state);
 
     QGraphicsScene* scene_ = nullptr;
 
@@ -108,6 +112,20 @@ private:
     std::array<QGraphicsSimpleTextItem*, 5> stage_pc_labels_{};     // PCs under the mnemonics
     std::vector<QGraphicsLineItem*>         legend_swatches_;       // wire-colour legend
     std::vector<QGraphicsSimpleTextItem*>   legend_texts_;
+
+    // Mux select-input markers: a dot on the input port each mux is passing
+    // through this cycle. Index: 0 = PC-source, 1 = fwd A, 2 = fwd B, 3 = WB.
+    std::array<QGraphicsEllipseItem*, 4> mux_markers_{};
+
+    // Live value labels pinned to wires whose values are known exactly:
+    // the fetch PC, the ID-stage immediate, and the WB write-back result.
+    QGraphicsSimpleTextItem* val_pc_  = nullptr;
+    QGraphicsSimpleTextItem* val_imm_ = nullptr;
+    QGraphicsSimpleTextItem* val_wb_  = nullptr;
+
+    // Step-animation tokens gliding between stage columns on each clock edge.
+    std::array<QGraphicsRectItem*, 5> tokens_{};
+    QVariantAnimation*                token_anim_ = nullptr;
 
     mips::PipelineState          state_{};
     std::unordered_set<uint32_t> breakpoints_{};

--- a/include/nsc_qt/widgets/schematic_datapath_widget.h
+++ b/include/nsc_qt/widgets/schematic_datapath_widget.h
@@ -25,8 +25,10 @@
 #include <utility>
 #include <vector>
 
+class QAbstractGraphicsShapeItem;
 class QGraphicsScene;
 class QGraphicsEllipseItem;
+class QGraphicsLineItem;
 class QGraphicsRectItem;
 class QGraphicsSimpleTextItem;
 
@@ -43,6 +45,9 @@ public:
     void setPipelineState(const mips::PipelineState& state);
     void setBreakpoints(const std::unordered_set<uint32_t>& bps);
     void setDarkMode(bool dark);
+    // Live register-file contents, used to enrich component tooltips with the
+    // actual operand values of the instructions in flight.
+    void setRegisterValues(const std::array<uint32_t, 32>& regs);
 
 signals:
     void breakpointToggleRequested(uint32_t pc);
@@ -69,6 +74,10 @@ private:
     int stageAtViewPos(const QPoint& pos) const;
     // Zoom-to-fit while the user hasn't zoomed manually.
     void fitSchematic();
+    // Refresh the live parts of the educational component tooltips.
+    void updateTooltips();
+    // Render the scene to a 2x PNG chosen via a save dialog (lab reports).
+    void exportImage();
 
     QGraphicsScene* scene_ = nullptr;
 
@@ -87,8 +96,22 @@ private:
     // Per-stage breakpoint bullseye (outer ring, punched-out centre).
     std::array<std::pair<QGraphicsEllipseItem*, QGraphicsEllipseItem*>, 5> bp_markers_{};
 
+    // Components with live tooltips / control-signal accents.
+    QAbstractGraphicsShapeItem* pc_box_      = nullptr;
+    QAbstractGraphicsShapeItem* imem_box_    = nullptr;
+    QAbstractGraphicsShapeItem* control_box_ = nullptr;
+    QAbstractGraphicsShapeItem* regs_box_    = nullptr;
+    QAbstractGraphicsShapeItem* alu_item_    = nullptr;
+    QAbstractGraphicsShapeItem* dmem_box_    = nullptr;
+
+    QGraphicsSimpleTextItem*                cycle_text_ = nullptr;  // in-scene cycle counter
+    std::array<QGraphicsSimpleTextItem*, 5> stage_pc_labels_{};     // PCs under the mnemonics
+    std::vector<QGraphicsLineItem*>         legend_swatches_;       // wire-colour legend
+    std::vector<QGraphicsSimpleTextItem*>   legend_texts_;
+
     mips::PipelineState          state_{};
     std::unordered_set<uint32_t> breakpoints_{};
+    std::array<uint32_t, 32>     reg_values_{};
     bool                         dark_mode_      = false;
     bool                         user_zoomed_    = false;
     int                          selected_stage_ = 0;

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -6,10 +6,10 @@
 #include "nsc_qt/examples.h"
 #include "nsc_qt/preferences_dialog.h"
 #include "nsc_qt/widgets/code_editor.h"
-#include "nsc_qt/widgets/datapath_widget.h"
 #include "nsc_qt/widgets/memory_widget.h"
 #include "nsc_qt/widgets/pipeline_trace_widget.h"
 #include "nsc_qt/widgets/register_widget.h"
+#include "nsc_qt/widgets/schematic_datapath_widget.h"
 
 #include "mips/decoder.h"
 #include "mips/pipelined_cpu.h"
@@ -159,7 +159,7 @@ void MainWindow::setupCentralWidget() {
     ads::CDockManager::setConfigFlag(ads::CDockManager::DockAreaHasUndockButton, false);
     dock_manager_ = new ads::CDockManager(this);
 
-    datapath_widget_ = new DatapathWidget(this);
+    datapath_widget_ = new SchematicDatapathWidget(this);
     register_widget_ = new RegisterWidget(this);
     memory_widget_   = new MemoryWidget(this);
     trace_widget_    = new PipelineTraceWidget(this);
@@ -415,9 +415,9 @@ void MainWindow::setupConnections() {
         setRunState(false);
     });
 
-    connect(datapath_widget_, &DatapathWidget::breakpointToggleRequested, this,
+    connect(datapath_widget_, &SchematicDatapathWidget::breakpointToggleRequested, this,
             &MainWindow::onBreakpointToggle);
-    connect(datapath_widget_, &DatapathWidget::stageDetailRequested, this,
+    connect(datapath_widget_, &SchematicDatapathWidget::stageDetailRequested, this,
             &MainWindow::onStageDetailRequested);
 }
 

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -359,39 +359,75 @@ void MainWindow::onExampleSelected(int idx) {
 }
 
 QWidget* MainWindow::createStatisticsTab() {
-    auto* w  = new QWidget;
+    auto* w = new QWidget;
+    w->setAutoFillBackground(true);
     auto* vl = new QVBoxLayout(w);
-    vl->setContentsMargins(16, 16, 16, 16);
+    vl->setContentsMargins(12, 12, 12, 12);
     vl->setSpacing(12);
 
-    auto mkLabel = [&](QFormLayout* fl, const QString& name, QLabel*& ptr) {
-        ptr = new QLabel("—", w);
-        ptr->setFont(scale::monoFont(scale::kFontSizeBody));
-        fl->addRow(name, ptr);
+    // ── KPI card row ──────────────────────────────────────────────────────────
+    // Three headline metrics in large-number "cards" for immediate readability.
+    // The CPI card background is color-coded (green/orange/red) in onStatisticsUpdated()
+    // and stored in stat_cpi_card_ for later updates. Values are mouse-selectable
+    // so students can copy numbers into lab reports without retyping.
+    auto mkCard = [&](const QString& label, QLabel*& val_ptr) -> QFrame* {
+        auto* card = new QFrame(w);
+        card->setFrameShape(QFrame::StyledPanel);
+        card->setObjectName("statCard");
+        auto* cl = new QVBoxLayout(card);
+        cl->setContentsMargins(12, 10, 12, 10);
+        cl->setSpacing(4);
+
+        val_ptr = new QLabel("—", card);
+        val_ptr->setAlignment(Qt::AlignCenter);
+        val_ptr->setFont(scale::monoFont(26, true));
+        val_ptr->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        auto* name_lbl = new QLabel(label, card);
+        name_lbl->setAlignment(Qt::AlignCenter);
+        name_lbl->setObjectName("statCardLabel");
+        name_lbl->setFont(scale::monoFont(scale::kFontSizeDense));
+
+        cl->addWidget(val_ptr);
+        cl->addWidget(name_lbl);
+        return card;
     };
 
-    // ── Performance group ──────────────────────────────────────────────────────
-    auto* perf_box = new QGroupBox(tr("Performance"), w);
-    auto* perf_fl  = new QFormLayout(perf_box);
-    perf_fl->setContentsMargins(12, 8, 12, 8);
-    perf_fl->setSpacing(8);
-    perf_fl->setLabelAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    mkLabel(perf_fl, tr("Cycles executed:"), stat_cycles_lbl_);
-    mkLabel(perf_fl, tr("Instructions retired:"), stat_instrs_lbl_);
-    mkLabel(perf_fl, tr("CPI:"), stat_cpi_lbl_);
-    vl->addWidget(perf_box);
+    auto* kpi_row = new QHBoxLayout;
+    kpi_row->setSpacing(8);
+    kpi_row->addWidget(mkCard(tr("Cycles"), stat_cycles_lbl_), 1);
+    kpi_row->addWidget(mkCard(tr("Instructions"), stat_instrs_lbl_), 1);
+    auto* cpi_card = mkCard(tr("CPI"), stat_cpi_lbl_);
+    cpi_card->setToolTip(tr("Cycles Per Instruction — lower is better\n"
+                            "1.0 = ideal (no stalls)   >2.0 = heavy pipeline overhead"));
+    stat_cpi_card_ = cpi_card;
+    kpi_row->addWidget(cpi_card, 1);
+    vl->addLayout(kpi_row);
 
-    // ── Pipeline events group ──────────────────────────────────────────────────
+    // ── Pipeline events ────────────────────────────────────────────────────────
     auto* pipe_box = new QGroupBox(tr("Pipeline Events"), w);
     auto* pipe_fl  = new QFormLayout(pipe_box);
-    pipe_fl->setContentsMargins(12, 8, 12, 8);
+    pipe_fl->setContentsMargins(12, 8, 12, 12);
     pipe_fl->setSpacing(8);
     pipe_fl->setLabelAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    mkLabel(pipe_fl, tr("Data hazards:"), stat_data_haz_lbl_);
-    mkLabel(pipe_fl, tr("Control hazards:"), stat_ctrl_haz_lbl_);
-    mkLabel(pipe_fl, tr("Forwarding events:"), stat_fwd_lbl_);
-    mkLabel(pipe_fl, tr("Stalls:"), stat_stalls_lbl_);
-    mkLabel(pipe_fl, tr("Flushes:"), stat_flushes_lbl_);
+
+    auto mkRow = [&](const QString& name, QLabel*& ptr, const QString& tip) {
+        ptr = new QLabel("—", pipe_box);
+        ptr->setFont(scale::monoFont(scale::kFontSizeBody));
+        ptr->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        ptr->setToolTip(tip);
+        pipe_fl->addRow(name, ptr);
+    };
+    mkRow(tr("Data hazards:"), stat_data_haz_lbl_,
+          tr("RAW (Read-After-Write) hazards detected in the Decode stage"));
+    mkRow(tr("Control hazards:"), stat_ctrl_haz_lbl_,
+          tr("Hazards from branches and jumps that disrupted the pipeline"));
+    mkRow(tr("Forwarding events:"), stat_fwd_lbl_,
+          tr("Times the forwarding unit bypassed the register file to resolve a data hazard"));
+    mkRow(tr("Stalls:"), stat_stalls_lbl_,
+          tr("Bubble cycles inserted for hazards that could not be resolved by forwarding"));
+    mkRow(tr("Flushes:"), stat_flushes_lbl_,
+          tr("Pipeline flushes caused by branch mispredictions or control hazards"));
     vl->addWidget(pipe_box);
 
     vl->addStretch();
@@ -581,14 +617,35 @@ void MainWindow::onStatisticsUpdated(nsc::qt::SimulatorStatistics stats) {
 
     if (cpi > 0) {
         stat_cpi_lbl_->setText(QString::number(cpi, 'f', 2));
-        const QColor cpi_color = cpi >= 2.0   ? QColor("#F44336")
-                                 : cpi >= 1.5 ? QColor("#FF9800")
-                                              : QColor("#4CAF50");
+        const QColor text_color = cpi >= 2.0   ? QColor("#F44336")
+                                  : cpi >= 1.5 ? QColor("#FF9800")
+                                               : QColor("#4CAF50");
         stat_cpi_lbl_->setStyleSheet(
-            QString("color: %1; font-weight: bold;").arg(cpi_color.name()));
+            QString("color: %1; font-weight: bold;").arg(text_color.name()));
+        // Color the card background to give a glanceable health signal even
+        // when the user isn't reading the exact number.
+        if (stat_cpi_card_) {
+            const QColor bg  = dark_mode_ ? (cpi >= 2.0   ? QColor("#3D1515")
+                                             : cpi >= 1.5 ? QColor("#3D2D10")
+                                                          : QColor("#152D15"))
+                                          : (cpi >= 2.0   ? QColor("#FFEBEE")
+                                             : cpi >= 1.5 ? QColor("#FFF3E0")
+                                                          : QColor("#E8F5E9"));
+            const QColor bdr = dark_mode_ ? (cpi >= 2.0   ? QColor("#7C2020")
+                                             : cpi >= 1.5 ? QColor("#7C5810")
+                                                          : QColor("#1E7C1E"))
+                                          : (cpi >= 2.0   ? QColor("#EF9A9A")
+                                             : cpi >= 1.5 ? QColor("#FFCC80")
+                                                          : QColor("#A5D6A7"));
+            stat_cpi_card_->setStyleSheet(
+                QString(
+                    "QFrame#statCard { background: %1; border: 1px solid %2; border-radius: 6px; }")
+                    .arg(bg.name(), bdr.name()));
+        }
     } else {
         stat_cpi_lbl_->setText("—");
         stat_cpi_lbl_->setStyleSheet("");
+        if (stat_cpi_card_) stat_cpi_card_->setStyleSheet("");
     }
 
     stat_data_haz_lbl_->setText(QString::number(stats.data_hazards));
@@ -714,6 +771,14 @@ void MainWindow::applyColorScheme(bool dark) {
         pal.setColor(QPalette::Button, QColor(0x3C, 0x3C, 0x3C));
         pal.setColor(QPalette::ButtonText, Qt::white);
         pal.setColor(QPalette::BrightText, Qt::red);
+        // 3D/bevel roles — set explicitly so ADS's palette(light/dark/mid) selectors
+        // resolve to our dark-theme values rather than the system palette's defaults.
+        pal.setColor(QPalette::Light, QColor(0x3C, 0x3C, 0x3C));
+        pal.setColor(QPalette::Midlight, QColor(0x2D, 0x2D, 0x2D));
+        pal.setColor(QPalette::Dark, QColor(0x14, 0x14, 0x14));
+        pal.setColor(QPalette::Mid, QColor(0x22, 0x22, 0x22));
+        pal.setColor(QPalette::Shadow, Qt::black);
+        pal.setColor(QPalette::PlaceholderText, QColor(0x66, 0x66, 0x66));
         pal.setColor(QPalette::Highlight, QColor(0x26, 0x4F, 0x78));
         pal.setColor(QPalette::HighlightedText, Qt::white);
     } else {
@@ -726,6 +791,15 @@ void MainWindow::applyColorScheme(bool dark) {
         pal.setColor(QPalette::Text, Qt::black);
         pal.setColor(QPalette::Button, QColor(0xEE, 0xEE, 0xEE));
         pal.setColor(QPalette::ButtonText, Qt::black);
+        // 3D/bevel roles — critical: ADS uses palette(light) as CDockWidget background.
+        // Setting Light=white here means that background resolves to white in light mode
+        // rather than inheriting whatever the system's dark theme has for QPalette::Light.
+        pal.setColor(QPalette::Light, Qt::white);
+        pal.setColor(QPalette::Midlight, QColor(0xF8, 0xF8, 0xF8));
+        pal.setColor(QPalette::Dark, QColor(0xBE, 0xBE, 0xBE));
+        pal.setColor(QPalette::Mid, QColor(0xD0, 0xD0, 0xD0));
+        pal.setColor(QPalette::Shadow, QColor(0x80, 0x80, 0x80));
+        pal.setColor(QPalette::PlaceholderText, QColor(0x99, 0x99, 0x99));
         pal.setColor(QPalette::Highlight, QColor(0x00, 0x78, 0xD4));
         pal.setColor(QPalette::HighlightedText, Qt::white);
     }
@@ -860,12 +934,16 @@ QComboBox {
     color: #CCCCCC;
     border: 1px solid #555555;
     border-radius: 3px;
-    padding: 4px 8px;
+    padding: 4px 8px 4px 10px;
     min-width: 80px;
 }
 QComboBox:hover { border-color: #777777; }
-QComboBox::drop-down { border: none; width: 20px; }
-QComboBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top: 4px solid #888; }
+QComboBox::drop-down {
+    border: none;
+    border-left: 1px solid #555555;
+    width: 22px;
+    background: transparent;
+}
 QComboBox QAbstractItemView {
     background: #252526;
     color: #CCCCCC;
@@ -878,6 +956,14 @@ QWidget#codeEditorBtnBar {
     background: #252526;
     border-top: 1px solid #3C3C3C;
 }
+
+QFrame#statCard {
+    background: #2D2D2D;
+    border: 1px solid #3C3C3C;
+    border-radius: 6px;
+}
+QFrame#statCard QLabel { background: transparent; }
+QLabel#statCardLabel { color: #888888; }
 )"
                              : R"(
 QMainWindow, QDialog { background: #F5F5F5; }
@@ -1007,12 +1093,16 @@ QComboBox {
     color: #333333;
     border: 1px solid #CCCCCC;
     border-radius: 3px;
-    padding: 4px 8px;
+    padding: 4px 8px 4px 10px;
     min-width: 80px;
 }
 QComboBox:hover { border-color: #AAAAAA; }
-QComboBox::drop-down { border: none; width: 20px; }
-QComboBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top: 4px solid #666; }
+QComboBox::drop-down {
+    border: none;
+    border-left: 1px solid #CCCCCC;
+    width: 22px;
+    background: transparent;
+}
 QComboBox QAbstractItemView {
     background: white;
     color: #333333;
@@ -1025,6 +1115,14 @@ QWidget#codeEditorBtnBar {
     background: #F0F0F0;
     border-top: 1px solid #DDDDDD;
 }
+
+QFrame#statCard {
+    background: white;
+    border: 1px solid #E0E0E0;
+    border-radius: 6px;
+}
+QFrame#statCard QLabel { background: transparent; }
+QLabel#statCardLabel { color: #777777; }
 )";
     qApp->setStyleSheet(qss);
 
@@ -1053,6 +1151,8 @@ ads--CDockWidgetTab[activeTab="true"] {
 }
 ads--CDockWidgetTab QLabel           { color: #888888; }
 ads--CDockWidgetTab[activeTab="true"] QLabel { color: #FFFFFF; }
+ads--CDockWidget { background: #1E1E1E; border: none; }
+QScrollArea#dockWidgetScrollArea { background: transparent; border: none; }
 )"
                                               : R"(
 ads--CDockContainerWidget { background: #F5F5F5; }
@@ -1071,9 +1171,14 @@ ads--CDockWidgetTab[activeTab="true"] {
 }
 ads--CDockWidgetTab QLabel           { color: #555555; }
 ads--CDockWidgetTab[activeTab="true"] QLabel { color: #1A1A1A; }
+ads--CDockWidget { background: white; border: none; }
+QScrollArea#dockWidgetScrollArea { background: transparent; border: none; }
 )";
         dock_manager_->setStyleSheet(ads_base + ads_theme);
     }
+
+    // Reset the CPI card to the QSS default (color re-applied by onStatisticsUpdated).
+    if (stat_cpi_card_) stat_cpi_card_->setStyleSheet("");
 
     datapath_widget_->setDarkMode(dark);
     register_widget_->setDarkMode(dark);

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -285,15 +285,15 @@ QWidget* MainWindow::createCodeEditorTab() {
                                         "#   add  $t2, $t0, $t1\n"));
     vl->addWidget(code_editor_);
 
-    // Separator line above button row
-    auto* sep = new QFrame(w);
-    sep->setFrameShape(QFrame::HLine);
-    sep->setFrameShadow(QFrame::Sunken);
-    vl->addWidget(sep);
-
-    auto* btn_row = new QHBoxLayout;
+    // Button toolbar row — given a named container so the QSS can set its
+    // background independently of the ADS dock area that hosts this panel.
+    auto* btn_bar = new QWidget(w);
+    btn_bar->setObjectName("codeEditorBtnBar");
+    btn_bar->setAutoFillBackground(true);
+    auto* btn_row = new QHBoxLayout(btn_bar);
     btn_row->setContentsMargins(8, 6, 8, 6);
     btn_row->setSpacing(8);
+    vl->addWidget(btn_bar);
 
     auto* asm_btn = new QPushButton(tr("Assemble"), w);
     asm_btn->setObjectName("primaryButton");
@@ -318,7 +318,7 @@ QWidget* MainWindow::createCodeEditorTab() {
     connect(examples_combo_, qOverload<int>(&QComboBox::activated), this,
             &MainWindow::onExampleSelected);
 
-    asm_status_lbl_ = new QLabel(w);
+    asm_status_lbl_ = new QLabel(btn_bar);
     asm_status_lbl_->setFont(scale::monoFont(scale::kFontSizeBody));
     btn_row->addWidget(asm_btn);
     btn_row->addWidget(load_btn);
@@ -327,7 +327,6 @@ QWidget* MainWindow::createCodeEditorTab() {
     btn_row->addSpacing(12);
     btn_row->addWidget(asm_status_lbl_);
     btn_row->addStretch();
-    vl->addLayout(btn_row);
 
     connect(asm_btn, &QPushButton::clicked, this, &MainWindow::onAssemble);
     connect(load_btn, &QPushButton::clicked, this, &MainWindow::onLoad);
@@ -360,39 +359,75 @@ void MainWindow::onExampleSelected(int idx) {
 }
 
 QWidget* MainWindow::createStatisticsTab() {
-    auto* w  = new QWidget;
+    auto* w = new QWidget;
+    w->setAutoFillBackground(true);
     auto* vl = new QVBoxLayout(w);
-    vl->setContentsMargins(16, 16, 16, 16);
+    vl->setContentsMargins(12, 12, 12, 12);
     vl->setSpacing(12);
 
-    auto mkLabel = [&](QFormLayout* fl, const QString& name, QLabel*& ptr) {
-        ptr = new QLabel("—", w);
-        ptr->setFont(scale::monoFont(scale::kFontSizeBody));
-        fl->addRow(name, ptr);
+    // ── KPI card row ──────────────────────────────────────────────────────────
+    // Three headline metrics in large-number "cards" for immediate readability.
+    // The CPI card background is color-coded (green/orange/red) in onStatisticsUpdated()
+    // and stored in stat_cpi_card_ for later updates. Values are mouse-selectable
+    // so students can copy numbers into lab reports without retyping.
+    auto mkCard = [&](const QString& label, QLabel*& val_ptr) -> QFrame* {
+        auto* card = new QFrame(w);
+        card->setFrameShape(QFrame::StyledPanel);
+        card->setObjectName("statCard");
+        auto* cl = new QVBoxLayout(card);
+        cl->setContentsMargins(12, 10, 12, 10);
+        cl->setSpacing(4);
+
+        val_ptr = new QLabel("—", card);
+        val_ptr->setAlignment(Qt::AlignCenter);
+        val_ptr->setFont(scale::monoFont(26, true));
+        val_ptr->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        auto* name_lbl = new QLabel(label, card);
+        name_lbl->setAlignment(Qt::AlignCenter);
+        name_lbl->setObjectName("statCardLabel");
+        name_lbl->setFont(scale::monoFont(scale::kFontSizeDense));
+
+        cl->addWidget(val_ptr);
+        cl->addWidget(name_lbl);
+        return card;
     };
 
-    // ── Performance group ──────────────────────────────────────────────────────
-    auto* perf_box = new QGroupBox(tr("Performance"), w);
-    auto* perf_fl  = new QFormLayout(perf_box);
-    perf_fl->setContentsMargins(12, 8, 12, 8);
-    perf_fl->setSpacing(8);
-    perf_fl->setLabelAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    mkLabel(perf_fl, tr("Cycles executed:"), stat_cycles_lbl_);
-    mkLabel(perf_fl, tr("Instructions retired:"), stat_instrs_lbl_);
-    mkLabel(perf_fl, tr("CPI:"), stat_cpi_lbl_);
-    vl->addWidget(perf_box);
+    auto* kpi_row = new QHBoxLayout;
+    kpi_row->setSpacing(8);
+    kpi_row->addWidget(mkCard(tr("Cycles"), stat_cycles_lbl_), 1);
+    kpi_row->addWidget(mkCard(tr("Instructions"), stat_instrs_lbl_), 1);
+    auto* cpi_card = mkCard(tr("CPI"), stat_cpi_lbl_);
+    cpi_card->setToolTip(tr("Cycles Per Instruction — lower is better\n"
+                            "1.0 = ideal (no stalls)   >2.0 = heavy pipeline overhead"));
+    stat_cpi_card_ = cpi_card;
+    kpi_row->addWidget(cpi_card, 1);
+    vl->addLayout(kpi_row);
 
-    // ── Pipeline events group ──────────────────────────────────────────────────
+    // ── Pipeline events ────────────────────────────────────────────────────────
     auto* pipe_box = new QGroupBox(tr("Pipeline Events"), w);
     auto* pipe_fl  = new QFormLayout(pipe_box);
-    pipe_fl->setContentsMargins(12, 8, 12, 8);
+    pipe_fl->setContentsMargins(12, 8, 12, 12);
     pipe_fl->setSpacing(8);
     pipe_fl->setLabelAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    mkLabel(pipe_fl, tr("Data hazards:"), stat_data_haz_lbl_);
-    mkLabel(pipe_fl, tr("Control hazards:"), stat_ctrl_haz_lbl_);
-    mkLabel(pipe_fl, tr("Forwarding events:"), stat_fwd_lbl_);
-    mkLabel(pipe_fl, tr("Stalls:"), stat_stalls_lbl_);
-    mkLabel(pipe_fl, tr("Flushes:"), stat_flushes_lbl_);
+
+    auto mkRow = [&](const QString& name, QLabel*& ptr, const QString& tip) {
+        ptr = new QLabel("—", pipe_box);
+        ptr->setFont(scale::monoFont(scale::kFontSizeBody));
+        ptr->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        ptr->setToolTip(tip);
+        pipe_fl->addRow(name, ptr);
+    };
+    mkRow(tr("Data hazards:"), stat_data_haz_lbl_,
+          tr("RAW (Read-After-Write) hazards detected in the Decode stage"));
+    mkRow(tr("Control hazards:"), stat_ctrl_haz_lbl_,
+          tr("Hazards from branches and jumps that disrupted the pipeline"));
+    mkRow(tr("Forwarding events:"), stat_fwd_lbl_,
+          tr("Times the forwarding unit bypassed the register file to resolve a data hazard"));
+    mkRow(tr("Stalls:"), stat_stalls_lbl_,
+          tr("Bubble cycles inserted for hazards that could not be resolved by forwarding"));
+    mkRow(tr("Flushes:"), stat_flushes_lbl_,
+          tr("Pipeline flushes caused by branch mispredictions or control hazards"));
     vl->addWidget(pipe_box);
 
     vl->addStretch();
@@ -582,14 +617,35 @@ void MainWindow::onStatisticsUpdated(nsc::qt::SimulatorStatistics stats) {
 
     if (cpi > 0) {
         stat_cpi_lbl_->setText(QString::number(cpi, 'f', 2));
-        const QColor cpi_color = cpi >= 2.0   ? QColor("#F44336")
-                                 : cpi >= 1.5 ? QColor("#FF9800")
-                                              : QColor("#4CAF50");
+        const QColor text_color = cpi >= 2.0   ? QColor("#F44336")
+                                  : cpi >= 1.5 ? QColor("#FF9800")
+                                               : QColor("#4CAF50");
         stat_cpi_lbl_->setStyleSheet(
-            QString("color: %1; font-weight: bold;").arg(cpi_color.name()));
+            QString("color: %1; font-weight: bold;").arg(text_color.name()));
+        // Color the card background to give a glanceable health signal even
+        // when the user isn't reading the exact number.
+        if (stat_cpi_card_) {
+            const QColor bg  = dark_mode_ ? (cpi >= 2.0   ? QColor("#3D1515")
+                                             : cpi >= 1.5 ? QColor("#3D2D10")
+                                                          : QColor("#152D15"))
+                                          : (cpi >= 2.0   ? QColor("#FFEBEE")
+                                             : cpi >= 1.5 ? QColor("#FFF3E0")
+                                                          : QColor("#E8F5E9"));
+            const QColor bdr = dark_mode_ ? (cpi >= 2.0   ? QColor("#7C2020")
+                                             : cpi >= 1.5 ? QColor("#7C5810")
+                                                          : QColor("#1E7C1E"))
+                                          : (cpi >= 2.0   ? QColor("#EF9A9A")
+                                             : cpi >= 1.5 ? QColor("#FFCC80")
+                                                          : QColor("#A5D6A7"));
+            stat_cpi_card_->setStyleSheet(
+                QString(
+                    "QFrame#statCard { background: %1; border: 1px solid %2; border-radius: 6px; }")
+                    .arg(bg.name(), bdr.name()));
+        }
     } else {
         stat_cpi_lbl_->setText("—");
         stat_cpi_lbl_->setStyleSheet("");
+        if (stat_cpi_card_) stat_cpi_card_->setStyleSheet("");
     }
 
     stat_data_haz_lbl_->setText(QString::number(stats.data_hazards));
@@ -715,6 +771,14 @@ void MainWindow::applyColorScheme(bool dark) {
         pal.setColor(QPalette::Button, QColor(0x3C, 0x3C, 0x3C));
         pal.setColor(QPalette::ButtonText, Qt::white);
         pal.setColor(QPalette::BrightText, Qt::red);
+        // 3D/bevel roles — set explicitly so ADS's palette(light/dark/mid) selectors
+        // resolve to our dark-theme values rather than the system palette's defaults.
+        pal.setColor(QPalette::Light, QColor(0x3C, 0x3C, 0x3C));
+        pal.setColor(QPalette::Midlight, QColor(0x2D, 0x2D, 0x2D));
+        pal.setColor(QPalette::Dark, QColor(0x14, 0x14, 0x14));
+        pal.setColor(QPalette::Mid, QColor(0x22, 0x22, 0x22));
+        pal.setColor(QPalette::Shadow, Qt::black);
+        pal.setColor(QPalette::PlaceholderText, QColor(0x66, 0x66, 0x66));
         pal.setColor(QPalette::Highlight, QColor(0x26, 0x4F, 0x78));
         pal.setColor(QPalette::HighlightedText, Qt::white);
     } else {
@@ -727,6 +791,15 @@ void MainWindow::applyColorScheme(bool dark) {
         pal.setColor(QPalette::Text, Qt::black);
         pal.setColor(QPalette::Button, QColor(0xEE, 0xEE, 0xEE));
         pal.setColor(QPalette::ButtonText, Qt::black);
+        // 3D/bevel roles — critical: ADS uses palette(light) as CDockWidget background.
+        // Setting Light=white here means that background resolves to white in light mode
+        // rather than inheriting whatever the system's dark theme has for QPalette::Light.
+        pal.setColor(QPalette::Light, Qt::white);
+        pal.setColor(QPalette::Midlight, QColor(0xF8, 0xF8, 0xF8));
+        pal.setColor(QPalette::Dark, QColor(0xBE, 0xBE, 0xBE));
+        pal.setColor(QPalette::Mid, QColor(0xD0, 0xD0, 0xD0));
+        pal.setColor(QPalette::Shadow, QColor(0x80, 0x80, 0x80));
+        pal.setColor(QPalette::PlaceholderText, QColor(0x99, 0x99, 0x99));
         pal.setColor(QPalette::Highlight, QColor(0x00, 0x78, 0xD4));
         pal.setColor(QPalette::HighlightedText, Qt::white);
     }
@@ -840,8 +913,6 @@ QSpinBox {
     padding: 2px 6px;
 }
 QSpinBox::up-button, QSpinBox::down-button { background: #3C3C3C; border: none; width: 16px; }
-QSpinBox::up-arrow   { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 4px solid #888; }
-QSpinBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top:    4px solid #888; }
 
 QScrollBar:vertical   { background: #1E1E1E; width: 10px; border: none; }
 QScrollBar:horizontal { background: #1E1E1E; height: 10px; border: none; }
@@ -855,6 +926,36 @@ QFrame[frameShape="4"] { color: #444444; }
 QFrame[frameShape="5"] { color: #444444; }
 QWidget#regHeader { background: #252526; border-bottom: 1px solid #3C3C3C; }
 QWidget#regHeader QLabel { color: #9CDCFE; background: transparent; border: none; }
+
+QComboBox {
+    background: #3C3C3C;
+    color: #CCCCCC;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    padding: 4px 8px 4px 10px;
+    min-width: 80px;
+}
+QComboBox:hover { border-color: #777777; }
+QComboBox QAbstractItemView {
+    background: #252526;
+    color: #CCCCCC;
+    border: 1px solid #454545;
+    selection-background-color: #094771;
+    selection-color: white;
+}
+
+QWidget#codeEditorBtnBar {
+    background: #252526;
+    border-top: 1px solid #3C3C3C;
+}
+
+QFrame#statCard {
+    background: #2D2D2D;
+    border: 1px solid #3C3C3C;
+    border-radius: 6px;
+}
+QFrame#statCard QLabel { background: transparent; }
+QLabel#statCardLabel { color: #888888; }
 )"
                              : R"(
 QMainWindow, QDialog { background: #F5F5F5; }
@@ -963,8 +1064,6 @@ QSpinBox {
     padding: 2px 6px;
 }
 QSpinBox::up-button, QSpinBox::down-button { background: #EEEEEE; border: none; width: 16px; }
-QSpinBox::up-arrow   { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 4px solid #666; }
-QSpinBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top:    4px solid #666; }
 
 QScrollBar:vertical   { background: #F5F5F5; width: 10px; border: none; }
 QScrollBar:horizontal { background: #F5F5F5; height: 10px; border: none; }
@@ -978,8 +1077,92 @@ QFrame[frameShape="4"] { color: #DDDDDD; }
 QFrame[frameShape="5"] { color: #DDDDDD; }
 QWidget#regHeader { background: #EBEBEB; border-bottom: 1px solid #DDDDDD; }
 QWidget#regHeader QLabel { color: #0078D4; background: transparent; border: none; }
+
+QComboBox {
+    background: white;
+    color: #333333;
+    border: 1px solid #CCCCCC;
+    border-radius: 3px;
+    padding: 4px 8px 4px 10px;
+    min-width: 80px;
+}
+QComboBox:hover { border-color: #AAAAAA; }
+QComboBox QAbstractItemView {
+    background: white;
+    color: #333333;
+    border: 1px solid #CCCCCC;
+    selection-background-color: #0078D4;
+    selection-color: white;
+}
+
+QWidget#codeEditorBtnBar {
+    background: #F0F0F0;
+    border-top: 1px solid #DDDDDD;
+}
+
+QFrame#statCard {
+    background: white;
+    border: 1px solid #E0E0E0;
+    border-radius: 6px;
+}
+QFrame#statCard QLabel { background: transparent; }
+QLabel#statCardLabel { color: #777777; }
 )";
     qApp->setStyleSheet(qss);
+
+    // ADS calls dock_manager_->setStyleSheet(its_built_in_css) during
+    // construction, which takes precedence over qApp->setStyleSheet() for
+    // all ads--* selectors. The only way to theme ADS elements is to append
+    // our overrides onto its own stylesheet. We cache the ADS base CSS once
+    // on the first call (after dock_manager_ is created) so subsequent
+    // scheme switches always start from the unmodified original.
+    if (dock_manager_) {
+        static const QString ads_base  = dock_manager_->styleSheet();
+        const QString        ads_theme = dark ? R"(
+ads--CDockContainerWidget { background: #1E1E1E; }
+ads--CDockContainerWidget ads--CDockSplitter::handle { background: #3C3C3C; }
+ads--CDockAreaWidget      { background: #1E1E1E; }
+ads--CDockAreaTitleBar    { background: #252526; border-bottom: 1px solid #3C3C3C; }
+ads--CDockWidgetTab {
+    background: #2D2D2D;
+    border-color: #3C3C3C;
+    padding: 4px 16px;
+}
+ads--CDockWidgetTab:hover { background: #383838; }
+ads--CDockWidgetTab[activeTab="true"] {
+    background: #1E1E1E;
+    border-top: 2px solid #007ACC;
+}
+ads--CDockWidgetTab QLabel           { color: #888888; }
+ads--CDockWidgetTab[activeTab="true"] QLabel { color: #FFFFFF; }
+ads--CDockWidget { background: #1E1E1E; border: none; }
+QScrollArea#dockWidgetScrollArea { background: transparent; border: none; }
+)"
+                                              : R"(
+ads--CDockContainerWidget { background: #F5F5F5; }
+ads--CDockContainerWidget ads--CDockSplitter::handle { background: #D5D5D5; }
+ads--CDockAreaWidget      { background: #F5F5F5; }
+ads--CDockAreaTitleBar    { background: #E8E8E8; border-bottom: 1px solid #CCCCCC; }
+ads--CDockWidgetTab {
+    background: #E8E8E8;
+    border-color: #D0D0D0;
+    padding: 4px 16px;
+}
+ads--CDockWidgetTab:hover { background: #DCDCDC; }
+ads--CDockWidgetTab[activeTab="true"] {
+    background: white;
+    border-top: 2px solid #0078D4;
+}
+ads--CDockWidgetTab QLabel           { color: #555555; }
+ads--CDockWidgetTab[activeTab="true"] QLabel { color: #1A1A1A; }
+ads--CDockWidget { background: white; border: none; }
+QScrollArea#dockWidgetScrollArea { background: transparent; border: none; }
+)";
+        dock_manager_->setStyleSheet(ads_base + ads_theme);
+    }
+
+    // Reset the CPI card to the QSS default (color re-applied by onStatisticsUpdated).
+    if (stat_cpi_card_) stat_cpi_card_->setStyleSheet("");
 
     datapath_widget_->setDarkMode(dark);
     register_widget_->setDarkMode(dark);

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -285,15 +285,15 @@ QWidget* MainWindow::createCodeEditorTab() {
                                         "#   add  $t2, $t0, $t1\n"));
     vl->addWidget(code_editor_);
 
-    // Separator line above button row
-    auto* sep = new QFrame(w);
-    sep->setFrameShape(QFrame::HLine);
-    sep->setFrameShadow(QFrame::Sunken);
-    vl->addWidget(sep);
-
-    auto* btn_row = new QHBoxLayout;
+    // Button toolbar row — given a named container so the QSS can set its
+    // background independently of the ADS dock area that hosts this panel.
+    auto* btn_bar = new QWidget(w);
+    btn_bar->setObjectName("codeEditorBtnBar");
+    btn_bar->setAutoFillBackground(true);
+    auto* btn_row = new QHBoxLayout(btn_bar);
     btn_row->setContentsMargins(8, 6, 8, 6);
     btn_row->setSpacing(8);
+    vl->addWidget(btn_bar);
 
     auto* asm_btn = new QPushButton(tr("Assemble"), w);
     asm_btn->setObjectName("primaryButton");
@@ -318,7 +318,7 @@ QWidget* MainWindow::createCodeEditorTab() {
     connect(examples_combo_, qOverload<int>(&QComboBox::activated), this,
             &MainWindow::onExampleSelected);
 
-    asm_status_lbl_ = new QLabel(w);
+    asm_status_lbl_ = new QLabel(btn_bar);
     asm_status_lbl_->setFont(scale::monoFont(scale::kFontSizeBody));
     btn_row->addWidget(asm_btn);
     btn_row->addWidget(load_btn);
@@ -327,7 +327,6 @@ QWidget* MainWindow::createCodeEditorTab() {
     btn_row->addSpacing(12);
     btn_row->addWidget(asm_status_lbl_);
     btn_row->addStretch();
-    vl->addLayout(btn_row);
 
     connect(asm_btn, &QPushButton::clicked, this, &MainWindow::onAssemble);
     connect(load_btn, &QPushButton::clicked, this, &MainWindow::onLoad);
@@ -855,6 +854,30 @@ QFrame[frameShape="4"] { color: #444444; }
 QFrame[frameShape="5"] { color: #444444; }
 QWidget#regHeader { background: #252526; border-bottom: 1px solid #3C3C3C; }
 QWidget#regHeader QLabel { color: #9CDCFE; background: transparent; border: none; }
+
+QComboBox {
+    background: #3C3C3C;
+    color: #CCCCCC;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    padding: 4px 8px;
+    min-width: 80px;
+}
+QComboBox:hover { border-color: #777777; }
+QComboBox::drop-down { border: none; width: 20px; }
+QComboBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top: 4px solid #888; }
+QComboBox QAbstractItemView {
+    background: #252526;
+    color: #CCCCCC;
+    border: 1px solid #454545;
+    selection-background-color: #094771;
+    selection-color: white;
+}
+
+QWidget#codeEditorBtnBar {
+    background: #252526;
+    border-top: 1px solid #3C3C3C;
+}
 )"
                              : R"(
 QMainWindow, QDialog { background: #F5F5F5; }
@@ -978,8 +1001,79 @@ QFrame[frameShape="4"] { color: #DDDDDD; }
 QFrame[frameShape="5"] { color: #DDDDDD; }
 QWidget#regHeader { background: #EBEBEB; border-bottom: 1px solid #DDDDDD; }
 QWidget#regHeader QLabel { color: #0078D4; background: transparent; border: none; }
+
+QComboBox {
+    background: white;
+    color: #333333;
+    border: 1px solid #CCCCCC;
+    border-radius: 3px;
+    padding: 4px 8px;
+    min-width: 80px;
+}
+QComboBox:hover { border-color: #AAAAAA; }
+QComboBox::drop-down { border: none; width: 20px; }
+QComboBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top: 4px solid #666; }
+QComboBox QAbstractItemView {
+    background: white;
+    color: #333333;
+    border: 1px solid #CCCCCC;
+    selection-background-color: #0078D4;
+    selection-color: white;
+}
+
+QWidget#codeEditorBtnBar {
+    background: #F0F0F0;
+    border-top: 1px solid #DDDDDD;
+}
 )";
     qApp->setStyleSheet(qss);
+
+    // ADS calls dock_manager_->setStyleSheet(its_built_in_css) during
+    // construction, which takes precedence over qApp->setStyleSheet() for
+    // all ads--* selectors. The only way to theme ADS elements is to append
+    // our overrides onto its own stylesheet. We cache the ADS base CSS once
+    // on the first call (after dock_manager_ is created) so subsequent
+    // scheme switches always start from the unmodified original.
+    if (dock_manager_) {
+        static const QString ads_base  = dock_manager_->styleSheet();
+        const QString        ads_theme = dark ? R"(
+ads--CDockContainerWidget { background: #1E1E1E; }
+ads--CDockContainerWidget ads--CDockSplitter::handle { background: #3C3C3C; }
+ads--CDockAreaWidget      { background: #1E1E1E; }
+ads--CDockAreaTitleBar    { background: #252526; border-bottom: 1px solid #3C3C3C; }
+ads--CDockWidgetTab {
+    background: #2D2D2D;
+    border-color: #3C3C3C;
+    padding: 4px 16px;
+}
+ads--CDockWidgetTab:hover { background: #383838; }
+ads--CDockWidgetTab[activeTab="true"] {
+    background: #1E1E1E;
+    border-top: 2px solid #007ACC;
+}
+ads--CDockWidgetTab QLabel           { color: #888888; }
+ads--CDockWidgetTab[activeTab="true"] QLabel { color: #FFFFFF; }
+)"
+                                              : R"(
+ads--CDockContainerWidget { background: #F5F5F5; }
+ads--CDockContainerWidget ads--CDockSplitter::handle { background: #D5D5D5; }
+ads--CDockAreaWidget      { background: #F5F5F5; }
+ads--CDockAreaTitleBar    { background: #E8E8E8; border-bottom: 1px solid #CCCCCC; }
+ads--CDockWidgetTab {
+    background: #E8E8E8;
+    border-color: #D0D0D0;
+    padding: 4px 16px;
+}
+ads--CDockWidgetTab:hover { background: #DCDCDC; }
+ads--CDockWidgetTab[activeTab="true"] {
+    background: white;
+    border-top: 2px solid #0078D4;
+}
+ads--CDockWidgetTab QLabel           { color: #555555; }
+ads--CDockWidgetTab[activeTab="true"] QLabel { color: #1A1A1A; }
+)";
+        dock_manager_->setStyleSheet(ads_base + ads_theme);
+    }
 
     datapath_widget_->setDarkMode(dark);
     register_widget_->setDarkMode(dark);

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -132,7 +132,8 @@ void MainWindow::setupMenuBar() {
                                 "Datapath panel (click or Tab to focus):\n"
                                 "Left/Right  – Select a pipeline stage\n"
                                 "Enter       – Show stage detail\n"
-                                "Space       – Toggle breakpoint on selected stage");
+                                "Space       – Toggle breakpoint on selected stage\n"
+                                "Ctrl+Wheel  – Zoom schematic (right-click to fit/export)");
         QMessageBox::information(this, tr("Keyboard Shortcuts"), text);
     });
 }
@@ -601,6 +602,7 @@ void MainWindow::onPipelineStateChanged(mips::PipelineState state) {
     for (int i = 0; i < 32; ++i)
         reg_vals[i] = controller_->registerValue(static_cast<uint8_t>(i));
     register_widget_->updateCycle(state, reg_vals);
+    datapath_widget_->setRegisterValues(reg_vals);  // live operand tooltips
 
     // Refresh memory
     memory_widget_->updateDisplay(controller_->memory());

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -7,6 +7,7 @@
 #include "nsc_qt/preferences_dialog.h"
 #include "nsc_qt/widgets/code_editor.h"
 #include "nsc_qt/widgets/memory_widget.h"
+#include "nsc_qt/widgets/pipeline_events_widget.h"
 #include "nsc_qt/widgets/pipeline_trace_widget.h"
 #include "nsc_qt/widgets/register_widget.h"
 #include "nsc_qt/widgets/schematic_datapath_widget.h"
@@ -55,7 +56,8 @@ namespace {
 // different version, so stale/incompatible layouts are cleanly discarded.
 // v1: all panels in one central tabbed area.
 // v2: 2-column split — Code Editor left, Datapath center-top, inspector tabs bottom.
-constexpr int kLayoutVersion = 2;
+// v3: adds the Pipeline Events panel to the bottom inspector row.
+constexpr int kLayoutVersion = 3;
 }  // namespace
 
 MainWindow::MainWindow(QWidget* parent)
@@ -187,6 +189,7 @@ void MainWindow::setupCentralWidget() {
     register_widget_ = new RegisterWidget(this);
     memory_widget_   = new MemoryWidget(this);
     trace_widget_    = new PipelineTraceWidget(this);
+    events_widget_   = new PipelineEventsWidget(this);
 
     // Helper: create a named dock and register its View > Panels toggle.
     auto make_dock = [&](const QString& title, QWidget* contents) -> ads::CDockWidget* {
@@ -232,6 +235,8 @@ void MainWindow::setupCentralWidget() {
     dock_manager_->addDockWidgetTabToArea(trace_dock, bottom_area);
     auto* stats_dock = make_dock(tr("Statistics"), createStatisticsTab());
     dock_manager_->addDockWidgetTabToArea(stats_dock, bottom_area);
+    auto* events_dock = make_dock(tr("Pipeline Events"), events_widget_);
+    dock_manager_->addDockWidgetTabToArea(events_dock, bottom_area);
     bottom_area->setCurrentIndex(0);  // Registers in front
 
     // Snapshot the default arrangement so resetLayout() and the fallback
@@ -471,6 +476,8 @@ void MainWindow::setupConnections() {
     connect(controller_.get(), &SimulatorController::faulted, this, &MainWindow::onFaulted);
     connect(controller_.get(), &SimulatorController::breakpointHit, this, [this](uint32_t pc) {
         statusBar()->showMessage(tr("Breakpoint hit at 0x%1").arg(pc, 8, 16, QChar('0')), 5000);
+        events_widget_->logEvent(PipelineEventsWidget::Kind::Info, controller_->cycleCount(),
+                                 tr("breakpoint hit at 0x%1").arg(pc, 8, 16, QChar('0')));
         setRunState(false);
     });
 
@@ -504,6 +511,7 @@ void MainWindow::onReset() {
     controller_->reset();
     register_widget_->clear();
     trace_widget_->clear();
+    events_widget_->clear();
     statusBar()->showMessage(tr("Reset."), 2000);
 }
 
@@ -539,6 +547,9 @@ void MainWindow::onOpenFile() {
     }
     statusBar()->showMessage(tr("Loaded %1 instructions from %2").arg(prog.words.size()).arg(path),
                              4000);
+    events_widget_->logEvent(
+        PipelineEventsWidget::Kind::Info, 0,
+        tr("program loaded from file (%1 instructions)").arg(prog.words.size()));
 }
 
 void MainWindow::onSaveTrace() {
@@ -596,6 +607,8 @@ void MainWindow::onLoad() {
     }
     asm_status_lbl_->setStyleSheet("color: green;");
     asm_status_lbl_->setText(tr("✓ %1 instructions loaded").arg(assembled_words_.size()));
+    events_widget_->logEvent(PipelineEventsWidget::Kind::Info, 0,
+                             tr("program loaded (%1 instructions)").arg(assembled_words_.size()));
 }
 
 void MainWindow::onShowPreferences() {
@@ -620,6 +633,7 @@ void MainWindow::onCycleExecuted(uint64_t count) {
 void MainWindow::onPipelineStateChanged(mips::PipelineState state) {
     datapath_widget_->setPipelineState(state);
     trace_widget_->updateCycle(state);
+    events_widget_->updateCycle(state);
 
     // Gather register values once, then push state + values to RegisterWidget
     // together so it refreshes each of its 32 cells exactly once per cycle.
@@ -685,12 +699,16 @@ void MainWindow::onStatisticsUpdated(nsc::qt::SimulatorStatistics stats) {
 void MainWindow::onHalted() {
     controller_->stop();
     setRunState(false);
+    events_widget_->logEvent(PipelineEventsWidget::Kind::Success, controller_->cycleCount(),
+                             tr("program halted (spin-loop detected)"));
     flashStatusBanner(true, tr("✓ Program halted (spin-loop detected)."));
 }
 
 void MainWindow::onFaulted() {
     controller_->stop();
     setRunState(false);
+    events_widget_->logEvent(PipelineEventsWidget::Kind::Error, controller_->cycleCount(),
+                             tr("processor fault"));
     flashStatusBanner(false, tr("✗ Processor fault — check your program."));
 }
 
@@ -976,6 +994,9 @@ QWidget#codeEditorBtnBar {
     border-top: 1px solid #3C3C3C;
 }
 
+QListWidget { background: #1E1E1E; color: #CCCCCC; border: none; }
+QListWidget::item { padding: 1px 6px; }
+
 QFrame#statCard {
     background: #2D2D2D;
     border: 1px solid #3C3C3C;
@@ -1127,6 +1148,9 @@ QWidget#codeEditorBtnBar {
     border-top: 1px solid #DDDDDD;
 }
 
+QListWidget { background: white; color: #333333; border: none; }
+QListWidget::item { padding: 1px 6px; }
+
 QFrame#statCard {
     background: white;
     border: 1px solid #E0E0E0;
@@ -1195,6 +1219,7 @@ QScrollArea#dockWidgetScrollArea { background: transparent; border: none; }
     register_widget_->setDarkMode(dark);
     memory_widget_->setDarkMode(dark);
     trace_widget_->setDarkMode(dark);
+    events_widget_->setDarkMode(dark);
     code_editor_->setDarkMode(dark);
 }
 

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -913,8 +913,6 @@ QSpinBox {
     padding: 2px 6px;
 }
 QSpinBox::up-button, QSpinBox::down-button { background: #3C3C3C; border: none; width: 16px; }
-QSpinBox::up-arrow   { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 4px solid #888; }
-QSpinBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top:    4px solid #888; }
 
 QScrollBar:vertical   { background: #1E1E1E; width: 10px; border: none; }
 QScrollBar:horizontal { background: #1E1E1E; height: 10px; border: none; }
@@ -938,12 +936,6 @@ QComboBox {
     min-width: 80px;
 }
 QComboBox:hover { border-color: #777777; }
-QComboBox::drop-down {
-    border: none;
-    border-left: 1px solid #555555;
-    width: 22px;
-    background: transparent;
-}
 QComboBox QAbstractItemView {
     background: #252526;
     color: #CCCCCC;
@@ -1072,8 +1064,6 @@ QSpinBox {
     padding: 2px 6px;
 }
 QSpinBox::up-button, QSpinBox::down-button { background: #EEEEEE; border: none; width: 16px; }
-QSpinBox::up-arrow   { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 4px solid #666; }
-QSpinBox::down-arrow { image: none; border-left: 4px solid transparent; border-right: 4px solid transparent; border-top:    4px solid #666; }
 
 QScrollBar:vertical   { background: #F5F5F5; width: 10px; border: none; }
 QScrollBar:horizontal { background: #F5F5F5; height: 10px; border: none; }
@@ -1097,12 +1087,6 @@ QComboBox {
     min-width: 80px;
 }
 QComboBox:hover { border-color: #AAAAAA; }
-QComboBox::drop-down {
-    border: none;
-    border-left: 1px solid #CCCCCC;
-    width: 22px;
-    background: transparent;
-}
 QComboBox QAbstractItemView {
     background: white;
     color: #333333;

--- a/src/nsc_qt/main_window.cpp
+++ b/src/nsc_qt/main_window.cpp
@@ -33,6 +33,7 @@
 #include <QPushButton>
 #include <QSettings>
 #include <QSize>
+#include <QSlider>
 #include <QStatusBar>
 #include <QStyle>
 #include <QTimer>
@@ -151,6 +152,28 @@ void MainWindow::setupToolBar() {
     tb->addAction(act_reset_);
     tb->addSeparator();
     tb->addAction(act_open_);
+    tb->addSeparator();
+
+    // Execution-speed slider, in the toolbar where runs are started rather
+    // than buried in Preferences. Left = slow (long cycle interval, good for
+    // watching the datapath), right = fast. Mirrors the Preferences setting.
+    auto* speed_lbl = new QLabel(tr(" Speed: "), tb);
+    tb->addWidget(speed_lbl);
+    speed_slider_ = new QSlider(Qt::Horizontal, tb);
+    speed_slider_->setRange(10, 1000);  // cycle interval in ms
+    speed_slider_->setInvertedAppearance(true);
+    speed_slider_->setFixedWidth(140);
+    const QSettings s("nsc-qt", "clearCore-gui");
+    speed_slider_->setValue(s.value("executionSpeed", 100).toInt());
+    speed_slider_->setToolTip(
+        tr("Run speed — one pipeline cycle every %1 ms").arg(speed_slider_->value()));
+    connect(speed_slider_, &QSlider::valueChanged, this, [this](int ms) {
+        controller_->setExecutionSpeed(ms);
+        speed_slider_->setToolTip(tr("Run speed — one pipeline cycle every %1 ms").arg(ms));
+        QSettings settings("nsc-qt", "clearCore-gui");
+        settings.setValue("executionSpeed", ms);
+    });
+    tb->addWidget(speed_slider_);
 }
 
 // ── Central widget ────────────────────────────────────────────────────────────
@@ -580,6 +603,8 @@ void MainWindow::onShowPreferences() {
     connect(&dlg, &PreferencesDialog::colorSchemeChanged, this, &MainWindow::applyColorScheme);
     connect(&dlg, &PreferencesDialog::executionSpeedChanged, controller_.get(),
             &SimulatorController::setExecutionSpeed);
+    // Keep the toolbar slider in step with the Preferences control.
+    connect(&dlg, &PreferencesDialog::executionSpeedChanged, speed_slider_, &QSlider::setValue);
     connect(&dlg, &PreferencesDialog::showRegisterAliasesChanged, register_widget_,
             &RegisterWidget::setShowAliases);
     connect(&dlg, &PreferencesDialog::fontSizeChanged, this, [this](int sz) {

--- a/src/nsc_qt/widgets/datapath_widget.cpp
+++ b/src/nsc_qt/widgets/datapath_widget.cpp
@@ -1,6 +1,7 @@
 #include "nsc_qt/widgets/datapath_widget.h"
 #include "mips/decoder.h"
 #include "mips/registers.h"
+#include "nsc_qt/instr_format.h"
 #include "nsc_qt/ui_scale.h"
 
 #include <QContextMenuEvent>
@@ -37,64 +38,6 @@ static const QColor STAGE_COLORS_DARK[5] = {
 };
 
 static const char* STAGE_NAMES[5] = {"IF", "ID", "EX", "MEM", "WB"};
-
-// Format a decoded instruction as a human-readable string. This is assembly
-// notation (mnemonics, register names), not natural-language UI copy, so it
-// intentionally is not routed through tr().
-static std::string format_instr(uint32_t raw) {
-    using namespace mips;
-    auto decoded = Decoder::decode(raw);
-    if (!decoded) return "(?/?)";
-    const auto&        d  = *decoded;
-    std::string        mn = std::string(Decoder::mnemonic(d));
-    std::ostringstream os;
-    os << mn << " ";
-    switch (d.format) {
-    case InstrFormat::R: {
-        const auto& r = d.r();
-        if (d.opcode == Opcode::SPECIAL) {
-            using F = FunctCode;
-            if (r.funct == F::SLL || r.funct == F::SRL || r.funct == F::SRA) {
-                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rt) << ", "
-                   << +r.shamt;
-            } else if (r.funct == F::JR) {
-                os << "$" << register_abi_name(r.rs);
-            } else if (r.funct == F::JALR) {
-                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs);
-            } else {
-                os << "$" << register_abi_name(r.rd) << ", $" << register_abi_name(r.rs) << ", $"
-                   << register_abi_name(r.rt);
-            }
-        }
-        break;
-    }
-    case InstrFormat::I: {
-        const auto& i = d.i();
-        if (d.opcode == Opcode::LW || d.opcode == Opcode::LBU || d.opcode == Opcode::LHU ||
-            d.opcode == Opcode::SW) {
-            os << "$" << register_abi_name(i.rt) << ", " << static_cast<int16_t>(i.imm) << "($"
-               << register_abi_name(i.rs) << ")";
-        } else if (d.opcode == Opcode::LUI) {
-            os << "$" << register_abi_name(i.rt) << ", 0x" << std::hex << i.imm;
-        } else if (d.opcode == Opcode::BEQ || d.opcode == Opcode::BNE) {
-            os << "$" << register_abi_name(i.rs) << ", $" << register_abi_name(i.rt) << ", "
-               << static_cast<int16_t>(i.imm);
-        } else {
-            os << "$" << register_abi_name(i.rt) << ", $" << register_abi_name(i.rs) << ", "
-               << static_cast<int16_t>(i.imm);
-        }
-        break;
-    }
-    case InstrFormat::J: {
-        const auto& j = d.j();
-        os << "0x" << std::hex << j.target;
-        break;
-    }
-    default:
-        break;
-    }
-    return os.str();
-}
 
 }  // anonymous namespace
 

--- a/src/nsc_qt/widgets/memory_widget.cpp
+++ b/src/nsc_qt/widgets/memory_widget.cpp
@@ -50,6 +50,18 @@ MemoryWidget::MemoryWidget(QWidget* parent) : QWidget(parent) {
     hex_view_ = new QHexView(this);
     hex_view_->setReadOnly(true);
     hex_view_->setFont(scale::monoFont(scale::kFontSizeDense));
+
+    // Label each section of the hex dump so new users immediately understand
+    // what they are looking at. "Offset" = row start address, hex column keeps
+    // its default byte-position numbers (00–0F), "ASCII" = text view.
+    {
+        auto opts          = hex_view_->options();
+        opts.address_label = tr("Offset");
+        opts.ascii_label   = QStringLiteral("ASCII");
+        opts.flags |= QHexFlags::StyledHeader | QHexFlags::Separators;
+        hex_view_->setOptions(opts);
+    }
+
     vl->addWidget(hex_view_);
 
     connect(addr_spin_, qOverload<int>(&QSpinBox::valueChanged), this,
@@ -92,6 +104,14 @@ void MemoryWidget::onAddressChanged(int value) {
 
 void MemoryWidget::setDarkMode(bool dark) {
     dark_mode_ = dark;
+    // Sync the QHexView header text colour to match the app's accent colour.
+    auto         opts                    = hex_view_->options();
+    const QColor hdr_fg                  = dark ? QColor("#9CDCFE") : QColor("#0078D4");
+    opts.header_format.foreground        = hdr_fg;
+    opts.addressheader_format.foreground = hdr_fg;
+    opts.hexheader_format.foreground     = hdr_fg;
+    opts.asciiheader_format.foreground   = hdr_fg;
+    hex_view_->setOptions(opts);
     if (last_mem_) refreshView(*last_mem_);
 }
 

--- a/src/nsc_qt/widgets/pipeline_events_widget.cpp
+++ b/src/nsc_qt/widgets/pipeline_events_widget.cpp
@@ -1,0 +1,141 @@
+#include "nsc_qt/widgets/pipeline_events_widget.h"
+#include "nsc_qt/instr_format.h"
+#include "nsc_qt/ui_scale.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QVBoxLayout>
+
+namespace nsc::qt {
+
+namespace {
+
+// Kind is stashed in each item's UserRole so setDarkMode() can re-colour
+// the whole history when the theme flips.
+constexpr int kKindRole = Qt::UserRole;
+
+QString instr_or(const mips::StageSnapshot& s, const QString& fallback) {
+    if (!s.valid || s.raw == 0) return fallback;
+    return QString::fromStdString(format_instr(s.raw));
+}
+
+}  // anonymous namespace
+
+PipelineEventsWidget::PipelineEventsWidget(QWidget* parent) : QWidget(parent) {
+    auto* vl = new QVBoxLayout(this);
+    vl->setContentsMargins(4, 4, 4, 4);
+    vl->setSpacing(4);
+
+    // Header row: entry count + clear button.
+    auto* header = new QHBoxLayout;
+    count_lbl_   = new QLabel(tr("0 events"), this);
+    count_lbl_->setFont(scale::monoFont(scale::kFontSizeDense));
+    header->addWidget(count_lbl_);
+    header->addStretch();
+    auto* clear_btn = new QPushButton(tr("Clear"), this);
+    clear_btn->setToolTip(tr("Clear the event log (the simulation is not affected)"));
+    connect(clear_btn, &QPushButton::clicked, this, &PipelineEventsWidget::clear);
+    header->addWidget(clear_btn);
+    vl->addLayout(header);
+
+    list_ = new QListWidget(this);
+    list_->setFont(scale::monoFont(scale::kFontSizeDense));
+    list_->setSelectionMode(QAbstractItemView::NoSelection);
+    list_->setFocusPolicy(Qt::NoFocus);
+    list_->setUniformItemSizes(true);
+    vl->addWidget(list_);
+}
+
+QColor PipelineEventsWidget::kindColor(Kind kind) const {
+    // Matches the schematic's wire/hazard palette so the same event reads
+    // in the same colour across both panels.
+    switch (kind) {
+    case Kind::FwdExMem:
+        return dark_mode_ ? QColor("#FFA726") : QColor("#E65100");
+    case Kind::FwdMemWb:
+        return dark_mode_ ? QColor("#CE93D8") : QColor("#7B1FA2");
+    case Kind::Stall:
+        return dark_mode_ ? QColor("#FFB74D") : QColor("#B45309");
+    case Kind::Flush:
+        return dark_mode_ ? QColor("#FF5252") : QColor("#C62828");
+    case Kind::Success:
+        return dark_mode_ ? QColor("#81C784") : QColor("#2E7D32");
+    case Kind::Error:
+        return dark_mode_ ? QColor("#FF5252") : QColor("#C62828");
+    case Kind::Info:
+    default:
+        return dark_mode_ ? QColor("#9CDCFE") : QColor("#00529B");
+    }
+}
+
+void PipelineEventsWidget::logEvent(Kind kind, uint64_t cycle, const QString& text) {
+    // Only auto-scroll when the user is already at the bottom, so reading
+    // back through history isn't yanked away by new events.
+    auto*      sb        = list_->verticalScrollBar();
+    const bool at_bottom = sb->value() >= sb->maximum() - 2;
+
+    auto* item = new QListWidgetItem(QStringLiteral("%1  ● %2").arg(cycle, 5).arg(text), list_);
+    item->setForeground(kindColor(kind));
+    item->setData(kKindRole, static_cast<int>(kind));
+
+    while (list_->count() > kMaxEntries)
+        delete list_->takeItem(0);
+
+    count_lbl_->setText(tr("%n event(s)", nullptr, list_->count()));
+    if (at_bottom) list_->scrollToBottom();
+}
+
+void PipelineEventsWidget::updateCycle(const mips::PipelineState& state) {
+    const auto cycle = static_cast<quint64>(state.cycle);
+
+    // Rising-edge suppression: an event repeated on the very next cycle
+    // (multi-cycle stall, back-to-back forwards of the same pair) logs once.
+    auto log_edge = [&](Kind kind, const QString& text) {
+        const auto it        = recent_.constFind(text);
+        const bool continued = it != recent_.constEnd() && (*it + 1 == cycle || *it == cycle);
+        recent_[text]        = cycle;
+        if (!continued) logEvent(kind, cycle, text);
+    };
+
+    const auto& ex  = state.stages[2];
+    const auto& mem = state.stages[3];
+
+    if (state.fwd_ex_to_ex_a)
+        log_edge(Kind::FwdExMem, tr("EX/MEM→EX forward, ALU input A: %1").arg(instr_or(ex, "?")));
+    if (state.fwd_ex_to_ex_b)
+        log_edge(Kind::FwdExMem, tr("EX/MEM→EX forward, ALU input B: %1").arg(instr_or(ex, "?")));
+    if (state.fwd_mem_to_ex_a)
+        log_edge(Kind::FwdMemWb, tr("MEM/WB→EX forward, ALU input A: %1").arg(instr_or(ex, "?")));
+    if (state.fwd_mem_to_ex_b)
+        log_edge(Kind::FwdMemWb, tr("MEM/WB→EX forward, ALU input B: %1").arg(instr_or(ex, "?")));
+    if (state.load_stall)
+        log_edge(
+            Kind::Stall,
+            tr("load-use stall: %1 — bubble inserted").arg(instr_or(ex, QStringLiteral("lw"))));
+    if (state.branch_flush)
+        log_edge(Kind::Flush, tr("branch taken: %1 — younger instructions flushed")
+                                  .arg(instr_or(mem, QStringLiteral("branch"))));
+}
+
+void PipelineEventsWidget::clear() {
+    list_->clear();
+    recent_.clear();
+    count_lbl_->setText(tr("0 events"));
+}
+
+void PipelineEventsWidget::setDarkMode(bool dark) {
+    dark_mode_ = dark;
+    for (int i = 0; i < list_->count(); ++i) {
+        auto* item = list_->item(i);
+        item->setForeground(kindColor(static_cast<Kind>(item->data(kKindRole).toInt())));
+    }
+}
+
+int PipelineEventsWidget::eventCount() const {
+    return list_->count();
+}
+
+}  // namespace nsc::qt

--- a/src/nsc_qt/widgets/schematic_datapath_widget.cpp
+++ b/src/nsc_qt/widgets/schematic_datapath_widget.cpp
@@ -24,6 +24,7 @@
 #include <QPen>
 #include <QPolygonF>
 #include <QStringList>
+#include <QVariantAnimation>
 #include <QWheelEvent>
 #include <algorithm>
 #include <cmath>
@@ -59,6 +60,13 @@ constexpr qreal kColTop = 44.0, kColBot = 500.0;
 
 const char* const kStageNames[5]   = {"IF", "ID", "EX", "MEM", "WB"};
 const char* const kPipeRegNames[4] = {"IF/ID", "ID/EX", "EX/MEM", "MEM/WB"};
+
+// Input-port scene positions for the four muxes, in select order. The select
+// markers snap to these; they must match the wire endpoints in buildScene().
+const QPointF kPcMuxPorts[2]   = {{16, 262}, {16, 298}};                // PC+4, branch target
+const QPointF kFwdAMuxPorts[3] = {{600, 222}, {600, 238}, {600, 254}};  // reg, EX/MEM, MEM/WB
+const QPointF kFwdBMuxPorts[3] = {{600, 292}, {600, 308}, {600, 324}};
+const QPointF kWbMuxPorts[2]   = {{1180, 272}, {1180, 298}};  // mem data, ALU result
 
 // Stage tint hues (shared with the old widget's palette).
 const QColor kStageLight[5] = {QColor("#E3F2FD"), QColor("#E0F7FA"), QColor("#E8F5E9"),
@@ -308,7 +316,8 @@ void SchematicDatapathWidget::buildScene() {
         auto* name = scene_->addSimpleText(QString::fromLatin1(kStageNames[i]),
                                            scale::monoFont(scale::kFontSizeBody, true));
         name->setData(0, QStringLiteral("stage-name"));
-        name->setPos((c.x0 + c.x1) / 2 - name->boundingRect().width() / 2, kColBot + 8);
+        // +14 keeps the row clear of the write-back wire's bottom run (y 510).
+        name->setPos((c.x0 + c.x1) / 2 - name->boundingRect().width() / 2, kColBot + 14);
 
         stage_labels_[static_cast<std::size_t>(i)] =
             scene_->addSimpleText(QString(), scale::monoFont(scale::kFontSizeDense));
@@ -321,10 +330,11 @@ void SchematicDatapathWidget::buildScene() {
         stage_pc_labels_[static_cast<std::size_t>(i)]->setPos((c.x0 + c.x1) / 2, 30);
     }
 
-    // In-scene cycle counter (top-right, mirrors the status bar for exports).
+    // In-scene cycle counter (bottom-right, opposite the legend; the top row
+    // belongs to the per-stage mnemonics and must stay clear).
     cycle_text_ = scene_->addSimpleText(QStringLiteral("Cycle 0"),
                                         scale::monoFont(scale::kFontSizeBody, true));
-    cycle_text_->setPos(kSceneW - cycle_text_->boundingRect().width() - 16, 12);
+    cycle_text_->setPos(kSceneW - cycle_text_->boundingRect().width() - 20, kSceneH - 28);
 
     // Wire-colour legend along the bottom: the special wires communicate by
     // colour, so they need a permanent key (never rely on colour alone).
@@ -512,6 +522,43 @@ void SchematicDatapathWidget::buildScene() {
         bp_markers_[static_cast<std::size_t>(i)] = {outer, inner};
     }
 
+    // ── Mux select-input markers ─────────────────────────────────────────────
+    // A dot parked on the input port each mux is currently passing through.
+    for (auto& marker : mux_markers_) {
+        marker = scene_->addEllipse(QRectF(-4, -4, 8, 8));
+        marker->setZValue(6);
+        marker->setToolTip(tr("Selected mux input — the dot marks which input "
+                              "this mux is passing through this cycle."));
+    }
+
+    // ── Pinned wire value labels ─────────────────────────────────────────────
+    // Only values the snapshot actually carries: fetch PC, ID immediate, and
+    // the WB result read back from the register file after the cycle.
+    auto mk_val = [&]() {
+        auto* v = scene_->addSimpleText(QString(), scale::monoFont(scale::kFontSizeDense - 3));
+        v->setZValue(7);
+        return v;
+    };
+    val_pc_  = mk_val();
+    val_imm_ = mk_val();
+    val_wb_  = mk_val();
+
+    // ── Step-animation tokens ────────────────────────────────────────────────
+    // Small pills that glide along the top of the stage bands on each clock
+    // edge, one per instruction that advanced a stage.
+    for (auto& tok : tokens_) {
+        tok = scene_->addRect(QRectF(0, 0, 26, 12));
+        tok->setZValue(9);
+        tok->setVisible(false);
+    }
+    token_anim_ = new QVariantAnimation(this);
+    token_anim_->setDuration(240);
+    token_anim_->setEasingCurve(QEasingCurve::OutCubic);
+    connect(token_anim_, &QVariantAnimation::finished, this, [this] {
+        for (auto* tok : tokens_)
+            tok->setVisible(false);
+    });
+
     // ── Keyboard focus ring ──────────────────────────────────────────────────
     focus_ring_ = scene_->addRect(QRectF());
     focus_ring_->setZValue(10);
@@ -609,7 +656,7 @@ void SchematicDatapathWidget::applyState() {
     }
 
     cycle_text_->setText(tr("Cycle %1").arg(static_cast<qulonglong>(state_.cycle)));
-    cycle_text_->setPos(kSceneW - cycle_text_->boundingRect().width() - 16, 12);
+    cycle_text_->setPos(kSceneW - cycle_text_->boundingRect().width() - 20, kSceneH - 28);
 
     // Pipeline-register bars: red = flushing, amber = stalled, else neutral.
     for (int i = 0; i < 4; ++i) {
@@ -643,6 +690,66 @@ void SchematicDatapathWidget::applyState() {
     dmem_box_->setPen((mem_ctl.mem_read || mem_ctl.mem_write) ? QPen(t.label, 2.4) : base_pen);
     regs_box_->setPen(wb_ctl.reg_write ? QPen(t.wb, 2.4) : base_pen);
     writeback_wire_->setActive(wb_ctl.reg_write);
+
+    // ── Mux select markers ───────────────────────────────────────────────────
+    // Selects are derived from the same signals that light the wires, so the
+    // dot and the lit wire always agree.
+    auto place_marker = [&](int idx, const QPointF& port, const QColor& color) {
+        auto* m = mux_markers_[static_cast<std::size_t>(idx)];
+        m->setPos(port);
+        m->setBrush(color);
+        m->setPen(QPen(t.comp_border, 0.8));
+    };
+    place_marker(0, kPcMuxPorts[state_.branch_flush ? 1 : 0],
+                 state_.branch_flush ? t.flush : t.wire);
+    const int sel_a = state_.fwd_ex_to_ex_a ? 1 : state_.fwd_mem_to_ex_a ? 2 : 0;
+    const int sel_b = state_.fwd_ex_to_ex_b ? 1 : state_.fwd_mem_to_ex_b ? 2 : 0;
+    place_marker(1, kFwdAMuxPorts[sel_a], sel_a == 1 ? t.fwd_ex : sel_a == 2 ? t.fwd_mem : t.wire);
+    place_marker(2, kFwdBMuxPorts[sel_b], sel_b == 1 ? t.fwd_ex : sel_b == 2 ? t.fwd_mem : t.wire);
+    place_marker(3, kWbMuxPorts[wb_ctl.mem_to_reg ? 0 : 1], wb_ctl.reg_write ? t.wb : t.wire);
+
+    // ── Pinned wire values ───────────────────────────────────────────────────
+    const auto& s_if = state_.stages[0];
+    val_pc_->setText(s_if.valid ? QStringLiteral("0x%1").arg(s_if.pc, 8, 16, QChar('0'))
+                                : QString());
+    val_pc_->setBrush(t.label);
+    val_pc_->setPos(73 - val_pc_->boundingRect().width() / 2, 312);
+
+    const auto& s_id = state_.stages[1];
+    QString     imm_text;
+    if (s_id.valid && s_id.raw != 0) {
+        if (const auto d = mips::Decoder::decode(s_id.raw)) {
+            if (d->format == mips::InstrFormat::I) {
+                const auto imm = static_cast<int16_t>(d->i().imm);
+                imm_text       = QStringLiteral("imm=%1").arg(imm);
+            }
+        }
+    }
+    val_imm_->setText(imm_text);
+    val_imm_->setBrush(t.label);
+    val_imm_->setPos(490 - val_imm_->boundingRect().width() / 2, 384);
+
+    const auto& s_wb = state_.stages[4];
+    QString     wb_text;
+    if (s_wb.valid && s_wb.raw != 0 && wb_ctl.reg_write) {
+        if (const auto d = mips::Decoder::decode(s_wb.raw)) {
+            uint8_t dest = 0;
+            if (d->format == mips::InstrFormat::R)
+                dest = d->r().rd;
+            else if (d->format == mips::InstrFormat::I)
+                dest = d->i().rt;
+            else if (d->opcode == mips::Opcode::JAL)
+                dest = 31;  // jal writes the return address into $ra
+            if (dest != 0)
+                wb_text =
+                    QStringLiteral("$%1 = 0x%2")
+                        .arg(QString::fromStdString(std::string(mips::register_abi_name(dest))))
+                        .arg(reg_values_[dest], 8, 16, QChar('0'));
+        }
+    }
+    val_wb_->setText(wb_text);
+    val_wb_->setBrush(t.wb);
+    val_wb_->setPos(700 - val_wb_->boundingRect().width() / 2, 486);
 
     updateTooltips();
 }
@@ -734,8 +841,10 @@ void SchematicDatapathWidget::updateTooltips() {
 // ── Public API ──────────────────────────────────────────────────────────────
 
 void SchematicDatapathWidget::setPipelineState(const mips::PipelineState& state) {
-    state_ = state;
+    const mips::PipelineState old = state_;
+    state_                        = state;
     applyState();
+    startTokenAnimation(old);
 }
 
 void SchematicDatapathWidget::setBreakpoints(const std::unordered_set<uint32_t>& bps) {
@@ -750,7 +859,64 @@ void SchematicDatapathWidget::setDarkMode(bool dark) {
 
 void SchematicDatapathWidget::setRegisterValues(const std::array<uint32_t, 32>& regs) {
     reg_values_ = regs;
-    updateTooltips();
+    applyState();  // refreshes the WB value label and operand tooltips
+}
+
+void SchematicDatapathWidget::startTokenAnimation(const mips::PipelineState& old_state) {
+    // Animate only across a single clock edge; resets and restores snap.
+    if (state_.cycle != old_state.cycle + 1) {
+        token_anim_->stop();
+        for (auto* tok : tokens_)
+            tok->setVisible(false);
+        return;
+    }
+    token_anim_->stop();
+
+    const Theme& t = theme(dark_mode_);
+    struct Move {
+        QGraphicsRectItem* tok;
+        qreal              from_x, to_x;
+    };
+    std::vector<Move> moves;
+
+    auto            col_center = [](int i) { return (kColumns[i].x0 + kColumns[i].x1) / 2 - 13; };
+    constexpr qreal kTokenY    = 48;
+
+    for (int i = 0; i < 5; ++i) {
+        const auto& now = state_.stages[static_cast<std::size_t>(i)];
+        if (!now.valid || now.stalled || now.flushed) continue;
+
+        qreal from_x = 0;
+        if (i == 0) {
+            // Fresh fetch: slide in from the left edge of the IF column.
+            const auto& before = old_state.stages[0];
+            if (before.valid && before.pc == now.pc) continue;  // IF held (stall)
+            from_x = kColumns[0].x0;
+        } else {
+            // Advanced: this instruction was in the previous column last cycle.
+            const auto& prev = old_state.stages[static_cast<std::size_t>(i - 1)];
+            if (!prev.valid || prev.pc != now.pc || prev.raw != now.raw) continue;
+            from_x = col_center(i - 1);
+        }
+
+        auto* tok = tokens_[static_cast<std::size_t>(i)];
+        tok->setBrush(dark_mode_ ? kStageDark[i] : kStageLight[i]);
+        tok->setPen(QPen(t.comp_border, 1));
+        tok->setPos(from_x, kTokenY);
+        tok->setVisible(true);
+        moves.push_back({tok, from_x, col_center(i)});
+    }
+    if (moves.empty()) return;
+
+    disconnect(token_anim_, &QVariantAnimation::valueChanged, this, nullptr);
+    token_anim_->setStartValue(0.0);
+    token_anim_->setEndValue(1.0);
+    connect(token_anim_, &QVariantAnimation::valueChanged, this, [this, moves](const QVariant& v) {
+        const qreal p = v.toReal();
+        for (const Move& m : moves)
+            m.tok->setPos(m.from_x + (m.to_x - m.from_x) * p, 48);
+    });
+    token_anim_->start();
 }
 
 // ── Interaction ─────────────────────────────────────────────────────────────

--- a/src/nsc_qt/widgets/schematic_datapath_widget.cpp
+++ b/src/nsc_qt/widgets/schematic_datapath_widget.cpp
@@ -1,25 +1,33 @@
 #include "nsc_qt/widgets/schematic_datapath_widget.h"
+#include "mips/processor.h"
 #include "nsc_qt/instr_format.h"
 #include "nsc_qt/ui_scale.h"
 
 #include <QContextMenuEvent>
+#include <QFileDialog>
 #include <QFocusEvent>
 #include <QGraphicsEllipseItem>
+#include <QGraphicsLineItem>
 #include <QGraphicsPathItem>
 #include <QGraphicsPolygonItem>
 #include <QGraphicsRectItem>
 #include <QGraphicsScene>
+#include <QGraphicsSceneHoverEvent>
 #include <QGraphicsSimpleTextItem>
+#include <QImage>
 #include <QKeyEvent>
 #include <QMenu>
+#include <QMessageBox>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPen>
 #include <QPolygonF>
+#include <QStringList>
 #include <QWheelEvent>
 #include <algorithm>
 #include <cmath>
+#include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -32,8 +40,8 @@ namespace {
 // All geometry is authored in this fixed coordinate space; QGraphicsView
 // scales it to the widget. Chosen wide enough that the schematic reads at a
 // glance, like Ripes' processor tab.
-constexpr qreal kSceneW = 1400.0;
-constexpr qreal kSceneH = 540.0;
+constexpr qreal kSceneW = 1290.0;
+constexpr qreal kSceneH = 560.0;
 
 // Stage column x-extents (tint bands + hit testing). Bars live between them.
 struct ColumnSpan {
@@ -44,7 +52,7 @@ constexpr ColumnSpan kColumns[5] = {
     {286, 555},    // ID
     {571, 845},    // EX
     {861, 1130},   // MEM
-    {1146, 1392},  // WB
+    {1146, 1276},  // WB
 };
 
 constexpr qreal kColTop = 44.0, kColBot = 500.0;
@@ -162,59 +170,94 @@ private:
 
 namespace {
 
+// ── Hover-capable component shapes ───────────────────────────────────────────
+// Thickens the border while hovered, giving components a tactile feel and
+// signalling that the tooltip carries more detail (progressive disclosure).
+template <typename Base> class HoverShape : public Base {
+public:
+    using Base::Base;
+
+protected:
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* ev) override {
+        saved_pen_ = this->pen();
+        QPen p     = saved_pen_;
+        p.setWidthF(saved_pen_.widthF() + 1.2);
+        this->setPen(p);
+        Base::hoverEnterEvent(ev);
+    }
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* ev) override {
+        this->setPen(saved_pen_);
+        Base::hoverLeaveEvent(ev);
+    }
+
+private:
+    QPen saved_pen_;
+};
+
+using HoverRect    = HoverShape<QGraphicsRectItem>;
+using HoverEllipse = HoverShape<QGraphicsEllipseItem>;
+using HoverPoly    = HoverShape<QGraphicsPolygonItem>;
+
 // ── Component construction helpers ──────────────────────────────────────────
-// Components are plain QGraphicsItems tagged with data(0)="comp" so the theme
-// pass can restyle fill/border/text without keeping a pointer to each one.
+// Components are tagged with data(0)="comp" so the theme pass can restyle
+// fill/border/text without keeping a pointer to each one.
+
+void attachLabel(QAbstractGraphicsShapeItem* item, const QRectF& r, const QString& label,
+                 const QFont& font, qreal cx_bias = 0.5) {
+    auto* txt = new QGraphicsSimpleTextItem(label, item);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(font);
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(r.x() + r.width() * cx_bias - tb.width() / 2, r.center().y() - tb.height() / 2);
+}
 
 QGraphicsRectItem* addBox(QGraphicsScene* s, const QRectF& r, const QString& label,
-                          int font_px = scale::kFontSizeDense) {
-    auto* box = s->addRect(r);
+                          const QString& tip, int font_px = scale::kFontSizeDense) {
+    auto* box = new HoverRect(r);
     box->setData(0, QStringLiteral("comp"));
-    auto* txt = new QGraphicsSimpleTextItem(label, box);
-    txt->setData(0, QStringLiteral("comp-label"));
-    txt->setFont(scale::monoFont(font_px));
-    const QRectF tb = txt->boundingRect();
-    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    box->setAcceptHoverEvents(true);
+    box->setToolTip(tip);
+    s->addItem(box);
+    attachLabel(box, r, label, scale::monoFont(font_px));
     return box;
 }
 
-QGraphicsEllipseItem* addEllipse(QGraphicsScene* s, const QRectF& r, const QString& label) {
-    auto* el = s->addEllipse(r);
+QGraphicsEllipseItem* addEllipse(QGraphicsScene* s, const QRectF& r, const QString& label,
+                                 const QString& tip) {
+    auto* el = new HoverEllipse(r);
     el->setData(0, QStringLiteral("comp"));
-    auto* txt = new QGraphicsSimpleTextItem(label, el);
-    txt->setData(0, QStringLiteral("comp-label"));
-    txt->setFont(scale::monoFont(scale::kFontSizeDense - 2));
-    const QRectF tb = txt->boundingRect();
-    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    el->setAcceptHoverEvents(true);
+    el->setToolTip(tip);
+    s->addItem(el);
+    attachLabel(el, r, label, scale::monoFont(scale::kFontSizeDense - 2));
     return el;
 }
 
 // Classic ALU / adder pentagon with the input notch on the left.
-QGraphicsPolygonItem* addAlu(QGraphicsScene* s, const QRectF& r, const QString& label) {
+QGraphicsPolygonItem* addAlu(QGraphicsScene* s, const QRectF& r, const QString& label,
+                             const QString& tip) {
     const qreal x = r.x(), y = r.y(), w = r.width(), h = r.height();
     QPolygonF   poly;
     poly << QPointF(x, y) << QPointF(x + w, y + h * 0.30) << QPointF(x + w, y + h * 0.70)
          << QPointF(x, y + h) << QPointF(x, y + h * 0.62) << QPointF(x + w * 0.18, y + h * 0.50)
          << QPointF(x, y + h * 0.38);
-    auto* item = s->addPolygon(poly);
+    auto* item = new HoverPoly(poly);
     item->setData(0, QStringLiteral("comp"));
-    auto* txt = new QGraphicsSimpleTextItem(label, item);
-    txt->setData(0, QStringLiteral("comp-label"));
-    txt->setFont(scale::monoFont(scale::kFontSizeDense, true));
-    const QRectF tb = txt->boundingRect();
-    txt->setPos(x + w * 0.52 - tb.width() / 2, y + h / 2 - tb.height() / 2);
+    item->setAcceptHoverEvents(true);
+    item->setToolTip(tip);
+    s->addItem(item);
+    attachLabel(item, r, label, scale::monoFont(scale::kFontSizeDense, true), 0.52);
     return item;
 }
 
 // Vertical capsule mux.
-QGraphicsRectItem* addMux(QGraphicsScene* s, const QRectF& r) {
-    auto* mux = s->addRect(r);  // rounded corners drawn via pen radius below
+QGraphicsRectItem* addMux(QGraphicsScene* s, const QRectF& r, const QString& tip) {
+    auto* mux = new HoverRect(r);
     mux->setData(0, QStringLiteral("comp"));
-    auto* txt = new QGraphicsSimpleTextItem(QStringLiteral("M"), mux);
-    txt->setData(0, QStringLiteral("comp-label"));
-    txt->setFont(scale::monoFont(scale::kFontSizeDense - 2, true));
-    const QRectF tb = txt->boundingRect();
-    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    mux->setAcceptHoverEvents(true);
+    mux->setToolTip(tip);
+    s->addItem(mux);
+    attachLabel(mux, r, QStringLiteral("M"), scale::monoFont(scale::kFontSizeDense - 2, true));
     return mux;
 }
 
@@ -269,7 +312,34 @@ void SchematicDatapathWidget::buildScene() {
 
         stage_labels_[static_cast<std::size_t>(i)] =
             scene_->addSimpleText(QString(), scale::monoFont(scale::kFontSizeDense));
-        stage_labels_[static_cast<std::size_t>(i)]->setPos((c.x0 + c.x1) / 2, 16);
+        stage_labels_[static_cast<std::size_t>(i)]->setPos((c.x0 + c.x1) / 2, 12);
+
+        // PC of the instruction in this stage, dimmer, under the mnemonic —
+        // lets users map schematic columns to Pipeline Trace rows at a glance.
+        stage_pc_labels_[static_cast<std::size_t>(i)] =
+            scene_->addSimpleText(QString(), scale::monoFont(scale::kFontSizeDense - 3));
+        stage_pc_labels_[static_cast<std::size_t>(i)]->setPos((c.x0 + c.x1) / 2, 30);
+    }
+
+    // In-scene cycle counter (top-right, mirrors the status bar for exports).
+    cycle_text_ = scene_->addSimpleText(QStringLiteral("Cycle 0"),
+                                        scale::monoFont(scale::kFontSizeBody, true));
+    cycle_text_->setPos(kSceneW - cycle_text_->boundingRect().width() - 16, 12);
+
+    // Wire-colour legend along the bottom: the special wires communicate by
+    // colour, so they need a permanent key (never rely on colour alone).
+    {
+        const char* names[4] = {QT_TR_NOOP("EX/MEM→EX forward"), QT_TR_NOOP("MEM/WB→EX forward"),
+                                QT_TR_NOOP("branch flush"), QT_TR_NOOP("write-back")};
+        qreal       x        = 20;
+        for (const char* name : names) {
+            auto* swatch = scene_->addLine(x, kSceneH - 18, x + 24, kSceneH - 18);
+            legend_swatches_.push_back(swatch);
+            auto* txt = scene_->addSimpleText(tr(name), scale::monoFont(scale::kFontSizeDense - 2));
+            txt->setPos(x + 30, kSceneH - 18 - txt->boundingRect().height() / 2);
+            legend_texts_.push_back(txt);
+            x += 30 + txt->boundingRect().width() + 34;
+        }
     }
 
     // ── Pipeline register bars ───────────────────────────────────────────────
@@ -277,6 +347,10 @@ void SchematicDatapathWidget::buildScene() {
     for (int i = 0; i < 4; ++i) {
         auto* bar = scene_->addRect(QRectF(bar_xs[i], 70, 16, 420));
         bar->setZValue(1);
+        bar->setToolTip(tr("Pipeline register %1 — latches this stage's results on "
+                           "every clock edge so the next stage can consume them.\n"
+                           "Red = being flushed, amber = frozen by a stall.")
+                            .arg(QString::fromLatin1(kPipeRegNames[i])));
         pipe_regs_[static_cast<std::size_t>(i)] = bar;
         auto* lbl = new QGraphicsSimpleTextItem(QString::fromLatin1(kPipeRegNames[i]), bar);
         lbl->setData(0, QStringLiteral("comp-label"));
@@ -286,10 +360,15 @@ void SchematicDatapathWidget::buildScene() {
     }
 
     // ── IF stage ─────────────────────────────────────────────────────────────
-    addMux(scene_, QRectF(16, 250, 20, 60));  // PC-source mux
-    addBox(scene_, QRectF(52, 255, 42, 50), QStringLiteral("PC"));
-    addAlu(scene_, QRectF(120, 100, 44, 56), QStringLiteral("+4"));  // PC+4 adder
-    addBox(scene_, QRectF(120, 235, 116, 105), QStringLiteral("Instr.\nmemory"));
+    addMux(scene_, QRectF(16, 250, 20, 60),
+           tr("PC-source mux — selects the next PC: PC+4 (sequential) or the "
+              "branch/jump target when a branch is taken."));
+    pc_box_ = addBox(scene_, QRectF(52, 255, 42, 50), QStringLiteral("PC"), QString());
+    addAlu(scene_, QRectF(120, 100, 44, 56), QStringLiteral("+4"),
+           tr("PC+4 adder — computes the next sequential instruction address "
+              "(each MIPS instruction is 4 bytes)."));
+    imem_box_ =
+        addBox(scene_, QRectF(120, 235, 116, 105), QStringLiteral("Instr.\nmemory"), QString());
 
     auto addWire = [&](QPainterPath p, std::vector<WireItem::Tip> tips,
                        std::vector<QPointF> junctions = {}) -> WireItem* {
@@ -310,9 +389,11 @@ void SchematicDatapathWidget::buildScene() {
     addWire(ortho({{236, 280}, {270, 280}}), {{{270, 280}, {1, 0}}});
 
     // ── ID stage ─────────────────────────────────────────────────────────────
-    addBox(scene_, QRectF(320, 74, 96, 40), QStringLiteral("Control"));
-    addBox(scene_, QRectF(320, 210, 130, 125), QStringLiteral("Registers"));
-    addEllipse(scene_, QRectF(340, 380, 84, 42), QStringLiteral("Sign-\nextend"));
+    control_box_ = addBox(scene_, QRectF(320, 74, 96, 40), QStringLiteral("Control"), QString());
+    regs_box_ = addBox(scene_, QRectF(320, 210, 130, 125), QStringLiteral("Registers"), QString());
+    addEllipse(scene_, QRectF(340, 380, 84, 42), QStringLiteral("Sign-\nextend"),
+               tr("Sign-extend — widens the 16-bit immediate field to 32 bits, "
+                  "replicating the sign bit."));
 
     // Instruction bus out of IF/ID: vertical spine at x=305 feeding Control,
     // both register read ports, and sign-extend.
@@ -341,10 +422,16 @@ void SchematicDatapathWidget::buildScene() {
     addWire(ortho({{416, 94}, {555, 94}}), {{{555, 94}, {1, 0}}})->setControlStyle(true);
 
     // ── EX stage ─────────────────────────────────────────────────────────────
-    addMux(scene_, QRectF(600, 210, 20, 56));  // forwarding mux A
-    addMux(scene_, QRectF(600, 280, 20, 56));  // forwarding mux B
-    addAlu(scene_, QRectF(680, 210, 84, 130), QStringLiteral("ALU"));
-    addAlu(scene_, QRectF(690, 92, 44, 56), QStringLiteral("+"));  // branch-target adder
+    const QString fwd_mux_tip =
+        tr("Forwarding mux — feeds the ALU with either the register value from "
+           "ID/EX, the EX/MEM bypass (orange), or the MEM/WB bypass (purple). "
+           "Forwarding resolves data hazards without stalling.");
+    addMux(scene_, QRectF(600, 210, 20, 56), fwd_mux_tip);
+    addMux(scene_, QRectF(600, 280, 20, 56), fwd_mux_tip);
+    alu_item_ = addAlu(scene_, QRectF(680, 210, 84, 130), QStringLiteral("ALU"), QString());
+    addAlu(scene_, QRectF(690, 92, 44, 56), QStringLiteral("+"),
+           tr("Branch-target adder — PC+4 plus the sign-extended immediate "
+              "shifted left 2 (word-aligned offset)."));
 
     // ID/EX → forwarding muxes → ALU
     addWire(ortho({{571, 240}, {585, 240}, {585, 222}, {600, 222}}), {{{600, 222}, {1, 0}}});
@@ -383,8 +470,12 @@ void SchematicDatapathWidget::buildScene() {
     }
 
     // ── MEM stage ────────────────────────────────────────────────────────────
-    addBox(scene_, QRectF(910, 230, 125, 125), QStringLiteral("Data\nmemory"));
-    addBox(scene_, QRectF(910, 96, 80, 44), QStringLiteral("Branch"));
+    dmem_box_ =
+        addBox(scene_, QRectF(910, 230, 125, 125), QStringLiteral("Data\nmemory"), QString());
+    addBox(scene_, QRectF(910, 96, 80, 44), QStringLiteral("Branch"),
+           tr("Branch decision — compares the operands and, on a taken branch, "
+              "redirects the PC to the branch target (red wire) and flushes the "
+              "younger instructions behind it."));
 
     addWire(ortho({{861, 275}, {910, 275}}), {{{910, 275}, {1, 0}}}, {{885, 275}});
     addWire(ortho({{861, 370}, {895, 370}, {895, 320}, {910, 320}}), {{{910, 320}, {1, 0}}});
@@ -399,7 +490,9 @@ void SchematicDatapathWidget::buildScene() {
                 {{{16, 298}, {1, 0}}});
 
     // ── WB stage ─────────────────────────────────────────────────────────────
-    addMux(scene_, QRectF(1180, 250, 22, 70));  // MemToReg mux
+    addMux(scene_, QRectF(1180, 250, 22, 70),
+           tr("MemToReg mux — selects what is written back to the register "
+              "file: the ALU result or the value loaded from data memory."));
     addWire(ortho({{1146, 275}, {1165, 275}, {1165, 272}, {1180, 272}}), {{{1180, 272}, {1, 0}}});
     addWire(ortho({{1146, 415}, {1172, 415}, {1172, 298}, {1180, 298}}), {{{1180, 298}, {1, 0}}});
     // Write-back loop to the register file write port
@@ -458,6 +551,14 @@ void SchematicDatapathWidget::applyTheme() {
 
     focus_ring_->setPen(QPen(dark_mode_ ? QColor("#4FC3F7") : QColor("#0078D4"), 2, Qt::DashLine));
 
+    // Legend swatches take the special-wire colours; text follows the theme.
+    const QColor legend_colors[4] = {t.fwd_ex, t.fwd_mem, t.flush, t.wb};
+    for (std::size_t i = 0; i < legend_swatches_.size() && i < 4; ++i) {
+        legend_swatches_[i]->setPen(QPen(legend_colors[i], 3));
+        legend_texts_[i]->setBrush(t.wire);
+    }
+    cycle_text_->setBrush(t.label);
+
     applyState();  // re-derives state-dependent tints for the new theme
 }
 
@@ -471,7 +572,8 @@ void SchematicDatapathWidget::applyState() {
         band.setAlpha(snap.valid ? (dark_mode_ ? 70 : 120) : (dark_mode_ ? 25 : 45));
         stage_tints_[static_cast<std::size_t>(i)]->setBrush(band);
 
-        // Mnemonic label above the column (Ripes-style).
+        // Mnemonic label above the column (Ripes-style). Raw word 0 encodes
+        // sll $zero,$zero,0 — the canonical MIPS nop — so print it as "nop".
         auto*   lbl = stage_labels_[static_cast<std::size_t>(i)];
         QString text;
         QColor  color = t.text;
@@ -482,7 +584,8 @@ void SchematicDatapathWidget::applyState() {
             text  = QStringLiteral("nop (stall)");
             color = t.stall;
         } else if (snap.valid) {
-            text = QString::fromStdString(format_instr(snap.raw));
+            text = snap.raw == 0 ? QStringLiteral("nop")
+                                 : QString::fromStdString(format_instr(snap.raw));
         } else {
             text  = QStringLiteral("—");
             color = t.wire_dim;
@@ -490,13 +593,23 @@ void SchematicDatapathWidget::applyState() {
         lbl->setText(text);
         lbl->setBrush(color);
         const auto& c = kColumns[i];
-        lbl->setPos((c.x0 + c.x1) / 2 - lbl->boundingRect().width() / 2, 16);
+        lbl->setPos((c.x0 + c.x1) / 2 - lbl->boundingRect().width() / 2, 12);
+
+        // PC chip under the mnemonic, matching the Pipeline Trace address column.
+        auto* pc_lbl = stage_pc_labels_[static_cast<std::size_t>(i)];
+        pc_lbl->setText(snap.valid ? QStringLiteral("0x%1").arg(snap.pc, 8, 16, QChar('0'))
+                                   : QString());
+        pc_lbl->setBrush(t.wire);
+        pc_lbl->setPos((c.x0 + c.x1) / 2 - pc_lbl->boundingRect().width() / 2, 30);
 
         // Breakpoint bullseye visibility.
         const bool bp = snap.valid && breakpoints_.count(snap.pc) > 0;
         bp_markers_[static_cast<std::size_t>(i)].first->setVisible(bp);
         bp_markers_[static_cast<std::size_t>(i)].second->setVisible(bp);
     }
+
+    cycle_text_->setText(tr("Cycle %1").arg(static_cast<qulonglong>(state_.cycle)));
+    cycle_text_->setPos(kSceneW - cycle_text_->boundingRect().width() - 16, 12);
 
     // Pipeline-register bars: red = flushing, amber = stalled, else neutral.
     for (int i = 0; i < 4; ++i) {
@@ -515,7 +628,107 @@ void SchematicDatapathWidget::applyState() {
     fwd_memwb_wire_->setActive(state_.fwd_mem_to_ex_a || state_.fwd_mem_to_ex_b);
     fwd_memwb_stub_->setActive(state_.fwd_mem_to_ex_b);
     branch_wire_->setActive(state_.branch_flush);
-    writeback_wire_->setActive(state_.stages[4].valid);
+
+    // Control-signal accents: light the component that is actually working
+    // this cycle, derived from the per-stage instruction's control word.
+    auto control_for = [](const mips::StageSnapshot& snap) -> mips::Control {
+        if (!snap.valid || snap.raw == 0) return {};
+        const auto d = mips::Decoder::decode(snap.raw);
+        return d ? mips::derive_control(*d) : mips::Control{};
+    };
+    const mips::Control mem_ctl = control_for(state_.stages[3]);
+    const mips::Control wb_ctl  = control_for(state_.stages[4]);
+
+    const QPen base_pen(t.comp_border, 1.4);
+    dmem_box_->setPen((mem_ctl.mem_read || mem_ctl.mem_write) ? QPen(t.label, 2.4) : base_pen);
+    regs_box_->setPen(wb_ctl.reg_write ? QPen(t.wb, 2.4) : base_pen);
+    writeback_wire_->setActive(wb_ctl.reg_write);
+
+    updateTooltips();
+}
+
+void SchematicDatapathWidget::updateTooltips() {
+    // Each tooltip = what the unit does (static teaching text) + what it is
+    // doing right now (live line derived from the stage snapshots).
+    const auto& s_if  = state_.stages[0];
+    const auto& s_id  = state_.stages[1];
+    const auto& s_ex  = state_.stages[2];
+    const auto& s_mem = state_.stages[3];
+
+    auto instr_line = [](const mips::StageSnapshot& s) {
+        if (!s.valid) return QString("—");
+        if (s.raw == 0) return QStringLiteral("nop");
+        return QString::fromStdString(format_instr(s.raw));
+    };
+
+    pc_box_->setToolTip(tr("Program Counter — holds the address of the instruction "
+                           "being fetched.\nPC = 0x%1")
+                            .arg(s_if.pc, 8, 16, QChar('0')));
+
+    imem_box_->setToolTip(tr("Instruction memory — read-only program storage; outputs "
+                             "the 32-bit word addressed by PC.\nFetching: %1")
+                              .arg(instr_line(s_if)));
+
+    // Control word of the instruction currently being decoded.
+    QString asserted = tr("(none)");
+    if (s_id.valid && s_id.raw != 0) {
+        if (const auto d = mips::Decoder::decode(s_id.raw)) {
+            const mips::Control c = mips::derive_control(*d);
+            QStringList         sig;
+            if (c.reg_write) sig << QStringLiteral("RegWrite");
+            if (c.mem_read) sig << QStringLiteral("MemRead");
+            if (c.mem_write) sig << QStringLiteral("MemWrite");
+            if (c.mem_to_reg) sig << QStringLiteral("MemToReg");
+            if (c.alu_src) sig << QStringLiteral("ALUSrc");
+            if (c.reg_dst) sig << QStringLiteral("RegDst");
+            if (c.branch) sig << QStringLiteral("Branch");
+            if (c.jump) sig << QStringLiteral("Jump");
+            if (!sig.isEmpty()) asserted = sig.join(QStringLiteral(", "));
+        }
+    }
+    control_box_->setToolTip(tr("Control unit — decodes the ID-stage instruction into the "
+                                "control signals that steer the datapath.\nID: %1\nAsserted: %2")
+                                 .arg(instr_line(s_id), asserted));
+
+    // Register file: show the ID instruction's source operands with live values.
+    QString read_line = tr("(idle)");
+    if (s_id.valid && s_id.raw != 0) {
+        if (const auto d = mips::Decoder::decode(s_id.raw)) {
+            uint8_t rs = 0, rt = 0;
+            if (d->format == mips::InstrFormat::R) {
+                rs = d->r().rs;
+                rt = d->r().rt;
+            } else if (d->format == mips::InstrFormat::I) {
+                rs = d->i().rs;
+                rt = d->i().rt;
+            }
+            read_line = QStringLiteral("$%1 = 0x%2   $%3 = 0x%4")
+                            .arg(QString::fromStdString(std::string(mips::register_abi_name(rs))))
+                            .arg(reg_values_[rs], 8, 16, QChar('0'))
+                            .arg(QString::fromStdString(std::string(mips::register_abi_name(rt))))
+                            .arg(reg_values_[rt], 8, 16, QChar('0'));
+        }
+    }
+    regs_box_->setToolTip(tr("Register file — 32 × 32-bit registers with two read ports "
+                             "(ID) and one write port (WB).\nID reads: %1")
+                              .arg(read_line));
+
+    alu_item_->setToolTip(tr("ALU — performs the arithmetic/logic operation for the "
+                             "EX-stage instruction. Its inputs come through the forwarding "
+                             "muxes on the left.\nEX: %1")
+                              .arg(instr_line(s_ex)));
+
+    const mips::Control mem_ctl = [&] {
+        if (s_mem.valid && s_mem.raw != 0)
+            if (const auto d = mips::Decoder::decode(s_mem.raw)) return mips::derive_control(*d);
+        return mips::Control{};
+    }();
+    const QString mem_act = mem_ctl.mem_read    ? tr("reading (load)")
+                            : mem_ctl.mem_write ? tr("writing (store)")
+                                                : tr("idle");
+    dmem_box_->setToolTip(tr("Data memory — the load/store port used in MEM. Only lw/sw "
+                             "class instructions touch it.\nMEM: %1 — %2")
+                              .arg(instr_line(s_mem), mem_act));
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────
@@ -533,6 +746,11 @@ void SchematicDatapathWidget::setBreakpoints(const std::unordered_set<uint32_t>&
 void SchematicDatapathWidget::setDarkMode(bool dark) {
     dark_mode_ = dark;
     applyTheme();
+}
+
+void SchematicDatapathWidget::setRegisterValues(const std::array<uint32_t, 32>& regs) {
+    reg_values_ = regs;
+    updateTooltips();
 }
 
 // ── Interaction ─────────────────────────────────────────────────────────────
@@ -581,21 +799,57 @@ void SchematicDatapathWidget::mouseDoubleClickEvent(QMouseEvent* ev) {
 }
 
 void SchematicDatapathWidget::contextMenuEvent(QContextMenuEvent* ev) {
-    const int idx = stageAtViewPos(ev->pos());
-    if (idx < 0) return;
-    const auto& snap = state_.stages[static_cast<std::size_t>(idx)];
-    if (!snap.valid) return;
+    QMenu menu(this);
 
-    QMenu      menu(this);
-    const bool has_bp = breakpoints_.count(snap.pc) > 0;
-    QAction*   act    = menu.addAction(has_bp ? tr("Clear Breakpoint") : tr("Set Breakpoint"));
-    QAction*   fit    = menu.addAction(tr("Zoom to Fit"));
-    QAction*   chosen = menu.exec(ev->globalPos());
-    if (chosen == act) emit breakpointToggleRequested(snap.pc);
-    if (chosen == fit) {
+    // Stage-specific actions only when the cursor is over a stage with a
+    // real instruction; view actions are available everywhere.
+    const int idx     = stageAtViewPos(ev->pos());
+    QAction*  bp_act  = nullptr;
+    QAction*  det_act = nullptr;
+    if (idx >= 0 && state_.stages[static_cast<std::size_t>(idx)].valid) {
+        const auto& snap   = state_.stages[static_cast<std::size_t>(idx)];
+        const bool  has_bp = breakpoints_.count(snap.pc) > 0;
+        bp_act             = menu.addAction(has_bp ? tr("Clear Breakpoint") : tr("Set Breakpoint"));
+        det_act            = menu.addAction(tr("Stage Detail…"));
+        menu.addSeparator();
+    }
+    QAction* fit_act    = menu.addAction(tr("Zoom to Fit"));
+    QAction* export_act = menu.addAction(tr("Export as Image…"));
+
+    QAction* chosen = menu.exec(ev->globalPos());
+    if (chosen == nullptr) return;
+    if (chosen == fit_act) {
         user_zoomed_ = false;
         fitSchematic();
+    } else if (chosen == export_act) {
+        exportImage();
+    } else if (chosen == bp_act) {
+        emit breakpointToggleRequested(state_.stages[static_cast<std::size_t>(idx)].pc);
+    } else if (chosen == det_act) {
+        const auto& snap = state_.stages[static_cast<std::size_t>(idx)];
+        emit        stageDetailRequested(idx, snap.pc, snap.raw);
     }
+}
+
+void SchematicDatapathWidget::exportImage() {
+    const QString path = QFileDialog::getSaveFileName(
+        this, tr("Export Schematic"),
+        QStringLiteral("datapath-cycle-%1.png").arg(static_cast<qulonglong>(state_.cycle)),
+        tr("PNG Images (*.png)"));
+    if (path.isEmpty()) return;
+
+    // 2x supersampling so wire and label detail survives in lab reports.
+    QImage img(static_cast<int>(kSceneW) * 2, static_cast<int>(kSceneH) * 2,
+               QImage::Format_ARGB32_Premultiplied);
+    img.fill(theme(dark_mode_).bg);
+    QPainter p(&img);
+    p.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+    scene_->render(&p);
+    p.end();
+
+    if (!img.save(path))
+        QMessageBox::warning(this, tr("Export Failed"),
+                             tr("Could not write the image to:\n%1").arg(path));
 }
 
 void SchematicDatapathWidget::keyPressEvent(QKeyEvent* ev) {

--- a/src/nsc_qt/widgets/schematic_datapath_widget.cpp
+++ b/src/nsc_qt/widgets/schematic_datapath_widget.cpp
@@ -24,11 +24,13 @@
 #include <QPen>
 #include <QPolygonF>
 #include <QStringList>
+#include <QToolButton>
 #include <QVariantAnimation>
 #include <QWheelEvent>
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -181,25 +183,46 @@ namespace {
 // ── Hover-capable component shapes ───────────────────────────────────────────
 // Thickens the border while hovered, giving components a tactile feel and
 // signalling that the tooltip carries more detail (progressive disclosure).
+// The highlight is drawn at paint time on top of the item's current pen —
+// never by swapping the pen — so control-signal accents applied by
+// applyState() mid-hover are not wiped when the cursor leaves.
 template <typename Base> class HoverShape : public Base {
 public:
     using Base::Base;
 
+    QRectF boundingRect() const override {
+        return Base::boundingRect().adjusted(-1.5, -1.5, 1.5, 1.5);  // room for the halo
+    }
+
+    void paint(QPainter* p, const QStyleOptionGraphicsItem* opt, QWidget* w) override {
+        Base::paint(p, opt, w);
+        if (!hovered_) return;
+        QPen hp = this->pen();
+        hp.setWidthF(hp.widthF() + 1.4);
+        p->setPen(hp);
+        p->setBrush(Qt::NoBrush);
+        if constexpr (std::is_same_v<Base, QGraphicsRectItem>)
+            p->drawRect(this->rect());
+        else if constexpr (std::is_same_v<Base, QGraphicsEllipseItem>)
+            p->drawEllipse(this->rect());
+        else
+            p->drawPolygon(this->polygon());
+    }
+
 protected:
     void hoverEnterEvent(QGraphicsSceneHoverEvent* ev) override {
-        saved_pen_ = this->pen();
-        QPen p     = saved_pen_;
-        p.setWidthF(saved_pen_.widthF() + 1.2);
-        this->setPen(p);
+        hovered_ = true;
+        this->update();
         Base::hoverEnterEvent(ev);
     }
     void hoverLeaveEvent(QGraphicsSceneHoverEvent* ev) override {
-        this->setPen(saved_pen_);
+        hovered_ = false;
+        this->update();
         Base::hoverLeaveEvent(ev);
     }
 
 private:
-    QPen saved_pen_;
+    bool hovered_ = false;
 };
 
 using HoverRect    = HoverShape<QGraphicsRectItem>;
@@ -298,6 +321,27 @@ SchematicDatapathWidget::SchematicDatapathWidget(QWidget* parent) : QGraphicsVie
     setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
     setFocusPolicy(Qt::StrongFocus);
     setMinimumSize(560, 260);
+
+    // Zoom controls overlaid top-right of the viewport: a visible, clickable
+    // alternative to Ctrl+wheel (which nothing on screen advertises).
+    auto mk_btn = [&](const QString& text, const QString& tip) {
+        auto* b = new QToolButton(this);
+        b->setText(text);
+        b->setToolTip(tip);
+        b->setAutoRaise(true);
+        b->setFixedSize(26, 26);
+        b->setFocusPolicy(Qt::NoFocus);  // keep keyboard focus on the schematic
+        return b;
+    };
+    btn_zoom_in_  = mk_btn(QStringLiteral("+"), tr("Zoom in (Ctrl+Wheel)"));
+    btn_zoom_out_ = mk_btn(QStringLiteral("−"), tr("Zoom out (Ctrl+Wheel)"));
+    btn_zoom_fit_ = mk_btn(QStringLiteral("⤢"), tr("Zoom to fit"));
+    connect(btn_zoom_in_, &QToolButton::clicked, this, [this] { zoomBy(1.2); });
+    connect(btn_zoom_out_, &QToolButton::clicked, this, [this] { zoomBy(1.0 / 1.2); });
+    connect(btn_zoom_fit_, &QToolButton::clicked, this, [this] {
+        user_zoomed_ = false;
+        fitSchematic();
+    });
 
     buildScene();
     applyTheme();
@@ -559,6 +603,17 @@ void SchematicDatapathWidget::buildScene() {
             tok->setVisible(false);
     });
 
+    // ── Hazard explainer chip ────────────────────────────────────────────────
+    // Appears the moment a stall or flush happens and says why, in the
+    // hazard's colour — turning "the pipeline did something weird" into a
+    // teachable moment. Hidden when no hazard is active.
+    hazard_chip_ = scene_->addRect(QRectF());
+    hazard_chip_->setZValue(11);
+    hazard_chip_->setVisible(false);
+    hazard_text_ = scene_->addSimpleText(QString(), scale::monoFont(scale::kFontSizeDense, true));
+    hazard_text_->setZValue(12);
+    hazard_text_->setVisible(false);
+
     // ── Keyboard focus ring ──────────────────────────────────────────────────
     focus_ring_ = scene_->addRect(QRectF());
     focus_ring_->setZValue(10);
@@ -616,7 +671,9 @@ void SchematicDatapathWidget::applyState() {
         const auto&  snap = state_.stages[static_cast<std::size_t>(i)];
         const QColor tint = dark_mode_ ? kStageDark[i] : kStageLight[i];
         QColor       band = tint;
-        band.setAlpha(snap.valid ? (dark_mode_ ? 70 : 120) : (dark_mode_ ? 25 : 45));
+        // Dark tints are deep, saturated hues; at high alpha they overwhelm
+        // the schematic (MEM turned solid brown). Keep them a faint wash.
+        band.setAlpha(snap.valid ? (dark_mode_ ? 32 : 120) : (dark_mode_ ? 12 : 45));
         stage_tints_[static_cast<std::size_t>(i)]->setBrush(band);
 
         // Mnemonic label above the column (Ripes-style). Raw word 0 encodes
@@ -750,6 +807,43 @@ void SchematicDatapathWidget::applyState() {
     val_wb_->setText(wb_text);
     val_wb_->setBrush(t.wb);
     val_wb_->setPos(700 - val_wb_->boundingRect().width() / 2, 486);
+
+    // ── Hazard explainer chip ────────────────────────────────────────────────
+    QString hz;
+    QColor  hz_color;
+    if (state_.branch_flush) {
+        const auto& s_mem2 = state_.stages[3];
+        hz                 = tr("Branch taken: %1 — PC redirected, younger instructions flushed")
+                                 .arg(s_mem2.valid && s_mem2.raw != 0
+                                          ? QString::fromStdString(format_instr(s_mem2.raw))
+                                          : QStringLiteral("branch"));
+        hz_color           = t.flush;
+    } else if (state_.load_stall) {
+        const auto& s_ex2 = state_.stages[2];
+        hz =
+            tr("Load-use hazard: %1 — its data arrives after MEM, so the "
+               "dependent instruction waits one cycle")
+                .arg(s_ex2.valid && s_ex2.raw != 0 ? QString::fromStdString(format_instr(s_ex2.raw))
+                                                   : QStringLiteral("lw"));
+        hz_color = t.stall;
+    }
+    if (hz.isEmpty()) {
+        hazard_chip_->setVisible(false);
+        hazard_text_->setVisible(false);
+    } else {
+        hazard_text_->setText(hz);
+        hazard_text_->setBrush(hz_color);
+        const QRectF tb = hazard_text_->boundingRect();
+        const qreal  cx = kSceneW / 2;
+        hazard_text_->setPos(cx - tb.width() / 2, 54);
+        QColor bg = t.comp_fill;
+        bg.setAlpha(235);
+        hazard_chip_->setRect(cx - tb.width() / 2 - 10, 50, tb.width() + 20, tb.height() + 8);
+        hazard_chip_->setBrush(bg);
+        hazard_chip_->setPen(QPen(hz_color, 1.4));
+        hazard_chip_->setVisible(true);
+        hazard_text_->setVisible(true);
+    }
 
     updateTooltips();
 }
@@ -933,14 +1027,17 @@ void SchematicDatapathWidget::fitSchematic() {
     if (!user_zoomed_) fitInView(scene_->sceneRect(), Qt::KeepAspectRatio);
 }
 
+void SchematicDatapathWidget::zoomBy(qreal factor) {
+    user_zoomed_       = true;
+    const qreal cur    = transform().m11();
+    const qreal target = std::clamp(cur * factor, 0.3, 4.0);
+    scale(target / cur, target / cur);
+}
+
 void SchematicDatapathWidget::wheelEvent(QWheelEvent* ev) {
     // Ctrl+wheel zooms around the cursor; plain wheel scrolls as usual.
     if (ev->modifiers() & Qt::ControlModifier) {
-        user_zoomed_       = true;
-        const qreal step   = std::pow(1.15, ev->angleDelta().y() / 120.0);
-        const qreal cur    = transform().m11();
-        const qreal target = std::clamp(cur * step, 0.3, 4.0);
-        scale(target / cur, target / cur);
+        zoomBy(std::pow(1.15, ev->angleDelta().y() / 120.0));
         ev->accept();
         return;
     }
@@ -1052,6 +1149,11 @@ void SchematicDatapathWidget::keyPressEvent(QKeyEvent* ev) {
 void SchematicDatapathWidget::resizeEvent(QResizeEvent* ev) {
     QGraphicsView::resizeEvent(ev);
     fitSchematic();
+    // Keep the zoom buttons pinned to the top-right of the viewport.
+    const int x = viewport()->width() - 30;
+    btn_zoom_in_->move(x, 6);
+    btn_zoom_out_->move(x, 34);
+    btn_zoom_fit_->move(x, 62);
 }
 
 void SchematicDatapathWidget::focusInEvent(QFocusEvent* ev) {

--- a/src/nsc_qt/widgets/schematic_datapath_widget.cpp
+++ b/src/nsc_qt/widgets/schematic_datapath_widget.cpp
@@ -1,0 +1,649 @@
+#include "nsc_qt/widgets/schematic_datapath_widget.h"
+#include "nsc_qt/instr_format.h"
+#include "nsc_qt/ui_scale.h"
+
+#include <QContextMenuEvent>
+#include <QFocusEvent>
+#include <QGraphicsEllipseItem>
+#include <QGraphicsPathItem>
+#include <QGraphicsPolygonItem>
+#include <QGraphicsRectItem>
+#include <QGraphicsScene>
+#include <QGraphicsSimpleTextItem>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+#include <QPolygonF>
+#include <QWheelEvent>
+#include <algorithm>
+#include <cmath>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace nsc::qt {
+
+namespace {
+
+// ── Logical canvas ──────────────────────────────────────────────────────────
+// All geometry is authored in this fixed coordinate space; QGraphicsView
+// scales it to the widget. Chosen wide enough that the schematic reads at a
+// glance, like Ripes' processor tab.
+constexpr qreal kSceneW = 1400.0;
+constexpr qreal kSceneH = 540.0;
+
+// Stage column x-extents (tint bands + hit testing). Bars live between them.
+struct ColumnSpan {
+    qreal x0, x1;
+};
+constexpr ColumnSpan kColumns[5] = {
+    {8, 270},      // IF
+    {286, 555},    // ID
+    {571, 845},    // EX
+    {861, 1130},   // MEM
+    {1146, 1392},  // WB
+};
+
+constexpr qreal kColTop = 44.0, kColBot = 500.0;
+
+const char* const kStageNames[5]   = {"IF", "ID", "EX", "MEM", "WB"};
+const char* const kPipeRegNames[4] = {"IF/ID", "ID/EX", "EX/MEM", "MEM/WB"};
+
+// Stage tint hues (shared with the old widget's palette).
+const QColor kStageLight[5] = {QColor("#E3F2FD"), QColor("#E0F7FA"), QColor("#E8F5E9"),
+                               QColor("#FFFDE7"), QColor("#FFEBEE")};
+const QColor kStageDark[5]  = {QColor("#0D47A1"), QColor("#006064"), QColor("#1B5E20"),
+                               QColor("#F57F17"), QColor("#B71C1C")};
+
+// Theme palette for schematic chrome.
+struct Theme {
+    QColor bg, comp_fill, comp_border, wire, wire_dim, text, label, flush, stall, fwd_ex, fwd_mem,
+        wb;
+};
+const Theme kLight = {
+    QColor("#F5F5F5"), QColor("#FFFFFF"), QColor("#606060"), QColor("#707070"),
+    QColor("#C4C4C4"), QColor("#1A1A1A"), QColor("#00529B"), QColor("#D32F2F"),
+    QColor("#E65100"), QColor("#FF6F00"), QColor("#7B1FA2"), QColor("#2E7D32"),
+};
+const Theme kDark = {
+    QColor("#1E1E1E"), QColor("#2D2D2D"), QColor("#9A9A9A"), QColor("#A0A0A0"),
+    QColor("#4A4A4A"), QColor("#E0E0E0"), QColor("#9CDCFE"), QColor("#FF5252"),
+    QColor("#FFB74D"), QColor("#FFA726"), QColor("#CE93D8"), QColor("#81C784"),
+};
+inline const Theme& theme(bool dark) {
+    return dark ? kDark : kLight;
+}
+
+}  // anonymous namespace
+
+// ── WireItem ────────────────────────────────────────────────────────────────
+// An orthogonal signal wire: an arbitrary painter path plus arrowheads at the
+// stated tips and junction dots where a bus splits. `setActive()` switches
+// between the dim resting look and a bright highlighted one — that's how
+// forwarding paths, the branch flush path, and the write-back loop light up.
+class WireItem : public QGraphicsItem {
+public:
+    struct Tip {
+        QPointF at;
+        // Unit direction the arrow points: (1,0)=right, (0,1)=down, …
+        QPointF dir;
+    };
+
+    WireItem(QPainterPath path, std::vector<Tip> tips, std::vector<QPointF> junctions,
+             QGraphicsItem* parent = nullptr)
+        : QGraphicsItem(parent), path_(std::move(path)), tips_(std::move(tips)),
+          junctions_(std::move(junctions)) {
+        setZValue(-1);  // wires under components
+    }
+
+    void setColors(const QColor& rest, const QColor& lit) {
+        rest_ = rest;
+        lit_  = lit;
+        update();
+    }
+
+    void setActive(bool on) {
+        if (active_ == on) return;
+        active_ = on;
+        update();
+    }
+
+    // Thin dashed rendering for control-signal wires.
+    void setControlStyle(bool on) {
+        control_ = on;
+        update();
+    }
+
+    QRectF boundingRect() const override { return path_.boundingRect().adjusted(-8, -8, 8, 8); }
+
+    void paint(QPainter* p, const QStyleOptionGraphicsItem*, QWidget*) override {
+        const QColor& c = active_ ? lit_ : rest_;
+        const qreal   w = active_ ? 3.0 : (control_ ? 1.0 : 1.6);
+
+        QPen pen(c, w);
+        if (control_ && !active_) pen.setStyle(Qt::DashLine);
+        pen.setJoinStyle(Qt::MiterJoin);
+        p->setRenderHint(QPainter::Antialiasing);
+
+        if (active_) {  // soft glow pass under the lit wire
+            QPen glow(QColor(c.red(), c.green(), c.blue(), 70), w + 4, Qt::SolidLine, Qt::RoundCap);
+            p->setPen(glow);
+            p->setBrush(Qt::NoBrush);
+            p->drawPath(path_);
+        }
+        p->setPen(pen);
+        p->setBrush(Qt::NoBrush);
+        p->drawPath(path_);
+
+        p->setPen(Qt::NoPen);
+        p->setBrush(c);
+        for (const Tip& t : tips_) {
+            const QPointF d = t.dir;
+            const QPointF n(-d.y(), d.x());  // normal
+            const qreal   len = 7.0, half = 4.0;
+            const QPointF base   = t.at - d * len;
+            const QPointF tri[3] = {t.at, base + n * half, base - n * half};
+            p->drawPolygon(tri, 3);
+        }
+        for (const QPointF& j : junctions_)
+            p->drawEllipse(j, 3.0, 3.0);
+    }
+
+private:
+    QPainterPath         path_;
+    std::vector<Tip>     tips_;
+    std::vector<QPointF> junctions_;
+    QColor               rest_ = Qt::gray, lit_ = Qt::red;
+    bool                 active_ = false, control_ = false;
+};
+
+namespace {
+
+// ── Component construction helpers ──────────────────────────────────────────
+// Components are plain QGraphicsItems tagged with data(0)="comp" so the theme
+// pass can restyle fill/border/text without keeping a pointer to each one.
+
+QGraphicsRectItem* addBox(QGraphicsScene* s, const QRectF& r, const QString& label,
+                          int font_px = scale::kFontSizeDense) {
+    auto* box = s->addRect(r);
+    box->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(label, box);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(font_px));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    return box;
+}
+
+QGraphicsEllipseItem* addEllipse(QGraphicsScene* s, const QRectF& r, const QString& label) {
+    auto* el = s->addEllipse(r);
+    el->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(label, el);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(scale::kFontSizeDense - 2));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    return el;
+}
+
+// Classic ALU / adder pentagon with the input notch on the left.
+QGraphicsPolygonItem* addAlu(QGraphicsScene* s, const QRectF& r, const QString& label) {
+    const qreal x = r.x(), y = r.y(), w = r.width(), h = r.height();
+    QPolygonF   poly;
+    poly << QPointF(x, y) << QPointF(x + w, y + h * 0.30) << QPointF(x + w, y + h * 0.70)
+         << QPointF(x, y + h) << QPointF(x, y + h * 0.62) << QPointF(x + w * 0.18, y + h * 0.50)
+         << QPointF(x, y + h * 0.38);
+    auto* item = s->addPolygon(poly);
+    item->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(label, item);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(scale::kFontSizeDense, true));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(x + w * 0.52 - tb.width() / 2, y + h / 2 - tb.height() / 2);
+    return item;
+}
+
+// Vertical capsule mux.
+QGraphicsRectItem* addMux(QGraphicsScene* s, const QRectF& r) {
+    auto* mux = s->addRect(r);  // rounded corners drawn via pen radius below
+    mux->setData(0, QStringLiteral("comp"));
+    auto* txt = new QGraphicsSimpleTextItem(QStringLiteral("M"), mux);
+    txt->setData(0, QStringLiteral("comp-label"));
+    txt->setFont(scale::monoFont(scale::kFontSizeDense - 2, true));
+    const QRectF tb = txt->boundingRect();
+    txt->setPos(r.center().x() - tb.width() / 2, r.center().y() - tb.height() / 2);
+    return mux;
+}
+
+// Build an orthogonal path through the given points.
+QPainterPath ortho(std::initializer_list<QPointF> pts) {
+    QPainterPath p;
+    bool         first = true;
+    for (const QPointF& pt : pts) {
+        if (first) {
+            p.moveTo(pt);
+            first = false;
+        } else {
+            p.lineTo(pt);
+        }
+    }
+    return p;
+}
+
+}  // anonymous namespace
+
+// ── SchematicDatapathWidget ─────────────────────────────────────────────────
+
+SchematicDatapathWidget::SchematicDatapathWidget(QWidget* parent) : QGraphicsView(parent) {
+    scene_ = new QGraphicsScene(0, 0, kSceneW, kSceneH, this);
+    setScene(scene_);
+
+    setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+    setDragMode(QGraphicsView::ScrollHandDrag);
+    setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
+    setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
+    setFocusPolicy(Qt::StrongFocus);
+    setMinimumSize(560, 260);
+
+    buildScene();
+    applyTheme();
+    applyState();
+}
+
+void SchematicDatapathWidget::buildScene() {
+    // ── Stage tint bands + mnemonic labels ──────────────────────────────────
+    for (int i = 0; i < 5; ++i) {
+        const auto& c = kColumns[i];
+        stage_tints_[static_cast<std::size_t>(i)] =
+            scene_->addRect(QRectF(c.x0, kColTop, c.x1 - c.x0, kColBot - kColTop));
+        stage_tints_[static_cast<std::size_t>(i)]->setZValue(-10);
+        stage_tints_[static_cast<std::size_t>(i)]->setPen(Qt::NoPen);
+
+        auto* name = scene_->addSimpleText(QString::fromLatin1(kStageNames[i]),
+                                           scale::monoFont(scale::kFontSizeBody, true));
+        name->setData(0, QStringLiteral("stage-name"));
+        name->setPos((c.x0 + c.x1) / 2 - name->boundingRect().width() / 2, kColBot + 8);
+
+        stage_labels_[static_cast<std::size_t>(i)] =
+            scene_->addSimpleText(QString(), scale::monoFont(scale::kFontSizeDense));
+        stage_labels_[static_cast<std::size_t>(i)]->setPos((c.x0 + c.x1) / 2, 16);
+    }
+
+    // ── Pipeline register bars ───────────────────────────────────────────────
+    const qreal bar_xs[4] = {270, 555, 845, 1130};
+    for (int i = 0; i < 4; ++i) {
+        auto* bar = scene_->addRect(QRectF(bar_xs[i], 70, 16, 420));
+        bar->setZValue(1);
+        pipe_regs_[static_cast<std::size_t>(i)] = bar;
+        auto* lbl = new QGraphicsSimpleTextItem(QString::fromLatin1(kPipeRegNames[i]), bar);
+        lbl->setData(0, QStringLiteral("comp-label"));
+        lbl->setFont(scale::monoFont(scale::kFontSizeDense - 3, true));
+        lbl->setRotation(-90);
+        lbl->setPos(bar_xs[i] + 13.5, 280 + lbl->boundingRect().width() / 2);
+    }
+
+    // ── IF stage ─────────────────────────────────────────────────────────────
+    addMux(scene_, QRectF(16, 250, 20, 60));  // PC-source mux
+    addBox(scene_, QRectF(52, 255, 42, 50), QStringLiteral("PC"));
+    addAlu(scene_, QRectF(120, 100, 44, 56), QStringLiteral("+4"));  // PC+4 adder
+    addBox(scene_, QRectF(120, 235, 116, 105), QStringLiteral("Instr.\nmemory"));
+
+    auto addWire = [&](QPainterPath p, std::vector<WireItem::Tip> tips,
+                       std::vector<QPointF> junctions = {}) -> WireItem* {
+        auto* w = new WireItem(std::move(p), std::move(tips), std::move(junctions));
+        scene_->addItem(w);
+        wires_.push_back(w);
+        return w;
+    };
+
+    // mux → PC → I-Mem, with a tap up to the +4 adder
+    addWire(ortho({{36, 280}, {52, 280}}), {{{52, 280}, {1, 0}}});
+    addWire(ortho({{94, 280}, {120, 280}}), {{{120, 280}, {1, 0}}});
+    addWire(ortho({{104, 280}, {104, 120}, {120, 120}}), {{{120, 120}, {1, 0}}}, {{104, 280}});
+    // +4 adder → over the top → PC mux input 0
+    addWire(ortho({{164, 128}, {178, 128}, {178, 56}, {10, 56}, {10, 262}, {16, 262}}),
+            {{{16, 262}, {1, 0}}});
+    // I-Mem → IF/ID
+    addWire(ortho({{236, 280}, {270, 280}}), {{{270, 280}, {1, 0}}});
+
+    // ── ID stage ─────────────────────────────────────────────────────────────
+    addBox(scene_, QRectF(320, 74, 96, 40), QStringLiteral("Control"));
+    addBox(scene_, QRectF(320, 210, 130, 125), QStringLiteral("Registers"));
+    addEllipse(scene_, QRectF(340, 380, 84, 42), QStringLiteral("Sign-\nextend"));
+
+    // Instruction bus out of IF/ID: vertical spine at x=305 feeding Control,
+    // both register read ports, and sign-extend.
+    {
+        QPainterPath p = ortho({{286, 280}, {305, 280}});
+        p.moveTo(305, 94);
+        p.lineTo(305, 401);
+        p.moveTo(305, 94);
+        p.lineTo(320, 94);
+        p.moveTo(305, 240);
+        p.lineTo(320, 240);
+        p.moveTo(305, 290);
+        p.lineTo(320, 290);
+        p.moveTo(305, 401);
+        p.lineTo(340, 401);
+        addWire(
+            std::move(p),
+            {{{320, 94}, {1, 0}}, {{320, 240}, {1, 0}}, {{320, 290}, {1, 0}}, {{340, 401}, {1, 0}}},
+            {{305, 280}, {305, 240}, {305, 290}});
+    }
+
+    // Register file outputs / sign-extend / control word → ID/EX
+    addWire(ortho({{450, 240}, {555, 240}}), {{{555, 240}, {1, 0}}});
+    addWire(ortho({{450, 290}, {555, 290}}), {{{555, 290}, {1, 0}}});
+    addWire(ortho({{424, 401}, {555, 401}}), {{{555, 401}, {1, 0}}});
+    addWire(ortho({{416, 94}, {555, 94}}), {{{555, 94}, {1, 0}}})->setControlStyle(true);
+
+    // ── EX stage ─────────────────────────────────────────────────────────────
+    addMux(scene_, QRectF(600, 210, 20, 56));  // forwarding mux A
+    addMux(scene_, QRectF(600, 280, 20, 56));  // forwarding mux B
+    addAlu(scene_, QRectF(680, 210, 84, 130), QStringLiteral("ALU"));
+    addAlu(scene_, QRectF(690, 92, 44, 56), QStringLiteral("+"));  // branch-target adder
+
+    // ID/EX → forwarding muxes → ALU
+    addWire(ortho({{571, 240}, {585, 240}, {585, 222}, {600, 222}}), {{{600, 222}, {1, 0}}});
+    addWire(ortho({{620, 238}, {650, 238}, {650, 242}, {680, 242}}), {{{680, 242}, {1, 0}}});
+    addWire(ortho({{571, 290}, {585, 290}, {585, 292}, {600, 292}}), {{{600, 292}, {1, 0}}});
+    addWire(ortho({{620, 308}, {680, 308}}), {{{680, 308}, {1, 0}}});
+    // PC + shifted immediate → branch-target adder
+    addWire(ortho({{571, 106}, {690, 106}}), {{{690, 106}, {1, 0}}});
+    addWire(ortho({{571, 401}, {660, 401}, {660, 134}, {690, 134}}), {{{690, 134}, {1, 0}}});
+    // Control word continues along the top
+    addWire(ortho({{571, 94}, {680, 94}}), {})->setControlStyle(true);
+    // ALU result / branch target → EX/MEM
+    addWire(ortho({{764, 275}, {845, 275}}), {{{845, 275}, {1, 0}}});
+    addWire(ortho({{734, 120}, {845, 120}}), {{{845, 120}, {1, 0}}});
+    // Store-data pass-through: mux B output also runs to EX/MEM
+    addWire(ortho({{650, 308}, {650, 370}, {845, 370}}), {{{845, 370}, {1, 0}}}, {{650, 308}});
+
+    // Forwarding wires (always visible, lit when the hazard unit forwards)
+    fwd_exmem_wire_ = addWire(ortho({{845, 420}, {590, 420}, {590, 238}, {600, 238}}),
+                              {{{600, 238}, {1, 0}}}, {{590, 308}});
+    {
+        QPainterPath p = ortho({{590, 308}, {600, 308}});
+        // stub drawn as part of the same wire so it lights together
+        // (append to fwd wire path is not possible post-hoc; use second wire)
+        auto* stub = addWire(std::move(p), {{{600, 308}, {1, 0}}});
+        stub->setControlStyle(false);
+        // Keep the stub in sync by treating it as part of the EX/MEM wire:
+        // applyState() lights both via fwd_exmem_wire_ and this stub pointer.
+        fwd_exmem_stub_ = stub;
+    }
+    fwd_memwb_wire_ = addWire(ortho({{1130, 455}, {578, 455}, {578, 254}, {600, 254}}),
+                              {{{600, 254}, {1, 0}}}, {{578, 324}});
+    {
+        auto* stub      = addWire(ortho({{578, 324}, {600, 324}}), {{{600, 324}, {1, 0}}});
+        fwd_memwb_stub_ = stub;
+    }
+
+    // ── MEM stage ────────────────────────────────────────────────────────────
+    addBox(scene_, QRectF(910, 230, 125, 125), QStringLiteral("Data\nmemory"));
+    addBox(scene_, QRectF(910, 96, 80, 44), QStringLiteral("Branch"));
+
+    addWire(ortho({{861, 275}, {910, 275}}), {{{910, 275}, {1, 0}}}, {{885, 275}});
+    addWire(ortho({{861, 370}, {895, 370}, {895, 320}, {910, 320}}), {{{910, 320}, {1, 0}}});
+    addWire(ortho({{861, 120}, {910, 120}}), {{{910, 120}, {1, 0}}});
+    // ALU-result bypass to MEM/WB (non-load write-back)
+    addWire(ortho({{885, 275}, {885, 415}, {1130, 415}}), {{{1130, 415}, {1, 0}}});
+    // D-Mem read data → MEM/WB
+    addWire(ortho({{1035, 275}, {1130, 275}}), {{{1130, 275}, {1, 0}}});
+    // Branch decision → PC mux (the flush path; lights red on branch_flush)
+    branch_wire_ =
+        addWire(ortho({{990, 118}, {1056, 118}, {1056, 44}, {4, 44}, {4, 298}, {16, 298}}),
+                {{{16, 298}, {1, 0}}});
+
+    // ── WB stage ─────────────────────────────────────────────────────────────
+    addMux(scene_, QRectF(1180, 250, 22, 70));  // MemToReg mux
+    addWire(ortho({{1146, 275}, {1165, 275}, {1165, 272}, {1180, 272}}), {{{1180, 272}, {1, 0}}});
+    addWire(ortho({{1146, 415}, {1172, 415}, {1172, 298}, {1180, 298}}), {{{1180, 298}, {1, 0}}});
+    // Write-back loop to the register file write port
+    writeback_wire_ =
+        addWire(ortho({{1202, 285}, {1230, 285}, {1230, 510}, {300, 510}, {300, 325}, {320, 325}}),
+                {{{320, 325}, {1, 0}}});
+
+    // ── Breakpoint markers (bullseye per stage column) ───────────────────────
+    for (int i = 0; i < 5; ++i) {
+        const auto& c     = kColumns[i];
+        auto*       outer = scene_->addEllipse(QRectF(c.x1 - 24, kColTop + 6, 14, 14),
+                                               QPen(QColor("#AA0000"), 1), QColor("#E53935"));
+        auto*       inner =
+            scene_->addEllipse(QRectF(c.x1 - 20, kColTop + 10, 6, 6), Qt::NoPen, QColor("#FFFFFF"));
+        outer->setZValue(5);
+        inner->setZValue(6);
+        bp_markers_[static_cast<std::size_t>(i)] = {outer, inner};
+    }
+
+    // ── Keyboard focus ring ──────────────────────────────────────────────────
+    focus_ring_ = scene_->addRect(QRectF());
+    focus_ring_->setZValue(10);
+    focus_ring_->setBrush(Qt::NoBrush);
+    focus_ring_->setVisible(false);
+}
+
+void SchematicDatapathWidget::applyTheme() {
+    const Theme& t = theme(dark_mode_);
+    scene_->setBackgroundBrush(t.bg);
+
+    // Restyle every tagged component / label.
+    const QList<QGraphicsItem*> items = scene_->items();
+    for (QGraphicsItem* it : items) {
+        const QString tag = it->data(0).toString();
+        if (tag == QLatin1String("comp")) {
+            if (auto* shape = dynamic_cast<QAbstractGraphicsShapeItem*>(it)) {
+                shape->setBrush(t.comp_fill);
+                shape->setPen(QPen(t.comp_border, 1.4));
+            }
+        } else if (tag == QLatin1String("comp-label")) {
+            if (auto* txt = dynamic_cast<QGraphicsSimpleTextItem*>(it)) txt->setBrush(t.text);
+        } else if (tag == QLatin1String("stage-name")) {
+            if (auto* txt = dynamic_cast<QGraphicsSimpleTextItem*>(it)) txt->setBrush(t.label);
+        }
+    }
+
+    for (WireItem* w : wires_)
+        w->setColors(t.wire, t.label);
+    // Special wires get their own lit colors.
+    fwd_exmem_wire_->setColors(t.wire_dim, t.fwd_ex);
+    fwd_exmem_stub_->setColors(t.wire_dim, t.fwd_ex);
+    fwd_memwb_wire_->setColors(t.wire_dim, t.fwd_mem);
+    fwd_memwb_stub_->setColors(t.wire_dim, t.fwd_mem);
+    branch_wire_->setColors(t.wire_dim, t.flush);
+    writeback_wire_->setColors(t.wire_dim, t.wb);
+
+    focus_ring_->setPen(QPen(dark_mode_ ? QColor("#4FC3F7") : QColor("#0078D4"), 2, Qt::DashLine));
+
+    applyState();  // re-derives state-dependent tints for the new theme
+}
+
+void SchematicDatapathWidget::applyState() {
+    const Theme& t = theme(dark_mode_);
+
+    for (int i = 0; i < 5; ++i) {
+        const auto&  snap = state_.stages[static_cast<std::size_t>(i)];
+        const QColor tint = dark_mode_ ? kStageDark[i] : kStageLight[i];
+        QColor       band = tint;
+        band.setAlpha(snap.valid ? (dark_mode_ ? 70 : 120) : (dark_mode_ ? 25 : 45));
+        stage_tints_[static_cast<std::size_t>(i)]->setBrush(band);
+
+        // Mnemonic label above the column (Ripes-style).
+        auto*   lbl = stage_labels_[static_cast<std::size_t>(i)];
+        QString text;
+        QColor  color = t.text;
+        if (snap.flushed) {
+            text  = QStringLiteral("nop (flush)");
+            color = t.flush;
+        } else if (snap.stalled) {
+            text  = QStringLiteral("nop (stall)");
+            color = t.stall;
+        } else if (snap.valid) {
+            text = QString::fromStdString(format_instr(snap.raw));
+        } else {
+            text  = QStringLiteral("—");
+            color = t.wire_dim;
+        }
+        lbl->setText(text);
+        lbl->setBrush(color);
+        const auto& c = kColumns[i];
+        lbl->setPos((c.x0 + c.x1) / 2 - lbl->boundingRect().width() / 2, 16);
+
+        // Breakpoint bullseye visibility.
+        const bool bp = snap.valid && breakpoints_.count(snap.pc) > 0;
+        bp_markers_[static_cast<std::size_t>(i)].first->setVisible(bp);
+        bp_markers_[static_cast<std::size_t>(i)].second->setVisible(bp);
+    }
+
+    // Pipeline-register bars: red = flushing, amber = stalled, else neutral.
+    for (int i = 0; i < 4; ++i) {
+        const auto& snap = state_.stages[static_cast<std::size_t>(i + 1)];
+        QColor      fill = t.comp_fill;
+        if (snap.flushed)
+            fill = t.flush;
+        else if (snap.stalled)
+            fill = t.stall;
+        pipe_regs_[static_cast<std::size_t>(i)]->setBrush(fill);
+        pipe_regs_[static_cast<std::size_t>(i)]->setPen(QPen(t.comp_border, 1.4));
+    }
+
+    fwd_exmem_wire_->setActive(state_.fwd_ex_to_ex_a || state_.fwd_ex_to_ex_b);
+    fwd_exmem_stub_->setActive(state_.fwd_ex_to_ex_b);
+    fwd_memwb_wire_->setActive(state_.fwd_mem_to_ex_a || state_.fwd_mem_to_ex_b);
+    fwd_memwb_stub_->setActive(state_.fwd_mem_to_ex_b);
+    branch_wire_->setActive(state_.branch_flush);
+    writeback_wire_->setActive(state_.stages[4].valid);
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+void SchematicDatapathWidget::setPipelineState(const mips::PipelineState& state) {
+    state_ = state;
+    applyState();
+}
+
+void SchematicDatapathWidget::setBreakpoints(const std::unordered_set<uint32_t>& bps) {
+    breakpoints_ = bps;
+    applyState();
+}
+
+void SchematicDatapathWidget::setDarkMode(bool dark) {
+    dark_mode_ = dark;
+    applyTheme();
+}
+
+// ── Interaction ─────────────────────────────────────────────────────────────
+
+int SchematicDatapathWidget::stageAtViewPos(const QPoint& pos) const {
+    const QPointF sp = mapToScene(pos);
+    if (sp.y() < kColTop || sp.y() > kColBot) return -1;
+    for (int i = 0; i < 5; ++i)
+        if (sp.x() >= kColumns[i].x0 && sp.x() <= kColumns[i].x1) return i;
+    return -1;
+}
+
+void SchematicDatapathWidget::fitSchematic() {
+    if (!user_zoomed_) fitInView(scene_->sceneRect(), Qt::KeepAspectRatio);
+}
+
+void SchematicDatapathWidget::wheelEvent(QWheelEvent* ev) {
+    // Ctrl+wheel zooms around the cursor; plain wheel scrolls as usual.
+    if (ev->modifiers() & Qt::ControlModifier) {
+        user_zoomed_       = true;
+        const qreal step   = std::pow(1.15, ev->angleDelta().y() / 120.0);
+        const qreal cur    = transform().m11();
+        const qreal target = std::clamp(cur * step, 0.3, 4.0);
+        scale(target / cur, target / cur);
+        ev->accept();
+        return;
+    }
+    QGraphicsView::wheelEvent(ev);
+}
+
+void SchematicDatapathWidget::mousePressEvent(QMouseEvent* ev) {
+    setFocus(Qt::MouseFocusReason);
+    const int idx = stageAtViewPos(ev->pos());
+    if (idx >= 0) {
+        selected_stage_ = idx;
+        if (hasFocus()) focusInEvent(nullptr);  // refresh ring position
+    }
+    QGraphicsView::mousePressEvent(ev);
+}
+
+void SchematicDatapathWidget::mouseDoubleClickEvent(QMouseEvent* ev) {
+    const int idx = stageAtViewPos(ev->pos());
+    if (idx < 0) return;
+    const auto& snap = state_.stages[static_cast<std::size_t>(idx)];
+    if (snap.valid) emit stageDetailRequested(idx, snap.pc, snap.raw);
+}
+
+void SchematicDatapathWidget::contextMenuEvent(QContextMenuEvent* ev) {
+    const int idx = stageAtViewPos(ev->pos());
+    if (idx < 0) return;
+    const auto& snap = state_.stages[static_cast<std::size_t>(idx)];
+    if (!snap.valid) return;
+
+    QMenu      menu(this);
+    const bool has_bp = breakpoints_.count(snap.pc) > 0;
+    QAction*   act    = menu.addAction(has_bp ? tr("Clear Breakpoint") : tr("Set Breakpoint"));
+    QAction*   fit    = menu.addAction(tr("Zoom to Fit"));
+    QAction*   chosen = menu.exec(ev->globalPos());
+    if (chosen == act) emit breakpointToggleRequested(snap.pc);
+    if (chosen == fit) {
+        user_zoomed_ = false;
+        fitSchematic();
+    }
+}
+
+void SchematicDatapathWidget::keyPressEvent(QKeyEvent* ev) {
+    switch (ev->key()) {
+    case Qt::Key_Left:
+        selected_stage_ = (selected_stage_ + 4) % 5;
+        focusInEvent(nullptr);
+        ev->accept();
+        return;
+    case Qt::Key_Right:
+        selected_stage_ = (selected_stage_ + 1) % 5;
+        focusInEvent(nullptr);
+        ev->accept();
+        return;
+    case Qt::Key_Return:
+    case Qt::Key_Enter: {
+        const auto& snap = state_.stages[static_cast<std::size_t>(selected_stage_)];
+        if (snap.valid) emit stageDetailRequested(selected_stage_, snap.pc, snap.raw);
+        ev->accept();
+        return;
+    }
+    case Qt::Key_Space:
+    case Qt::Key_B: {
+        const auto& snap = state_.stages[static_cast<std::size_t>(selected_stage_)];
+        if (snap.valid) emit breakpointToggleRequested(snap.pc);
+        ev->accept();
+        return;
+    }
+    default:
+        QGraphicsView::keyPressEvent(ev);
+    }
+}
+
+void SchematicDatapathWidget::resizeEvent(QResizeEvent* ev) {
+    QGraphicsView::resizeEvent(ev);
+    fitSchematic();
+}
+
+void SchematicDatapathWidget::focusInEvent(QFocusEvent* ev) {
+    if (ev) QGraphicsView::focusInEvent(ev);
+    const auto& c = kColumns[selected_stage_];
+    focus_ring_->setRect(QRectF(c.x0 - 3, kColTop - 3, (c.x1 - c.x0) + 6, (kColBot - kColTop) + 6));
+    focus_ring_->setVisible(true);
+}
+
+void SchematicDatapathWidget::focusOutEvent(QFocusEvent* ev) {
+    QGraphicsView::focusOutEvent(ev);
+    focus_ring_->setVisible(false);
+}
+
+}  // namespace nsc::qt

--- a/tests/qt_ui/qt_ui_test.cpp
+++ b/tests/qt_ui/qt_ui_test.cpp
@@ -2,6 +2,7 @@
 #include "nsc_qt/dock_panels.h"
 #include "nsc_qt/simulator_controller.h"
 #include "nsc_qt/widgets/memory_widget.h"
+#include "nsc_qt/widgets/pipeline_events_widget.h"
 #include "nsc_qt/widgets/pipeline_trace_widget.h"
 #include "nsc_qt/widgets/register_widget.h"
 
@@ -203,6 +204,39 @@ static void test_trace_widget_clear() {
     CHECK(true);
 }
 
+// ── PipelineEventsWidget log behaviour ───────────────────────────────────────
+
+static void test_events_widget_log() {
+    using namespace nsc::qt;
+
+    PipelineEventsWidget ew;
+    CHECK(ew.eventCount() == 0);
+
+    ew.logEvent(PipelineEventsWidget::Kind::Info, 0, "program loaded");
+    CHECK(ew.eventCount() == 1);
+
+    // A forwarding event is derived from the pipeline state.
+    mips::PipelineState st{};
+    st.stages[2]      = {"EX", true, false, false, 0x08, 0x012A5020u};  // add $t2,$t1,$t2
+    st.fwd_ex_to_ex_a = true;
+    st.cycle          = 4;
+    ew.updateCycle(st);
+    CHECK(ew.eventCount() == 2);
+
+    // The same event on the very next cycle is suppressed (rising edge only)…
+    st.cycle = 5;
+    ew.updateCycle(st);
+    CHECK(ew.eventCount() == 2);
+
+    // …but logs again after a gap.
+    st.cycle = 9;
+    ew.updateCycle(st);
+    CHECK(ew.eventCount() == 3);
+
+    ew.clear();
+    CHECK(ew.eventCount() == 0);
+}
+
 // ── Dock panels ───────────────────────────────────────────────────────────────
 
 // Regression guard: every panel added via addDockPanel() must actually carry
@@ -244,6 +278,7 @@ int main(int argc, char* argv[]) {
     test_register_widget_clear();
     test_memory_widget_construct();
     test_trace_widget_clear();
+    test_events_widget_log();
     test_dock_panels_carry_content();
 
     std::printf("%d passed, %d failed\n", g_pass, g_fail);


### PR DESCRIPTION
Two things needed before publishing the v0.3.0 draft:

1. **Sync develop with main** — the datapath/GUI PRs (#80, #82, #83, #84) were merged to `main`, leaving `develop` 31 commits behind. This merges `main` back so the release-promotion flow works from a current base.
2. **Fill `[Unreleased]`** — the section was empty, so the post-publish changelog promotion would have produced an empty 0.3.0 entry. Adds the full v0.3.0 notes (schematic datapath, Pipeline Events panel, IDE layout, statistics redesign, theming fixes, and the packaged-TUI launch-hang fix from #87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)