### PR TITLE
fixing the cross-platform windows-x64 job, mac os passes

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -137,12 +137,22 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $dll = Get-ChildItem -Recurse -Path build\release\_deps\qtads-build `
+          # qt_standard_project_setup() sets CMAKE_RUNTIME_OUTPUT_DIRECTORY to
+          # the build root, so the QADS DLL lands in build\release\ directly
+          # rather than build\release\_deps\qtads-build\. Search the whole
+          # build tree so this step works regardless of where CMake places it.
+          $dll = Get-ChildItem -Recurse -Path build\release `
                    -Filter "qtadvanceddocking*.dll" |
-                 Where-Object { $_.Name -notmatch 'd\.dll$' } |
+                 Where-Object {
+                   $_.Name -notmatch 'd\.dll$' -and
+                   $_.FullName -notmatch '\\CMakeFiles\\'
+                 } |
+                 Sort-Object FullName |
                  Select-Object -First 1
           if (-not $dll) {
-            Write-Error "QADS DLL not found under build\release\_deps\qtads-build"
+            Write-Error "QADS DLL not found anywhere under build\release"
+            Get-ChildItem -Recurse -Path build\release -File |
+              Select-Object -First 100 FullName
             exit 1
           }
           Write-Host "QADS DLL: $($dll.FullName)"


### PR DESCRIPTION
This pull request updates the Windows build step in the cross-platform workflow to make the search for the QADS DLL more robust and informative. The main improvement is broadening the search path and filtering out unwanted files and directories to ensure the correct DLL is found regardless of CMake output location.

**Build process improvements:**

* The DLL search now starts from `build\releaseThis pull request updates the Windows build step in the cross-platform workflow to make the search for the QADS DLL more robust and informative. The main improvement is broadening the search path and filtering out unwanted files and directories to ensure the correct DLL is found regardless of CMake output location.

**Build process improvements:**

 instead of the more specific `build\release\_deps\qtads-buildThis pull request updates the Windows build step in the cross-platform workflow to make the search for the QADS DLL more robust and informative. The main improvement is broadening the search path and filtering out unwanted files and directories to ensure the correct DLL is found regardless of CMake output location.

**Build process improvements:**

, accommodating changes in where CMake places the output.
* The search excludes files in `CMakeFiles` directories and sorts results to ensure the correct DLL is selected.
* If the DLL is not found, the step outputs the first 100 files found under `build\release` to help with debugging.