### PR TITLE
fix(nsc_quick,nsc_qt): address Qt code review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # clearCore CI — build and test on every push/PR.
 #
 # Jobs:
-#   format     : clang-format check via cpp-linter (same .clang-format as the
-#                pre-commit hook and editors; annotates violations on PRs).
+#   format     : clang-format-22 check (same .clang-format as the pre-commit
+#                hook and editors; annotates violations on PRs).
 #   coverage   : core-only build instrumented with --coverage; gcovr report
 #                uploaded to codecov.io via OIDC (no token needed).
 #                Runs on push and on PRs from this repo (not forks — OIDC
@@ -48,17 +48,30 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # cpp-linter-action (v2.20.0 and earlier) hard-codes uv 0.9.5 and always
+      # re-downloads it from GitHub releases, which produces intermittent 504
+      # failures. We only need clang-format for this job, so install it directly
+      # from the LLVM apt repository — no Python, no uv, no CDN dependency.
+      - name: Install clang-format-22
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository -y \
+            "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-22 main"
+          sudo apt-get update -qq
+          sudo apt-get install -y clang-format-22
+
       - name: Check clang-format
         id: linter
-        uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          style: file          # use the repo's .clang-format
-          tidy-checks: '-*'    # formatting only; clang-tidy runs via builds/IDE
-          version: 22          # keep in sync with .pre-commit-config.yaml
-          files-changed-only: false
-          step-summary: true
+        run: |
+          failed=0
+          while IFS= read -r f; do
+            if ! clang-format-22 --dry-run --Werror "$f" 2>&1; then
+              echo "::error file=$f::clang-format violation"
+              failed=$((failed + 1))
+            fi
+          done < <(find src include tests qml -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \
+                   2>/dev/null | sort)
+          echo "clang-format-checks-failed=$failed" >> "$GITHUB_OUTPUT"
 
       - name: Fail on formatting violations
         if: steps.linter.outputs.clang-format-checks-failed > 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@
 #                pre-commit hook and editors; annotates violations on PRs).
 #   coverage   : core-only build instrumented with --coverage; gcovr report
 #                uploaded to codecov.io via OIDC (no token needed).
+#                Runs on push and on PRs from this repo (not forks — OIDC
+#                requires the same-repo token context).
 #   core-tests : fast path — core libraries + TUI + unit tests, no Qt/LLVM.
 #                Runs twice (Debug, Debug+ASan/UBSan) via the preset matrix.
 #   full-build : everything including both Qt6 GUIs and Nyxstone, Release.
@@ -63,11 +65,16 @@ jobs:
         run: exit 1
 
   coverage:
-    if: github.event_name == 'push'
+    # Push to main/develop always runs. PRs from forks lack the id-token needed
+    # for OIDC, so restrict to same-repo PRs only to avoid silent upload failures.
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # codecov OIDC upload (tokenless for public repos)
+      id-token: write       # codecov OIDC upload (tokenless for public repos)
+      pull-requests: write  # allow codecov-action to post PR diff comments
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -125,6 +125,27 @@ jobs:
           New-ItemProperty -Force -Path "HKCU:\Software\Microsoft\Windows\Windows Error Reporting" `
             -Name DontShowUI -Value 1 -PropertyType DWord | Out-Null
 
+      # qt_ui_test links the Qt Advanced Docking System as a shared library
+      # (LGPL compliance — cannot be static). The DLL is built by FetchContent
+      # into build/release/_deps/qtads-build/ and is not on the system PATH,
+      # so Windows' DLL loader hangs on a missing-library dialog instead of
+      # exiting, causing the test to hit its 120 s timeout. Add the directory
+      # containing the Release DLL to PATH so the loader finds it.
+      - name: Add QADS DLL to PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dll = Get-ChildItem -Recurse -Path build\release\_deps\qtads-build `
+                   -Filter "qtadvanceddocking*.dll" |
+                 Where-Object { $_.Name -notmatch 'd\.dll$' } |
+                 Select-Object -First 1
+          if (-not $dll) {
+            Write-Error "QADS DLL not found under build\release\_deps\qtads-build"
+            exit 1
+          }
+          Write-Host "QADS DLL: $($dll.FullName)"
+          Add-Content $env:GITHUB_PATH $dll.DirectoryName
+
       - name: Test
         run: ctest --test-dir build/release --output-on-failure
 

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -11,3 +11,6 @@ filter=-whitespace/indent_namespace
 filter=-whitespace/indent
 filter=-build/include_order
 filter=-readability/check
+# clang-format canonicalises value-init as `Type{}` (no space); cpplint wants
+# a space before {. Suppress the conflict — clang-format is authoritative.
+filter=-whitespace/braces

--- a/include/nsc_qt/instr_format.h
+++ b/include/nsc_qt/instr_format.h
@@ -14,15 +14,11 @@
 
 namespace nsc::qt {
 
-// Format a decoded instruction as a human-readable string. This is assembly
-// notation (mnemonics, register names), not natural-language UI copy, so it
-// intentionally is not routed through tr().
-inline std::string format_instr(uint32_t raw) {
+// Format an already-decoded instruction. Called by format_instr and also
+// directly in applyState/updateTooltips where the decode result is cached.
+inline std::string format_decoded(const mips::DecodedInstr& d) {
     using namespace mips;
-    auto decoded = Decoder::decode(raw);
-    if (!decoded) return "(?/?)";
-    const auto&        d  = *decoded;
-    std::string        mn = std::string(Decoder::mnemonic(d));
+    const std::string  mn = std::string(Decoder::mnemonic(d));
     std::ostringstream os;
     os << mn << " ";
     switch (d.format) {
@@ -70,6 +66,14 @@ inline std::string format_instr(uint32_t raw) {
         break;
     }
     return os.str();
+}
+
+// Format a raw instruction word as human-readable assembly. Uses decode then
+// delegates to format_decoded; call format_decoded directly when the decode
+// result is already cached.
+inline std::string format_instr(uint32_t raw) {
+    const auto decoded = mips::Decoder::decode(raw);
+    return decoded ? format_decoded(*decoded) : "(?/?)";
 }
 
 }  // namespace nsc::qt

--- a/include/nsc_quick/quick_simulator.h
+++ b/include/nsc_quick/quick_simulator.h
@@ -177,6 +177,7 @@ private:
     QVariantMap                  hazards_;
     nsc::qt::SimulatorStatistics stats_{};
     std::vector<TraceRow>        trace_;
+    QVariantList                 trace_rows_cache_;
     std::vector<uint32_t>        last_program_;
 
     QString status_         = QStringLiteral("Idle");

--- a/src/nsc_qt/assembler.cpp
+++ b/src/nsc_qt/assembler.cpp
@@ -3,8 +3,11 @@
 #include <algorithm>
 #include <charconv>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace nsc::qt {
 
@@ -85,6 +88,42 @@ static uint32_t enc_i(uint8_t op, uint8_t rs, uint8_t rt, uint16_t imm) {
 static uint32_t enc_j(uint8_t op, uint32_t target) {
     return (static_cast<uint32_t>(op & 0x3F) << 26) | (target & 0x03FFFFFF);
 }
+
+// ── Instruction encoding tables ───────────────────────────────────────────────
+// Defined once at file scope so they are constructed once, not on every pass-2
+// loop iteration (each unordered_map build is O(n) hash + allocation).
+
+static const std::unordered_map<std::string, uint8_t> kR3Map = {
+    {"add", 0x20}, {"addu", 0x21}, {"sub", 0x22}, {"subu", 0x23}, {"and", 0x24},
+    {"or", 0x25},  {"xor", 0x26},  {"nor", 0x27}, {"slt", 0x2A},  {"sltu", 0x2B},
+};
+static const std::unordered_map<std::string, uint8_t> kShiftMap = {
+    {"sll", 0x00},
+    {"srl", 0x02},
+    {"sra", 0x03},
+};
+static const std::unordered_map<std::string, uint8_t> kVShiftMap = {
+    {"sllv", 0x04},
+    {"srlv", 0x06},
+};
+static const std::unordered_map<std::string, uint8_t> kIArithMap = {
+    {"addi", 0x08}, {"addiu", 0x09}, {"slti", 0x0A}, {"sltiu", 0x0B},
+    {"andi", 0x0C}, {"ori", 0x0D},   {"xori", 0x0E},
+};
+static const std::unordered_map<std::string, uint8_t> kMemMap = {
+    {"lw", 0x23},
+    {"lbu", 0x24},
+    {"lhu", 0x25},
+    {"sw", 0x2B},
+};
+static const std::unordered_map<std::string, uint8_t> kBranchMap = {
+    {"beq", 0x04},
+    {"bne", 0x05},
+};
+static const std::unordered_map<std::string, uint8_t> kJumpMap = {
+    {"j", 0x02},
+    {"jal", 0x03},
+};
 
 // ── Tokeniser ─────────────────────────────────────────────────────────────────
 
@@ -200,27 +239,18 @@ AssemblerResult assemble(const std::string& source) {
         }
 
         // ── R-type: add addu sub subu and or xor nor slt sltu ─────────────────
-        const std::unordered_map<std::string, uint8_t> r3_map = {
-            {"add", 0x20}, {"addu", 0x21}, {"sub", 0x22}, {"subu", 0x23}, {"and", 0x24},
-            {"or", 0x25},  {"xor", 0x26},  {"nor", 0x27}, {"slt", 0x2A},  {"sltu", 0x2B},
-        };
-        if (r3_map.count(mn)) {
+        if (kR3Map.count(mn)) {
             if (!need(3)) return err("expected $rd, $rs, $rt");
             auto rd = parse_reg(ops[0]);
             auto rs = parse_reg(ops[1]);
             auto rt = parse_reg(ops[2]);
             if (!rd || !rs || !rt) return err("bad register");
-            result.words.push_back(enc_r(*rs, *rt, *rd, 0, r3_map.at(mn)));
+            result.words.push_back(enc_r(*rs, *rt, *rd, 0, kR3Map.at(mn)));
             continue;
         }
 
         // ── R-type shifts: sll srl sra ($rd, $rt, shamt) ──────────────────────
-        const std::unordered_map<std::string, uint8_t> shift_map = {
-            {"sll", 0x00},
-            {"srl", 0x02},
-            {"sra", 0x03},
-        };
-        if (shift_map.count(mn)) {
+        if (kShiftMap.count(mn)) {
             if (!need(3)) return err("expected $rd, $rt, shamt");
             auto rd  = parse_reg(ops[0]);
             auto rt  = parse_reg(ops[1]);
@@ -228,22 +258,18 @@ AssemblerResult assemble(const std::string& source) {
             if (!rd || !rt || !imm) return err("bad operands");
             if (*imm < 0 || *imm > 31) return err("shift amount out of range");
             result.words.push_back(
-                enc_r(0, *rt, *rd, static_cast<uint8_t>(*imm), shift_map.at(mn)));
+                enc_r(0, *rt, *rd, static_cast<uint8_t>(*imm), kShiftMap.at(mn)));
             continue;
         }
 
         // ── R-type var shifts: sllv srlv ($rd, $rt, $rs) ──────────────────────
-        const std::unordered_map<std::string, uint8_t> vshift_map = {
-            {"sllv", 0x04},
-            {"srlv", 0x06},
-        };
-        if (vshift_map.count(mn)) {
+        if (kVShiftMap.count(mn)) {
             if (!need(3)) return err("expected $rd, $rt, $rs");
             auto rd = parse_reg(ops[0]);
             auto rt = parse_reg(ops[1]);
             auto rs = parse_reg(ops[2]);
             if (!rd || !rt || !rs) return err("bad register");
-            result.words.push_back(enc_r(*rs, *rt, *rd, 0, vshift_map.at(mn)));
+            result.words.push_back(enc_r(*rs, *rt, *rd, 0, kVShiftMap.at(mn)));
             continue;
         }
 
@@ -267,17 +293,13 @@ AssemblerResult assemble(const std::string& source) {
         }
 
         // ── I-type arithmetic: addi addiu slti sltiu andi ori xori ──────────────
-        const std::unordered_map<std::string, uint8_t> iarith_map = {
-            {"addi", 0x08}, {"addiu", 0x09}, {"slti", 0x0A}, {"sltiu", 0x0B},
-            {"andi", 0x0C}, {"ori", 0x0D},   {"xori", 0x0E},
-        };
-        if (iarith_map.count(mn)) {
+        if (kIArithMap.count(mn)) {
             if (!need(3)) return err("expected $rt, $rs, imm");
             auto rt  = parse_reg(ops[0]);
             auto rs  = parse_reg(ops[1]);
             auto imm = parse_imm(ops[2]);
             if (!rt || !rs || !imm) return err("bad operands");
-            result.words.push_back(enc_i(iarith_map.at(mn), *rs, *rt,
+            result.words.push_back(enc_i(kIArithMap.at(mn), *rs, *rt,
                                          static_cast<uint16_t>(static_cast<int16_t>(*imm))));
             continue;
         }
@@ -294,13 +316,7 @@ AssemblerResult assemble(const std::string& source) {
         }
 
         // ── Memory: lw lbu lhu sw ($rt, imm($rs)) ─────────────────────────────
-        const std::unordered_map<std::string, uint8_t> mem_map = {
-            {"lw", 0x23},
-            {"lbu", 0x24},
-            {"lhu", 0x25},
-            {"sw", 0x2B},
-        };
-        if (mem_map.count(mn)) {
+        if (kMemMap.count(mn)) {
             if (!need(2)) return err("expected $rt, imm($rs)");
             auto rt = parse_reg(ops[0]);
             if (!rt) return err("bad register");
@@ -308,16 +324,12 @@ AssemblerResult assemble(const std::string& source) {
             if (!mem_op) return err("expected imm($rs)");
             auto [imm, rs] = *mem_op;
             result.words.push_back(
-                enc_i(mem_map.at(mn), rs, *rt, static_cast<uint16_t>(static_cast<int16_t>(imm))));
+                enc_i(kMemMap.at(mn), rs, *rt, static_cast<uint16_t>(static_cast<int16_t>(imm))));
             continue;
         }
 
         // ── beq bne $rs, $rt, label_or_offset ─────────────────────────────────
-        const std::unordered_map<std::string, uint8_t> branch_map = {
-            {"beq", 0x04},
-            {"bne", 0x05},
-        };
-        if (branch_map.count(mn)) {
+        if (kBranchMap.count(mn)) {
             if (!need(3)) return err("expected $rs, $rt, label");
             auto rs = parse_reg(ops[0]);
             auto rt = parse_reg(ops[1]);
@@ -334,17 +346,13 @@ AssemblerResult assemble(const std::string& source) {
                 // offset = (target_word_addr - (current_word_addr + 4)) / 4
                 offset = static_cast<int32_t>(it->second) - static_cast<int32_t>(idx + 1);
             }
-            result.words.push_back(enc_i(branch_map.at(mn), *rs, *rt,
+            result.words.push_back(enc_i(kBranchMap.at(mn), *rs, *rt,
                                          static_cast<uint16_t>(static_cast<int16_t>(offset))));
             continue;
         }
 
         // ── j jal target_or_label ─────────────────────────────────────────────
-        const std::unordered_map<std::string, uint8_t> jump_map = {
-            {"j", 0x02},
-            {"jal", 0x03},
-        };
-        if (jump_map.count(mn)) {
+        if (kJumpMap.count(mn)) {
             if (!need(1)) return err("expected target");
             uint32_t target = 0;
             auto     imm    = parse_imm(ops[0]);
@@ -355,7 +363,7 @@ AssemblerResult assemble(const std::string& source) {
                 if (it == labels.end()) return err("undefined label '" + ops[0] + "'");
                 target = it->second;  // word index; IProcessor::load_program handles byte address
             }
-            result.words.push_back(enc_j(jump_map.at(mn), target));
+            result.words.push_back(enc_j(kJumpMap.at(mn), target));
             continue;
         }
 

--- a/src/nsc_qt/widgets/pipeline_trace_widget.cpp
+++ b/src/nsc_qt/widgets/pipeline_trace_widget.cpp
@@ -9,6 +9,8 @@
 #include <QVBoxLayout>
 #include <algorithm>
 #include <sstream>
+#include <string>
+#include <unordered_map>
 
 namespace nsc::qt {
 
@@ -140,18 +142,21 @@ void PipelineTraceWidget::rebuildTable() {
         lbl_item->setFont(scale::monoFont(scale::kFontSizeDense));
         table_->setItem(ri, 0, lbl_item);
 
+        // Build a cycle→stage lookup for this row so each column is O(1)
+        // instead of scanning the deque per column (O(n_cols × stages_per_row)).
+        std::unordered_map<uint64_t, const std::string*> stage_by_cycle;
+        stage_by_cycle.reserve(r.stages.size());
+        for (const auto& entry : r.stages)
+            stage_by_cycle.emplace(entry.first, &entry.second);
+
         // Stage columns -- look up by absolute cycle number so each column
         // always shows the entry that actually belongs under its header,
         // regardless of how many times the window has scrolled.
         for (int ci = 0; ci < n_cols; ++ci) {
             const uint64_t cycle = cycle_base_ + static_cast<uint64_t>(ci) + 1;
             std::string    stage_name;
-            for (const auto& entry : r.stages) {
-                if (entry.first == cycle) {
-                    stage_name = entry.second;
-                    break;
-                }
-            }
+            const auto     it = stage_by_cycle.find(cycle);
+            if (it != stage_by_cycle.end()) stage_name = *it->second;
 
             auto* item = new QTableWidgetItem(QString::fromStdString(stage_name));
             item->setTextAlignment(Qt::AlignCenter);

--- a/src/nsc_qt/widgets/schematic_datapath_widget.cpp
+++ b/src/nsc_qt/widgets/schematic_datapath_widget.cpp
@@ -667,6 +667,15 @@ void SchematicDatapathWidget::applyTheme() {
 void SchematicDatapathWidget::applyState() {
     const Theme& t = theme(dark_mode_);
 
+    // Pre-decode each stage once; reuse results everywhere in this function
+    // and in updateTooltips() to avoid repeated Decoder::decode() calls per cycle.
+    using OptDecoded = std::optional<mips::DecodedInstr>;
+    std::array<OptDecoded, 5> decoded;
+    for (std::size_t i = 0; i < 5; ++i) {
+        const auto& s = state_.stages[i];
+        decoded[i]    = (s.valid && s.raw != 0) ? mips::Decoder::decode(s.raw) : std::nullopt;
+    }
+
     for (int i = 0; i < 5; ++i) {
         const auto&  snap = state_.stages[static_cast<std::size_t>(i)];
         const QColor tint = dark_mode_ ? kStageDark[i] : kStageLight[i];
@@ -689,7 +698,10 @@ void SchematicDatapathWidget::applyState() {
             color = t.stall;
         } else if (snap.valid) {
             text = snap.raw == 0 ? QStringLiteral("nop")
-                                 : QString::fromStdString(format_instr(snap.raw));
+                                 : QString::fromStdString(
+                                       decoded[static_cast<std::size_t>(i)]
+                                           ? format_decoded(*decoded[static_cast<std::size_t>(i)])
+                                           : "(?/?)");
         } else {
             text  = QStringLiteral("—");
             color = t.wire_dim;
@@ -735,13 +747,8 @@ void SchematicDatapathWidget::applyState() {
 
     // Control-signal accents: light the component that is actually working
     // this cycle, derived from the per-stage instruction's control word.
-    auto control_for = [](const mips::StageSnapshot& snap) -> mips::Control {
-        if (!snap.valid || snap.raw == 0) return {};
-        const auto d = mips::Decoder::decode(snap.raw);
-        return d ? mips::derive_control(*d) : mips::Control{};
-    };
-    const mips::Control mem_ctl = control_for(state_.stages[3]);
-    const mips::Control wb_ctl  = control_for(state_.stages[4]);
+    const mips::Control mem_ctl = decoded[3] ? mips::derive_control(*decoded[3]) : mips::Control{};
+    const mips::Control wb_ctl  = decoded[4] ? mips::derive_control(*decoded[4]) : mips::Control{};
 
     const QPen base_pen(t.comp_border, 1.4);
     dmem_box_->setPen((mem_ctl.mem_read || mem_ctl.mem_write) ? QPen(t.label, 2.4) : base_pen);
@@ -774,13 +781,9 @@ void SchematicDatapathWidget::applyState() {
 
     const auto& s_id = state_.stages[1];
     QString     imm_text;
-    if (s_id.valid && s_id.raw != 0) {
-        if (const auto d = mips::Decoder::decode(s_id.raw)) {
-            if (d->format == mips::InstrFormat::I) {
-                const auto imm = static_cast<int16_t>(d->i().imm);
-                imm_text       = QStringLiteral("imm=%1").arg(imm);
-            }
-        }
+    if (decoded[1] && decoded[1]->format == mips::InstrFormat::I) {
+        const auto imm = static_cast<int16_t>(decoded[1]->i().imm);
+        imm_text       = QStringLiteral("imm=%1").arg(imm);
     }
     val_imm_->setText(imm_text);
     val_imm_->setBrush(t.label);
@@ -788,21 +791,19 @@ void SchematicDatapathWidget::applyState() {
 
     const auto& s_wb = state_.stages[4];
     QString     wb_text;
-    if (s_wb.valid && s_wb.raw != 0 && wb_ctl.reg_write) {
-        if (const auto d = mips::Decoder::decode(s_wb.raw)) {
-            uint8_t dest = 0;
-            if (d->format == mips::InstrFormat::R)
-                dest = d->r().rd;
-            else if (d->format == mips::InstrFormat::I)
-                dest = d->i().rt;
-            else if (d->opcode == mips::Opcode::JAL)
-                dest = 31;  // jal writes the return address into $ra
-            if (dest != 0)
-                wb_text =
-                    QStringLiteral("$%1 = 0x%2")
-                        .arg(QString::fromStdString(std::string(mips::register_abi_name(dest))))
-                        .arg(reg_values_[dest], 8, 16, QChar('0'));
-        }
+    if (decoded[4] && wb_ctl.reg_write) {
+        const auto& d    = *decoded[4];
+        uint8_t     dest = 0;
+        if (d.format == mips::InstrFormat::R)
+            dest = d.r().rd;
+        else if (d.format == mips::InstrFormat::I)
+            dest = d.i().rt;
+        else if (d.opcode == mips::Opcode::JAL)
+            dest = 31;  // jal writes the return address into $ra
+        if (dest != 0)
+            wb_text = QStringLiteral("$%1 = 0x%2")
+                          .arg(QString::fromStdString(std::string(mips::register_abi_name(dest))))
+                          .arg(reg_values_[dest], 8, 16, QChar('0'));
     }
     val_wb_->setText(wb_text);
     val_wb_->setBrush(t.wb);
@@ -812,19 +813,15 @@ void SchematicDatapathWidget::applyState() {
     QString hz;
     QColor  hz_color;
     if (state_.branch_flush) {
-        const auto& s_mem2 = state_.stages[3];
-        hz                 = tr("Branch taken: %1 — PC redirected, younger instructions flushed")
-                                 .arg(s_mem2.valid && s_mem2.raw != 0
-                                          ? QString::fromStdString(format_instr(s_mem2.raw))
-                                          : QStringLiteral("branch"));
-        hz_color           = t.flush;
+        hz       = tr("Branch taken: %1 — PC redirected, younger instructions flushed")
+                       .arg(decoded[3] ? QString::fromStdString(format_decoded(*decoded[3]))
+                                       : QStringLiteral("branch"));
+        hz_color = t.flush;
     } else if (state_.load_stall) {
-        const auto& s_ex2 = state_.stages[2];
-        hz =
-            tr("Load-use hazard: %1 — its data arrives after MEM, so the "
-               "dependent instruction waits one cycle")
-                .arg(s_ex2.valid && s_ex2.raw != 0 ? QString::fromStdString(format_instr(s_ex2.raw))
-                                                   : QStringLiteral("lw"));
+        hz       = tr("Load-use hazard: %1 — its data arrives after MEM, so the "
+                      "dependent instruction waits one cycle")
+                       .arg(decoded[2] ? QString::fromStdString(format_decoded(*decoded[2]))
+                                       : QStringLiteral("lw"));
         hz_color = t.stall;
     }
     if (hz.isEmpty()) {
@@ -856,10 +853,21 @@ void SchematicDatapathWidget::updateTooltips() {
     const auto& s_ex  = state_.stages[2];
     const auto& s_mem = state_.stages[3];
 
-    auto instr_line = [](const mips::StageSnapshot& s) {
-        if (!s.valid) return QString("—");
+    // Decode each stage once; avoid repeated Decoder::decode() per tooltip line.
+    using OptDecoded = std::optional<mips::DecodedInstr>;
+    const OptDecoded dec0 =
+        (s_if.valid && s_if.raw != 0) ? mips::Decoder::decode(s_if.raw) : std::nullopt;
+    const OptDecoded dec1 =
+        (s_id.valid && s_id.raw != 0) ? mips::Decoder::decode(s_id.raw) : std::nullopt;
+    const OptDecoded dec2 =
+        (s_ex.valid && s_ex.raw != 0) ? mips::Decoder::decode(s_ex.raw) : std::nullopt;
+    const OptDecoded dec3 =
+        (s_mem.valid && s_mem.raw != 0) ? mips::Decoder::decode(s_mem.raw) : std::nullopt;
+
+    auto instr_label = [](const mips::StageSnapshot& s, const OptDecoded& d) -> QString {
+        if (!s.valid) return QStringLiteral("—");
         if (s.raw == 0) return QStringLiteral("nop");
-        return QString::fromStdString(format_instr(s.raw));
+        return d ? QString::fromStdString(format_decoded(*d)) : QStringLiteral("(?/?)");
     };
 
     pc_box_->setToolTip(tr("Program Counter — holds the address of the instruction "
@@ -868,47 +876,43 @@ void SchematicDatapathWidget::updateTooltips() {
 
     imem_box_->setToolTip(tr("Instruction memory — read-only program storage; outputs "
                              "the 32-bit word addressed by PC.\nFetching: %1")
-                              .arg(instr_line(s_if)));
+                              .arg(instr_label(s_if, dec0)));
 
     // Control word of the instruction currently being decoded.
     QString asserted = tr("(none)");
-    if (s_id.valid && s_id.raw != 0) {
-        if (const auto d = mips::Decoder::decode(s_id.raw)) {
-            const mips::Control c = mips::derive_control(*d);
-            QStringList         sig;
-            if (c.reg_write) sig << QStringLiteral("RegWrite");
-            if (c.mem_read) sig << QStringLiteral("MemRead");
-            if (c.mem_write) sig << QStringLiteral("MemWrite");
-            if (c.mem_to_reg) sig << QStringLiteral("MemToReg");
-            if (c.alu_src) sig << QStringLiteral("ALUSrc");
-            if (c.reg_dst) sig << QStringLiteral("RegDst");
-            if (c.branch) sig << QStringLiteral("Branch");
-            if (c.jump) sig << QStringLiteral("Jump");
-            if (!sig.isEmpty()) asserted = sig.join(QStringLiteral(", "));
-        }
+    if (dec1) {
+        const mips::Control c = mips::derive_control(*dec1);
+        QStringList         sig;
+        if (c.reg_write) sig << QStringLiteral("RegWrite");
+        if (c.mem_read) sig << QStringLiteral("MemRead");
+        if (c.mem_write) sig << QStringLiteral("MemWrite");
+        if (c.mem_to_reg) sig << QStringLiteral("MemToReg");
+        if (c.alu_src) sig << QStringLiteral("ALUSrc");
+        if (c.reg_dst) sig << QStringLiteral("RegDst");
+        if (c.branch) sig << QStringLiteral("Branch");
+        if (c.jump) sig << QStringLiteral("Jump");
+        if (!sig.isEmpty()) asserted = sig.join(QStringLiteral(", "));
     }
     control_box_->setToolTip(tr("Control unit — decodes the ID-stage instruction into the "
                                 "control signals that steer the datapath.\nID: %1\nAsserted: %2")
-                                 .arg(instr_line(s_id), asserted));
+                                 .arg(instr_label(s_id, dec1), asserted));
 
     // Register file: show the ID instruction's source operands with live values.
     QString read_line = tr("(idle)");
-    if (s_id.valid && s_id.raw != 0) {
-        if (const auto d = mips::Decoder::decode(s_id.raw)) {
-            uint8_t rs = 0, rt = 0;
-            if (d->format == mips::InstrFormat::R) {
-                rs = d->r().rs;
-                rt = d->r().rt;
-            } else if (d->format == mips::InstrFormat::I) {
-                rs = d->i().rs;
-                rt = d->i().rt;
-            }
-            read_line = QStringLiteral("$%1 = 0x%2   $%3 = 0x%4")
-                            .arg(QString::fromStdString(std::string(mips::register_abi_name(rs))))
-                            .arg(reg_values_[rs], 8, 16, QChar('0'))
-                            .arg(QString::fromStdString(std::string(mips::register_abi_name(rt))))
-                            .arg(reg_values_[rt], 8, 16, QChar('0'));
+    if (dec1) {
+        uint8_t rs = 0, rt = 0;
+        if (dec1->format == mips::InstrFormat::R) {
+            rs = dec1->r().rs;
+            rt = dec1->r().rt;
+        } else if (dec1->format == mips::InstrFormat::I) {
+            rs = dec1->i().rs;
+            rt = dec1->i().rt;
         }
+        read_line = QStringLiteral("$%1 = 0x%2   $%3 = 0x%4")
+                        .arg(QString::fromStdString(std::string(mips::register_abi_name(rs))))
+                        .arg(reg_values_[rs], 8, 16, QChar('0'))
+                        .arg(QString::fromStdString(std::string(mips::register_abi_name(rt))))
+                        .arg(reg_values_[rt], 8, 16, QChar('0'));
     }
     regs_box_->setToolTip(tr("Register file — 32 × 32-bit registers with two read ports "
                              "(ID) and one write port (WB).\nID reads: %1")
@@ -917,19 +921,15 @@ void SchematicDatapathWidget::updateTooltips() {
     alu_item_->setToolTip(tr("ALU — performs the arithmetic/logic operation for the "
                              "EX-stage instruction. Its inputs come through the forwarding "
                              "muxes on the left.\nEX: %1")
-                              .arg(instr_line(s_ex)));
+                              .arg(instr_label(s_ex, dec2)));
 
-    const mips::Control mem_ctl = [&] {
-        if (s_mem.valid && s_mem.raw != 0)
-            if (const auto d = mips::Decoder::decode(s_mem.raw)) return mips::derive_control(*d);
-        return mips::Control{};
-    }();
-    const QString mem_act = mem_ctl.mem_read    ? tr("reading (load)")
-                            : mem_ctl.mem_write ? tr("writing (store)")
-                                                : tr("idle");
+    const mips::Control mem_ctl = dec3 ? mips::derive_control(*dec3) : mips::Control{};
+    const QString       mem_act = mem_ctl.mem_read    ? tr("reading (load)")
+                                  : mem_ctl.mem_write ? tr("writing (store)")
+                                                      : tr("idle");
     dmem_box_->setToolTip(tr("Data memory — the load/store port used in MEM. Only lw/sw "
                              "class instructions touch it.\nMEM: %1 — %2")
-                              .arg(instr_line(s_mem), mem_act));
+                              .arg(instr_label(s_mem, dec3), mem_act));
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────

--- a/src/nsc_quick/quick_simulator.cpp
+++ b/src/nsc_quick/quick_simulator.cpp
@@ -9,6 +9,9 @@
 
 #include <QChar>
 
+#include <memory>
+#include <utility>
+
 namespace nsc::quick {
 
 namespace {
@@ -63,26 +66,31 @@ QVariant RegisterModel::data(const QModelIndex& idx, int role) const {
 }
 
 QHash<int, QByteArray> RegisterModel::roleNames() const {
-    return {
+    static const QHash<int, QByteArray> kRoles = {
         {NumberRole, "number"}, {NameRole, "name"},       {HexRole, "hex"},
         {DecRole, "dec"},       {ChangedRole, "changed"},
     };
+    return kRoles;
 }
 
 void RegisterModel::refresh(const mips::RegisterFile& regs) {
-    const auto& raw     = regs.raw();
-    const int   written = regs.last_written();
+    const auto& raw          = regs.raw();
+    const int   written      = regs.last_written();
+    const int   prev_written = last_written_;
+
+    // Update last_written_ BEFORE emitting dataChanged so data(ChangedRole)
+    // is coherent when QML delegates re-read the model.
+    last_written_ = written;
 
     for (int i = 0; i < 32; ++i) {
         const bool value_changed = values_[static_cast<size_t>(i)] != raw[static_cast<size_t>(i)];
-        const bool mark_changed  = (i == written) != (i == last_written_);
+        const bool mark_changed  = (i == written) != (i == prev_written);
         values_[static_cast<size_t>(i)] = raw[static_cast<size_t>(i)];
         if (value_changed || mark_changed) {
             const QModelIndex mi = index(i);
             emit              dataChanged(mi, mi, {HexRole, DecRole, ChangedRole});
         }
     }
-    last_written_ = written;
 }
 
 void RegisterModel::resetAll() {
@@ -105,12 +113,14 @@ void QuickSimulator::rebuildController() {
 
     stats_ = {};
     trace_.clear();
+    trace_rows_cache_.clear();
     stages_.clear();
     hazards_.clear();
     reg_model_.resetAll();
 
     if (!last_program_.empty()) {
         program_loaded_ = ctl_->loadProgram(last_program_);
+        if (!program_loaded_) emit assemblyError(QStringLiteral("Program too large for memory."));
         emit programLoadedChanged();
     }
 
@@ -172,11 +182,15 @@ void QuickSimulator::reset() {
     ctl_->reset();
     stats_ = {};
     trace_.clear();
+    trace_rows_cache_.clear();
     stages_.clear();
     hazards_.clear();
     reg_model_.resetAll();
 
-    if (!last_program_.empty()) program_loaded_ = ctl_->loadProgram(last_program_);
+    if (!last_program_.empty()) {
+        program_loaded_ = ctl_->loadProgram(last_program_);
+        if (!program_loaded_) emit assemblyError(QStringLiteral("Program too large for memory."));
+    }
 
     emit statsChanged();
     emit traceChanged();
@@ -200,12 +214,20 @@ QString QuickSimulator::assembleAndLoad(const QString& source) {
 
     stats_ = {};
     trace_.clear();
+    trace_rows_cache_.clear();
     reg_model_.resetAll();
 
     emit programLoadedChanged();
     emit statsChanged();
     emit traceChanged();
     emit runningChanged();
+
+    if (!program_loaded_) {
+        const QString msg = QStringLiteral("Program too large for memory.");
+        emit          assemblyError(msg);
+        setStatus(msg);
+        return msg;
+    }
     setStatus(QStringLiteral("Loaded %1 instructions").arg(last_program_.size()));
     return {};
 }
@@ -247,7 +269,7 @@ QStringList QuickSimulator::memoryRows(quint32 base, int rows) const {
             }
             if (b == 7) hex += QLatin1Char(' ');
         }
-        out << QStringLiteral("%1  %2 |%3|").arg(addr, 8, 16, QLatin1Char('0')).arg(hex, ascii);
+        out << QStringLiteral("%1  %2 |%3|").arg(addr, 8, 16, QLatin1Char('0')).arg(hex).arg(ascii);
     }
     return out;
 }
@@ -332,7 +354,7 @@ void QuickSimulator::appendTrace(const mips::PipelineState& ps) {
         row.pc          = if_stage.pc;
         row.start_cycle = cycle;
         row.label =
-            QStringLiteral("%1  %2").arg(hex32(if_stage.pc), disasm(if_stage.raw, if_stage.pc));
+            QStringLiteral("%1  %2").arg(hex32(if_stage.pc)).arg(disasm(if_stage.raw, if_stage.pc));
         trace_.push_back(std::move(row));
         if (trace_.size() > kTraceMaxRows) trace_.erase(trace_.begin());
     }
@@ -357,19 +379,23 @@ void QuickSimulator::appendTrace(const mips::PipelineState& ps) {
             tag = QStringLiteral("**");
         row.cells << tag;
     }
-    emit traceChanged();
-}
 
-QVariantList QuickSimulator::traceRows() const {
-    QVariantList out;
+    // Rebuild the QML-facing cache once per cycle so traceRows() is a free
+    // getter (QML may evaluate the property multiple times per frame).
+    trace_rows_cache_.clear();
+    trace_rows_cache_.reserve(static_cast<qsizetype>(trace_.size()));
     for (const auto& row : trace_) {
         QVariantMap m;
         m.insert(QStringLiteral("label"), row.label);
         m.insert(QStringLiteral("start"), static_cast<qulonglong>(row.start_cycle));
         m.insert(QStringLiteral("cells"), row.cells);
-        out.append(m);
+        trace_rows_cache_.append(m);
     }
-    return out;
+    emit traceChanged();
+}
+
+QVariantList QuickSimulator::traceRows() const {
+    return trace_rows_cache_;
 }
 
 // ── Status ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#102 (D-001)** — RegisterModel QAIM contract: snapshot `last_written_` before emitting `dataChanged` so `data(ChangedRole)` is coherent when QML delegates re-read the model; fixes wrong-register highlight each cycle
- **#106 (D-007, L-015/016)** — All three `QuickSimulator::loadProgram` call sites now check the `bool` return and emit `assemblyError("Program too large for memory.")`; `assembleAndLoad` returns the error string and updates the status bar; two-argument `.arg(a, b)` calls replaced with chained `.arg(a).arg(b)`
- **#107 (D-008/009/010/016/018)** — Performance sweep: encode tables hoisted to file-scope statics; `roleNames()` returns a static `QHash`; `rebuildTable()` uses a per-row O(1) lookup map; `applyState()`/`updateTooltips()` pre-decode stages once per call; `traceRows()` returns a pre-built cache rebuilt only in `appendTrace()`

Additional:
- `cross-platform.yml`: add QADS DLL to PATH on Windows before ctest (fixes 120 s timeout on `qt_ui_test`)
- `ci.yml`: coverage job now runs on same-repo PRs so Codecov posts diff comments
- `CPPLINT.cfg`: suppress `whitespace/braces` to resolve clang-format vs cpplint conflict on `Type{}`

Closes #102
Closes #106
Closes #107

## Test plan

- [ ] `cmake --preset core-only && cmake --build --preset core-only && ctest --preset core-only` — all unit tests pass
- [ ] `cmake --preset debug && cmake --build --preset debug` — full Qt build succeeds
- [ ] Qt Quick UI: load a program, step through it — correct register highlighted each cycle (D-001)
- [ ] Qt Quick UI: load a program too large for memory — error message visible (D-007)
- [ ] CI `full-build` job green (covers D-008 through D-018 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)