### PR TITLE
hopefully this works

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     permissions:
       contents: write  # attach installers to the release
 
@@ -159,6 +160,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $dll.DirectoryName
 
       - name: Test
+        timeout-minutes: 10
         run: ctest --test-dir build/release --output-on-failure
 
       # ── Package (bundles Qt via windeployqt/macdeployqt at install time) ─────
@@ -203,12 +205,14 @@ jobs:
       # Runs after the artifact upload (broken build still downloadable) but
       # before the release attach, so broken binaries are never published.
       - name: Smoke-test packaged binaries
+        timeout-minutes: 15
         shell: bash
         run: |
           set -euo pipefail
           stage="$PWD/smoke-stage"
           cmake --install build/release --prefix "$stage"
-          echo "── install tree ──"; find "$stage" -maxdepth 3 -type f | sort
+          # maxdepth 5 shows QML plugin subdirs and other deep deploy artifacts
+          echo "── install tree ──"; find "$stage" -maxdepth 5 -type f | sort
 
           if [ "${{ runner.os }}" = "Windows" ]; then
             gui="$stage/bin/clearCore-gui.exe"
@@ -226,11 +230,12 @@ jobs:
           # stop it. No display is forced — deployqt bundles the native platform
           # plugin (cocoa/qwindows), not offscreen, so the app runs on the
           # runner's own session.
-          # kill -0 is unreliable in Git Bash for native .exe processes; use
-          # PowerShell's Get-Process on Windows to check process liveness.
           proc_alive() {
             if [ "$RUNNER_OS" = "Windows" ]; then
-              pwsh -c "if (Get-Process -Id $1 -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }" 2>/dev/null
+              # tasklist is a built-in Windows command (~100 ms); avoids the
+              # 1-3 s PowerShell startup cost that pwsh -c incurs every call.
+              # Double-slash is the MSYS2 idiom to pass /fi to a Win32 command.
+              tasklist //fi "pid eq $1" //nh 2>/dev/null | grep -qi "\.exe"
             else
               kill -0 "$1" 2>/dev/null
             fi
@@ -239,20 +244,19 @@ jobs:
           smoke() {
             local name="$1" bin="$2"
             [ -x "$bin" ] || { echo "::error::$name missing at $bin"; return 1; }
+            echo "  → $name: launching…"
             "$bin" </dev/null >"$name.log" 2>&1 &
             local pid=$!
-            # Wait 12 s then do one liveness check — avoids spawning a new
-            # pwsh process every second (each costs 1-3 s of startup time).
-            sleep 12
+            sleep 8
             if proc_alive "$pid"; then
               # kill -9 → TerminateProcess on Windows: bypasses WM_CLOSE so
               # Qt's closeEvent save-dialog can't block the wait indefinitely.
               kill -9 "$pid" 2>/dev/null || true
               wait "$pid" 2>/dev/null || true
-              echo "✓ $name survived 12s without crashing"; return 0
+              echo "  ✓ $name survived 8s without crashing"; return 0
             fi
             local rc=0; wait "$pid" 2>/dev/null || rc=$?
-            if [ "$rc" -eq 0 ]; then echo "✓ $name exited cleanly"; return 0; fi
+            if [ "$rc" -eq 0 ]; then echo "  ✓ $name exited cleanly"; return 0; fi
             echo "::error::$name exited early with code $rc (crash or missing dependency)"
             cat "$name.log" || true; return 1
           }
@@ -260,9 +264,10 @@ jobs:
           fail=0
           smoke number_system_converter "$tui" || fail=1
           smoke clearCore-gui "$gui" || fail=1
-          # clearCore-quick is optional (requires Qt6Quick); skip if not installed
           if [ -n "$quick" ] && [ -e "$quick" ]; then
             smoke clearCore-quick "$quick" || fail=1
+          else
+            echo "::notice::clearCore-quick not in install tree — QML smoke test skipped"
           fi
           exit "$fail"
 


### PR DESCRIPTION
hopefully this works
This pull request updates the `.github/workflows/cross-platform.yml` workflow to improve reliability, efficiency, and clarity of the CI process. The main changes include adding timeouts to critical steps, optimizing the smoke test process for speed and clarity, and improving the Windows process liveness check for better performance.

**CI Workflow Improvements**

* Added `timeout-minutes` to the main build, test, and smoke-test jobs to prevent jobs from hanging indefinitely and to ensure better resource management. (`build`: 60 minutes, `Test`: 10 minutes, `Smoke-test packaged binaries`: 15 minutes) [[1]](diffhunk://#diff-8bc7d2f2d308dd6233c8a479ffa5239250be2ce47cb4014d7af34ec0c355c8dcR26) [[2]](diffhunk://#diff-8bc7d2f2d308dd6233c8a479ffa5239250be2ce47cb4014d7af34ec0c355c8dcR163) [[3]](diffhunk://#diff-8bc7d2f2d308dd6233c8a479ffa5239250be2ce47cb4014d7af34ec0c355c8dcR208-R215)

**Smoke Test Enhancements**

* Increased `find` command depth in the smoke test to `-maxdepth 5` to show deeper deploy artifacts, such as QML plugin subdirectories.
* Replaced the PowerShell-based process liveness check on Windows with a much faster `tasklist`-based approach, reducing overhead and improving test speed.
* Reduced the smoke test wait time from 12 seconds to 8 seconds and improved logging to indicate when a binary is being launched and survives the test.
* Added a notice message when the optional `clearCore-quick` binary is missing, clarifying that the QML smoke test is being skipped rather than silently omitted.