### PR TITLE
fix(nsc): reject signed/whitespace/prefixed input in parseBase (#124)

### DIFF
--- a/src/nsc/parse.cpp
+++ b/src/nsc/parse.cpp
@@ -1,11 +1,33 @@
 #include "nsc/parse.h"
 
+#include <string>
+
 namespace nsc {
 
 std::optional<std::uint64_t> parseBase(const std::string& str, int base) {
     // Empty strings are invalid
     if (str.empty()) {
         return std::nullopt;
+    }
+
+    // std::stoull is lenient in ways the contract forbids: it silently accepts a
+    // leading '+'/'-' (wrapping negatives into the unsigned range), surrounding
+    // whitespace, and base-16 "0x" prefixes. Reject anything that is not a plain
+    // digit for `base` up front so those inputs return nullopt as documented.
+    for (const unsigned char c : str) {
+        int digit;
+        if (c >= '0' && c <= '9') {
+            digit = c - '0';
+        } else if (c >= 'a' && c <= 'z') {
+            digit = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'Z') {
+            digit = c - 'A' + 10;
+        } else {
+            return std::nullopt;  // sign, whitespace, '0x' prefix, punctuation, …
+        }
+        if (digit >= base) {
+            return std::nullopt;  // valid character, but not for this base
+        }
     }
 
     try {

--- a/tests/nsc/convert_test.cpp
+++ b/tests/nsc/convert_test.cpp
@@ -34,6 +34,21 @@ void parseTests() {
     EXPECT_EQ(nsc::parseBase("", 10).has_value(), false);     // empty
     EXPECT_EQ(nsc::parseBase("12x", 10).has_value(), false);  // trailing garbage
     EXPECT_EQ(nsc::parseBase("2", 2).has_value(), false);     // not a binary digit
+
+    // Regression (#124): stoull-lenient inputs the contract requires rejecting.
+    EXPECT_EQ(nsc::parseBase("-1", 10).has_value(), false);    // negative sign
+    EXPECT_EQ(nsc::parseBase("-0", 10).has_value(), false);    // negative zero
+    EXPECT_EQ(nsc::parseBase("+5", 10).has_value(), false);    // positive sign
+    EXPECT_EQ(nsc::parseBase(" 7", 10).has_value(), false);    // leading whitespace
+    EXPECT_EQ(nsc::parseBase("7 ", 10).has_value(), false);    // trailing whitespace
+    EXPECT_EQ(nsc::parseBase("0xFF", 16).has_value(), false);  // 0x prefix (base 16)
+    // Overflow past 64 bits must still be rejected.
+    EXPECT_EQ(nsc::parseBase("18446744073709551616", 10).has_value(), false);
+    // Valid inputs across bases remain accepted.
+    EXPECT_EQ(nsc::parseBase("FF", 16).value_or(0), std::uint64_t{255});
+    EXPECT_EQ(nsc::parseBase("ff", 16).value_or(0), std::uint64_t{255});
+    EXPECT_EQ(nsc::parseBase("18446744073709551615", 10).value_or(0),
+              std::uint64_t{18446744073709551615ULL});
 }
 
 void formatTests() {


### PR DESCRIPTION
### What

Fixes #124. `nsc::parseBase` delegated straight to `std::stoull`, which silently accepts inputs the [documented contract](include/nsc/parse.h) says must be rejected: a leading `+`/`-` (wrapping negatives into the unsigned range), surrounding whitespace, and base-16 `0x` prefixes. `parseBase("-1", 10)` returned `18446744073709551615` instead of `nullopt`.

### How

Before delegating to `stoull`, validate that every character is a plain digit valid for the requested `base`. This rejects signs, whitespace, and `0x` prefixes while leaving the 64-bit overflow case to `stoull` (still caught). No behavior change for valid inputs.

### Tests

Added regression assertions in `tests/nsc/convert_test.cpp` for `-1`, `-0`, `+5`, ` 7`, `7 `, `0xFF` (base 16), 64-bit overflow, plus positive cases (`FF`/`ff` base 16, `UINT64_MAX`). Full `core-only` suite passes (21/21).

### Notes

- Also adds a direct `#include <string>` to satisfy the cpplint IWYU hook.
- Base branch is `develop` per project workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce stricter validation in numeric base parsing to reject disallowed input forms and add regression coverage.

Bug Fixes:
- Reject signed, whitespace-padded, and 0x-prefixed inputs in nsc::parseBase instead of accepting them via std::stoull.
- Ensure digits are validated against the specified base before parsing, preventing invalid characters from being interpreted.
- Maintain rejection of 64-bit overflow values while preserving behavior for valid inputs.

Enhancements:
- Include the <string> header explicitly to satisfy IWYU and clarify dependencies in parse.cpp.

Tests:
- Add regression tests for previously accepted invalid inputs and for valid edge cases such as hexadecimal strings and UINT64_MAX in convert_test.cpp.