### PR TITLE
fix(gdb): non-throwing RSP hex parsing + bounded client lengths (#125)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,11 @@ clearcore_add_test(cp0_test tests/mips/cp0_test.cpp mips_core)  # CP0 exception 
 clearcore_add_test(elf_loader_test tests/mips/elf_loader_test.cpp mips_core)  # ELF32 loader
 clearcore_add_test(nsc_tests tests/nsc/convert_test.cpp nsc_core)   # Number conversion
 
+# ---- gdb_stub_test: RSP hex-parser robustness (only when the stub is built) ----
+if (BUILD_GDB_STUB)
+    clearcore_add_test(gdb_stub_test tests/mips/gdb_stub_test.cpp mips_core)
+endif ()
+
 # ---- nyxstone_test: differential Decoder/Disassembler vs LLVM (if enabled) ----
 # Only meaningful when Nyxstone was actually built; mips_core carries the
 # CLEARCORE_NYXSTONE_ENABLED definition either way, so the source also compiles

--- a/include/mips/gdb_stub.h
+++ b/include/mips/gdb_stub.h
@@ -40,6 +40,7 @@
 #include "mips/processor.h"
 
 #include <cstdint>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -55,6 +56,10 @@ public:
 
     GdbStub(const GdbStub&)            = delete;
     GdbStub& operator=(const GdbStub&) = delete;
+
+    // Grants the unit test access to the private, non-throwing hex parsers so the
+    // malformed-input contract can be checked without standing up a TCP session.
+    friend struct GdbStubTestAccess;
 
     // Block until a GDB client connects, then run the RSP event loop.
     // Returns when GDB sends 'k'/'D', or the CPU halts, or the socket drops.
@@ -103,8 +108,12 @@ private:
     static uint8_t     checksum(const std::string& data) noexcept;
     static std::string to_hex_le(uint32_t v);  // 4-byte little-endian hex
     static uint32_t    from_hex_le(const std::string& s, size_t off = 0);
-    static uint32_t    parse_hex(const std::string& s);
-    static std::string hex_byte(uint8_t b);
+    // Non-throwing hex parsers: RSP payloads are attacker-controllable (the
+    // checksum is intentionally unverified), so a malformed field must yield
+    // nullopt rather than throw out of the packet loop and abort the process.
+    static std::optional<uint32_t> parse_hex(const std::string& s);
+    static std::optional<uint8_t>  parse_hex_byte(const std::string& s, std::size_t off);
+    static std::string             hex_byte(uint8_t b);
 
     // Signal number to send for a given StepResult / exception code.
     int stop_signal() const;

--- a/src/mips/gdb_stub.cpp
+++ b/src/mips/gdb_stub.cpp
@@ -3,12 +3,15 @@
 
 #include <algorithm>
 #include <array>
+#include <charconv>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <gsl/gsl>
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <system_error>
 
 // POSIX socket headers — supported on Linux and macOS.
 #include <arpa/inet.h>
@@ -82,7 +85,14 @@ void GdbStub::listen() {
     last_result_ = StepResult::Ok;
     std::string pkt;
     while (recv_packet(pkt)) {
-        dispatch(pkt);
+        // Defense in depth: the individual handlers are written not to throw on
+        // malformed input, but a single bad packet must never abort the whole
+        // emulator, so any stray exception degrades to an RSP error reply.
+        try {
+            dispatch(pkt);
+        } catch (const std::exception&) {
+            send_error(0);
+        }
     }
 }
 
@@ -221,8 +231,23 @@ std::string GdbStub::to_hex_le(uint32_t v) {
     return {buf};
 }
 
-uint32_t GdbStub::parse_hex(const std::string& s) {
-    return static_cast<uint32_t>(std::stoul(s, nullptr, 16));
+std::optional<uint32_t> GdbStub::parse_hex(const std::string& s) {
+    if (s.empty()) return std::nullopt;
+    uint32_t v         = 0;
+    const auto [p, ec] = std::from_chars(s.data(), s.data() + s.size(), v, 16);
+    // from_chars accepts neither sign nor "0x" prefix and never throws; require
+    // the whole string to be consumed so trailing garbage is rejected.
+    if (ec != std::errc{} || p != s.data() + s.size()) return std::nullopt;
+    return v;
+}
+
+std::optional<uint8_t> GdbStub::parse_hex_byte(const std::string& s, std::size_t off) {
+    if (off + 2 > s.size()) return std::nullopt;
+    uint32_t    v      = 0;
+    const char* first  = s.data() + off;
+    const auto [p, ec] = std::from_chars(first, first + 2, v, 16);
+    if (ec != std::errc{} || p != first + 2) return std::nullopt;
+    return static_cast<uint8_t>(v);
 }
 
 // ─── Stop signal ─────────────────────────────────────────────────────────────
@@ -262,12 +287,13 @@ std::string GdbStub::handle_read_regs() {
 bool GdbStub::handle_write_regs(const std::string& hex) {
     if (hex.size() < static_cast<size_t>(kNumRegs * 8)) return false;
     for (int i = 0; i < kNumRegs; ++i) {
-        const std::string chunk = hex.substr(static_cast<size_t>(i) * 8, 8);
         // Little-endian: LSB is at the lowest address in the hex string.
         uint32_t v = 0;
         for (int b = 0; b < 4; ++b) {
-            const std::string byte_str = chunk.substr(static_cast<size_t>(b) * 2, 2);
-            v |= static_cast<uint32_t>(std::stoul(byte_str, nullptr, 16)) << (b * 8);
+            const auto byte =
+                parse_hex_byte(hex, static_cast<size_t>(i) * 8 + static_cast<size_t>(b) * 2);
+            if (!byte) return false;
+            v |= static_cast<uint32_t>(*byte) << (b * 8);
         }
         write_gdb_reg(i, v);
     }
@@ -275,35 +301,43 @@ bool GdbStub::handle_write_regs(const std::string& hex) {
 }
 
 std::string GdbStub::handle_read_reg(const std::string& args) {
-    const int n = static_cast<int>(parse_hex(args));
-    if (n >= kNumRegs) return "E01";
-    return to_hex_le(read_gdb_reg(n));
+    const auto n = parse_hex(args);
+    if (!n || *n >= static_cast<uint32_t>(kNumRegs)) return "E01";
+    return to_hex_le(read_gdb_reg(static_cast<int>(*n)));
 }
 
 bool GdbStub::handle_write_reg(const std::string& args) {
     const size_t eq = args.find('=');
     if (eq == std::string::npos) return false;
-    const int n = static_cast<int>(parse_hex(args.substr(0, eq)));
-    if (n >= kNumRegs) return false;
-    const std::string& vs = args.substr(eq + 1);
-    uint32_t           v  = 0;
-    for (int b = 0; b < 4 && b * 2 + 1 < static_cast<int>(vs.size()); ++b)
-        v |=
-            static_cast<uint32_t>(std::stoul(vs.substr(static_cast<size_t>(b) * 2, 2), nullptr, 16))
-            << (b * 8);
-    write_gdb_reg(n, v);
+    const auto n = parse_hex(args.substr(0, eq));
+    if (!n || *n >= static_cast<uint32_t>(kNumRegs)) return false;
+    const std::string vs = args.substr(eq + 1);
+    uint32_t          v  = 0;
+    // GDB may send fewer than 4 bytes; consume what is present, stop at the first
+    // incomplete/invalid byte.
+    for (int b = 0; b < 4; ++b) {
+        const auto byte = parse_hex_byte(vs, static_cast<size_t>(b) * 2);
+        if (!byte) break;
+        v |= static_cast<uint32_t>(*byte) << (b * 8);
+    }
+    write_gdb_reg(static_cast<int>(*n), v);
     return true;
 }
 
 std::string GdbStub::handle_read_mem(const std::string& args) {
     const size_t comma = args.find(',');
     if (comma == std::string::npos) return "E01";
-    const uint32_t addr = parse_hex(args.substr(0, comma));
-    const uint32_t len  = parse_hex(args.substr(comma + 1));
+    const auto addr = parse_hex(args.substr(0, comma));
+    const auto len  = parse_hex(args.substr(comma + 1));
+    if (!addr || !len) return "E01";
+    // Clamp the requested length to the physical memory size: `len` is
+    // attacker-controlled, and reserving `len * 2` for a bogus value would
+    // otherwise drive a multi-gigabyte allocation before the bounds check runs.
+    const uint32_t n = std::min<uint32_t>(*len, static_cast<uint32_t>(cpu_.mem().size()));
     std::string    out;
-    out.reserve(len * 2);
-    for (uint32_t i = 0; i < len; ++i) {
-        const auto b = cpu_.mem().read_byte(addr + i);
+    out.reserve(static_cast<size_t>(n) * 2);
+    for (uint32_t i = 0; i < n; ++i) {
+        const auto b = cpu_.mem().read_byte(*addr + i);
         if (!b) return "E02";  // OOB
         out += hex_byte(*b);
     }
@@ -313,15 +347,15 @@ std::string GdbStub::handle_read_mem(const std::string& args) {
 bool GdbStub::handle_write_mem(const std::string& args) {
     const size_t colon = args.find(':');
     const size_t comma = args.find(',');
-    if (colon == std::string::npos || comma == std::string::npos) return false;
-    const uint32_t     addr = parse_hex(args.substr(0, comma));
-    const uint32_t     len  = parse_hex(args.substr(comma + 1, colon - comma - 1));
-    const std::string& hex  = args.substr(colon + 1);
-    for (uint32_t i = 0; i < len; ++i) {
-        if (i * 2 + 1 >= hex.size()) return false;
-        const uint8_t byte = static_cast<uint8_t>(
-            std::stoul(hex.substr(static_cast<size_t>(i) * 2, 2), nullptr, 16));
-        if (!cpu_.mem().write_byte(addr + i, byte)) return false;
+    if (colon == std::string::npos || comma == std::string::npos || comma > colon) return false;
+    const auto addr = parse_hex(args.substr(0, comma));
+    const auto len  = parse_hex(args.substr(comma + 1, colon - comma - 1));
+    if (!addr || !len) return false;
+    const std::string hex = args.substr(colon + 1);
+    for (uint32_t i = 0; i < *len; ++i) {
+        const auto byte = parse_hex_byte(hex, static_cast<size_t>(i) * 2);
+        if (!byte) return false;  // truncated or non-hex payload
+        if (!cpu_.mem().write_byte(*addr + i, *byte)) return false;
     }
     return true;
 }
@@ -365,13 +399,21 @@ void GdbStub::handle_breakpoint_set(const std::string& args) {
         send_error(1);
         return;
     }
-    const int type = static_cast<int>(parse_hex(args.substr(0, c1)));
-    if (type != 0) {
+    const auto type = parse_hex(args.substr(0, c1));
+    if (!type) {
+        send_error(1);
+        return;
+    }
+    if (*type != 0) {
         send_empty();
         return;
     }  // unsupported breakpoint type
-    const uint32_t addr = parse_hex(args.substr(c1 + 1, c2 - c1 - 1));
-    insert_breakpoint(addr) ? send_ok() : send_error(1);
+    const auto addr = parse_hex(args.substr(c1 + 1, c2 - c1 - 1));
+    if (!addr) {
+        send_error(1);
+        return;
+    }
+    insert_breakpoint(*addr) ? send_ok() : send_error(1);
 }
 
 void GdbStub::handle_breakpoint_clear(const std::string& args) {
@@ -385,19 +427,29 @@ void GdbStub::handle_breakpoint_clear(const std::string& args) {
         send_error(1);
         return;
     }
-    const int type = static_cast<int>(parse_hex(args.substr(0, c1)));
-    if (type != 0) {
+    const auto type = parse_hex(args.substr(0, c1));
+    if (!type) {
+        send_error(1);
+        return;
+    }
+    if (*type != 0) {
         send_empty();
         return;
     }
-    const uint32_t addr = parse_hex(args.substr(c1 + 1, c2 - c1 - 1));
-    remove_breakpoint(addr) ? send_ok() : send_error(1);
+    const auto addr = parse_hex(args.substr(c1 + 1, c2 - c1 - 1));
+    if (!addr) {
+        send_error(1);
+        return;
+    }
+    remove_breakpoint(*addr) ? send_ok() : send_error(1);
 }
 
 // ─── Continue / step ──────────────────────────────────────────────────────────
 
 void GdbStub::handle_continue(const std::string& args) {
-    if (!args.empty()) cpu_.set_pc(parse_hex(args));
+    if (!args.empty()) {
+        if (const auto pc = parse_hex(args)) cpu_.set_pc(*pc);
+    }
 
     running_ = true;
     while (running_) {
@@ -431,7 +483,9 @@ void GdbStub::handle_continue(const std::string& args) {
 }
 
 void GdbStub::handle_step(const std::string& args) {
-    if (!args.empty()) cpu_.set_pc(parse_hex(args));
+    if (!args.empty()) {
+        if (const auto pc = parse_hex(args)) cpu_.set_pc(*pc);
+    }
 
     last_result_ = cpu_.step();
     if (last_result_ == StepResult::Exception) {

--- a/tests/mips/gdb_stub_test.cpp
+++ b/tests/mips/gdb_stub_test.cpp
@@ -1,0 +1,74 @@
+// GDB stub robustness tests (#125).
+//
+// The RSP handlers parse attacker-controllable hex fields from packets whose
+// checksum is intentionally unverified. Previously they delegated to std::stoul,
+// which throws std::invalid_argument / std::out_of_range on malformed or
+// oversized input; nothing between the handler and the packet loop caught it, so
+// a single bad packet aborted the emulator. These tests pin the replacement
+// parsers' contract: valid → value, everything else → nullopt, never throw.
+
+#include "mips/gdb_stub.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <optional>
+#include <string>
+
+static int g_passed = 0, g_failed = 0;
+
+#define CHECK(expr)                                                                                \
+    do {                                                                                           \
+        if (expr) {                                                                                \
+            ++g_passed;                                                                            \
+        } else {                                                                                   \
+            std::fprintf(stderr, "FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);                  \
+            ++g_failed;                                                                            \
+        }                                                                                          \
+    } while (false)
+
+namespace mips {
+
+// Test seam: forwards to the private static parsers (see friend decl in gdb_stub.h).
+struct GdbStubTestAccess {
+    static std::optional<uint32_t> parse_hex(const std::string& s) { return GdbStub::parse_hex(s); }
+    static std::optional<uint8_t>  parse_hex_byte(const std::string& s, std::size_t off) {
+        return GdbStub::parse_hex_byte(s, off);
+    }
+};
+
+}  // namespace mips
+
+int main() {
+    using mips::GdbStubTestAccess;
+
+    // ── parse_hex: valid input ────────────────────────────────────────────────
+    CHECK(GdbStubTestAccess::parse_hex("0").value_or(1) == 0u);
+    CHECK(GdbStubTestAccess::parse_hex("ff").value_or(0) == 0xffu);
+    CHECK(GdbStubTestAccess::parse_hex("FF").value_or(0) == 0xffu);
+    CHECK(GdbStubTestAccess::parse_hex("deadbeef").value_or(0) == 0xdeadbeefu);
+    CHECK(GdbStubTestAccess::parse_hex("ffffffff").value_or(0) == 0xffffffffu);
+
+    // ── parse_hex: malformed input must be nullopt, not a thrown exception ─────
+    CHECK(!GdbStubTestAccess::parse_hex("").has_value());           // empty
+    CHECK(!GdbStubTestAccess::parse_hex("zz").has_value());         // non-hex
+    CHECK(!GdbStubTestAccess::parse_hex("12g4").has_value());       // trailing garbage
+    CHECK(!GdbStubTestAccess::parse_hex("0xFF").has_value());       // 0x prefix rejected
+    CHECK(!GdbStubTestAccess::parse_hex("-1").has_value());         // sign rejected
+    CHECK(!GdbStubTestAccess::parse_hex(" 4").has_value());         // leading whitespace
+    CHECK(!GdbStubTestAccess::parse_hex("100000000").has_value());  // > 32 bits overflows
+
+    // ── parse_hex_byte: exactly two hex digits at the given offset ─────────────
+    CHECK(GdbStubTestAccess::parse_hex_byte("ab", 0).value_or(0) == 0xabu);
+    CHECK(GdbStubTestAccess::parse_hex_byte("00ff", 2).value_or(0) == 0xffu);
+    CHECK(!GdbStubTestAccess::parse_hex_byte("a", 0).has_value());   // too short
+    CHECK(!GdbStubTestAccess::parse_hex_byte("ab", 2).has_value());  // offset past end
+    CHECK(!GdbStubTestAccess::parse_hex_byte("zz", 0).has_value());  // non-hex
+    CHECK(!GdbStubTestAccess::parse_hex_byte("0x", 0).has_value());  // prefix, not a byte
+
+    if (g_failed == 0) {
+        std::printf("All %d gdb_stub tests passed.\n", g_passed);
+        return 0;
+    }
+    std::printf("%d of %d gdb_stub tests failed.\n", g_failed, g_passed + g_failed);
+    return 1;
+}


### PR DESCRIPTION
### What

Fixes #125. The GDB stub's RSP handlers parsed attacker-controllable packet fields (the checksum is intentionally unverified) straight through `std::stoul`, which throws `std::invalid_argument`/`std::out_of_range` on malformed or oversized input. Nothing between the handler and the `while (recv_packet) dispatch()` loop in `listen()` caught it, so a single bad packet — e.g. `$mzz,4#00` — aborted the whole emulator. The `m` handler additionally did `out.reserve(len * 2)` on an unvalidated client length, allowing a multi-gigabyte allocation before the bounds check.

### How

- **`parse_hex` → non-throwing** `std::optional<uint32_t>` via `std::from_chars` (rejects signs, `0x` prefixes, whitespace, trailing garbage, and >32-bit overflow; never throws).
- **New `parse_hex_byte`** for the two-hex-digit fields, replacing the inline `std::stoul` calls in the register/memory write paths.
- **All call sites updated** to reply with an RSP error (`E01`/`E02`) or `false` instead of unwinding.
- **Length clamp** in `handle_read_mem`: the requested length is capped to physical memory size before reserving.
- **Defense in depth**: `dispatch()` is wrapped in try/catch in the packet loop so no future handler can tear down the session.
- Removed nothing behavioral for well-formed GDB traffic.

### Tests

New `tests/mips/gdb_stub_test.cpp` (registered under `BUILD_GDB_STUB`) pins the parser contract — valid inputs decode, malformed/oversized inputs return `nullopt` and never throw — via a small `friend` test seam. Full `core-only` suite passes (22/22).

### Notes

- Deliberately **not** a socket/thread integration test: this repo just finished fixing smoke-test hangs (#121), so I kept the test hermetic and fast rather than standing up a live TCP session.
- Base branch is `develop` per project workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden GDB RSP hex parsing and memory access against malformed or attacker-controlled input while ensuring the emulator remains robust.

Bug Fixes:
- Prevent emulator aborts by replacing throwing std::stoul-based hex parsing with non-throwing, validated parsers that return RSP errors on malformed input.
- Clamp GDB memory read lengths to physical memory size to avoid excessive allocations and out-of-bounds accesses.
- Ensure invalid breakpoint and register/memory operations return appropriate errors instead of crashing or misbehaving.

Enhancements:
- Wrap the GDB packet dispatch loop in a safety net that converts unexpected handler exceptions into protocol errors instead of terminating the session.

Tests:
- Add a dedicated gdb_stub test that validates the new non-throwing hex parser behavior for valid, malformed, and overflowing inputs.