### PR TITLE
refactor(nsc): replace #ifndef guards with #pragma once; clean up return statements

### DIFF
--- a/include/nsc/converter.h
+++ b/include/nsc/converter.h
@@ -1,9 +1,4 @@
-//
-// Created by venus on 6/28/26.
-//
-
-#ifndef NUMBER_SYSTEM_CONVERTER_CONVERTER_H
-#define NUMBER_SYSTEM_CONVERTER_CONVERTER_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -42,4 +37,3 @@ private:
 };
 
 }  // namespace nsc
-#endif  // NUMBER_SYSTEM_CONVERTER_CONVERTER_H

--- a/include/nsc/format.h
+++ b/include/nsc/format.h
@@ -1,5 +1,4 @@
-#ifndef NUMBER_SYSTEM_CONVERTER_FORMAT_H
-#define NUMBER_SYSTEM_CONVERTER_FORMAT_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -20,5 +19,3 @@ namespace nsc {
 [[nodiscard]] std::string groupBits(std::uint64_t value);
 
 }  // namespace nsc
-
-#endif  // NUMBER_SYSTEM_CONVERTER_FORMAT_H

--- a/include/nsc/parse.h
+++ b/include/nsc/parse.h
@@ -1,5 +1,4 @@
-#ifndef NUMBER_SYSTEM_CONVERTER_PARSE_H
-#define NUMBER_SYSTEM_CONVERTER_PARSE_H
+#pragma once
 
 #include <cstdint>
 #include <optional>
@@ -15,5 +14,3 @@ namespace nsc {
 [[nodiscard]] std::optional<std::uint64_t> parseBase(const std::string& str, int base);
 
 }  // namespace nsc
-
-#endif  // NUMBER_SYSTEM_CONVERTER_PARSE_H

--- a/src/nsc/converter.cpp
+++ b/src/nsc/converter.cpp
@@ -1,5 +1,7 @@
 #include "nsc/converter.h"
 
+#include <string>
+
 #include "nsc/format.h"
 #include "nsc/parse.h"
 
@@ -21,12 +23,13 @@ std::string Converter::as(const Base base) const {
         return toDecimal(value_);
     case Base::Hex:
         return toHex(value_);
+    default:
+        return {};
     }
-    return {""};
 }
 
 std::string Converter::bits() const {
-    return {groupBits(value_)};
+    return groupBits(value_);
 }
 
 }  // namespace nsc

--- a/src/nsc/format.cpp
+++ b/src/nsc/format.cpp
@@ -47,7 +47,7 @@ std::string groupBits(std::uint64_t value) {
         }
         out.push_back(bits[i]);
     }
-    return {out};
+    return out;
 }
 
 }  // namespace nsc


### PR DESCRIPTION
## Summary

- Replace old-style `#ifndef`/`#define`/`#endif` include guards with `#pragma once` in `converter.h`, `parse.h`, and `format.h` — consistent with every other header in the project
- Remove CLion IDE-generated file header comment (`// Created by venus on 6/28/26.`) from `converter.h`
- Add explicit `#include <string>` to `converter.cpp` (IWYU / cpplint)
- Add `default: return {}` to `Converter::as()` so the switch is exhaustive and the dead-code trailing `return {""}` is eliminated
- Drop unnecessary brace-initialization from `return` statements in `converter.cpp` (`bits()`) and `format.cpp` (`groupBits()`)

## Test plan

- [x] `cmake --build --preset core-only` — clean build, zero warnings
- [x] `ctest --preset core-only` — 21/21 tests pass (unit + golden differential tests against MARS)
- [x] All pre-commit hooks pass (end-of-file-fixer, clang-format, cpplint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)