### PR TITLE
fixed smoke test hanging

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -240,15 +240,18 @@ jobs:
             local name="$1" bin="$2"
             [ -x "$bin" ] || { echo "::error::$name missing at $bin"; return 1; }
             "$bin" </dev/null >"$name.log" 2>&1 &
-            local pid=$! i=0
-            while proc_alive "$pid"; do
-              sleep 1; i=$((i + 1))
-              if [ "$i" -ge 12 ]; then
-                kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
-                echo "✓ $name survived ${i}s without crashing"; return 0
-              fi
-            done
-            local rc=0; wait "$pid" || rc=$?
+            local pid=$!
+            # Wait 12 s then do one liveness check — avoids spawning a new
+            # pwsh process every second (each costs 1-3 s of startup time).
+            sleep 12
+            if proc_alive "$pid"; then
+              # kill -9 → TerminateProcess on Windows: bypasses WM_CLOSE so
+              # Qt's closeEvent save-dialog can't block the wait indefinitely.
+              kill -9 "$pid" 2>/dev/null || true
+              wait "$pid" 2>/dev/null || true
+              echo "✓ $name survived 12s without crashing"; return 0
+            fi
+            local rc=0; wait "$pid" 2>/dev/null || rc=$?
             if [ "$rc" -eq 0 ]; then echo "✓ $name exited cleanly"; return 0; fi
             echo "::error::$name exited early with code $rc (crash or missing dependency)"
             cat "$name.log" || true; return 1


### PR DESCRIPTION
This pull request optimizes the process liveness check in the `.github/workflows/cross-platform.yml` workflow to reduce unnecessary resource usage and speed up CI runs. Instead of checking every second, the script now waits 12 seconds before performing a single liveness check, which is more efficient and avoids repeatedly spawning new processes.

**CI workflow performance improvements:**

* Changed the process liveness check in the cross-platform workflow to perform a single check after 12 seconds instead of checking every second, reducing the overhead of spawning new `pwsh` processes and improving job speed.
* Updated the process termination logic to use `kill -9` for better reliability on Windows, ensuring processes are forcefully terminated and do not block the workflow.