### PR TITLE
fix(ci): prevent qt_ui_test from hanging 42 min on Windows runners

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -116,6 +116,15 @@ jobs:
           echo "$archs" | grep -qw x86_64 || { echo "::error::missing x86_64 slice"; exit 1; }
           echo "✓ universal (arm64 + x86_64)"
 
+      # Suppress Windows Error Reporting dialogs so a crashing test subprocess
+      # exits immediately instead of blocking on a modal "stopped working" prompt.
+      - name: Suppress WER crash dialogs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-ItemProperty -Force -Path "HKCU:\Software\Microsoft\Windows\Windows Error Reporting" `
+            -Name DontShowUI -Value 1 -PropertyType DWord | Out-Null
+
       - name: Test
         run: ctest --test-dir build/release --output-on-failure
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,8 +606,11 @@ if (BUILD_QT6_UI)
 
     # QApplication needs a windowing platform; Qt's offscreen backend lets the
     # test run on headless machines and CI runners without a display.
+    # TIMEOUT: Qt plugin discovery failures on Windows produce a WER dialog
+    # (no stdout, blocks forever) rather than a clean process exit — cap it.
     set_tests_properties(qt_ui_test PROPERTIES
             ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+            TIMEOUT 120
     )
 endif ()
 


### PR DESCRIPTION
## Summary

- **`cross-platform.yml`**: add a step before `ctest` that sets `DontShowUI=1` in the WER registry key — when the test subprocess crashes on Windows, the OS exits it immediately instead of showing a blocking modal dialog
- **`CMakeLists.txt`**: add `TIMEOUT 120` to `qt_ui_test` as a hard cap so any future hang fails fast rather than burning Action minutes

## Root cause

`qt_ui_test` (test #8) hung for 42 minutes on the `windows-x64` runner. No output was produced at all — the tell that the subprocess never exited. When a Windows process crashes (missing plugin, assertion in `ads::CDockManager` init, etc.) the OS shows a native "This program has stopped working" dialog waiting for a human to dismiss it. In a headless CI session, that waits until the job timeout kills the runner.

## Test plan

- [x] Trigger `cross-platform` workflow via `workflow_dispatch` and confirm `qt_ui_test` either passes or fails within 2 minutes instead of timing out at the runner limit
- [ ] If it still fails, `--output-on-failure` will now surface the actual error message (previously invisible behind the WER dialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)