### PR TITLE
chore: pin remaining CI dependencies by SHA/digest for OpenSSF Scorecard

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder:v1
+FROM gcr.io/oss-fuzz-base/base-builder:v1@sha256:93e48e3853730255e873f9f3c63c90f3dfc298edd85fe3c02c0b9d399b87a80a
 RUN apt-get update && apt-get install -y cmake ninja-build
 COPY . $SRC/clearCore
 COPY .clusterfuzzlite/build.sh $SRC/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     groups:
       actions:
         patterns: ['*']
+
+  # The base-builder image is pinned by digest (see .clusterfuzzlite/Dockerfile)
+  # for Scorecard's Pinned-Dependencies check; without this, that digest would
+  # never move and the fuzzing environment would silently go stale.
+  - package-ecosystem: docker
+    directory: /.clusterfuzzlite
+    schedule:
+      interval: weekly

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -15,17 +15,31 @@ jobs:
   PR:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Build Fuzzers
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: c++
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 120
           mode: 'code-change'
           output-sarif: true
+
+      # run_fuzzers only writes the SARIF file; it doesn't upload it. Without
+      # this step security-events:write above is requested but never used.
+      - name: Upload crash SARIF
+        if: always() && steps.build.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          sarif_file: cifuzz-sarif/results.sarif
+          checkout_path: cifuzz-sarif

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -87,11 +87,16 @@ jobs:
           # choco can return exit 0 even when the community feed is down (503),
           # leaving NSIS uninstalled and cpack unable to find makensis. Retry
           # until makensis actually exists on disk.
+          #
+          # Version pinned for Scorecard's Pinned-Dependencies check. Dependabot
+          # has no Chocolatey ecosystem, so this needs a manual bump occasionally
+          # — check https://community.chocolatey.org/packages/nsis for the
+          # current release.
           makensis="/c/Program Files (x86)/NSIS/makensis.exe"
           for attempt in 1 2 3 4 5; do
             [ -f "$makensis" ] && { echo "NSIS present"; exit 0; }
             echo "Installing NSIS (attempt $attempt)…"
-            choco install nsis --no-progress -y || true
+            choco install nsis --version=3.12.0 --no-progress -y || true
             [ -f "$makensis" ] && { echo "NSIS installed"; exit 0; }
             sleep 20
           done

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,11 +17,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- Pins the last unpinned refs flagged by Scorecard's Pinned-Dependencies check: `google/clusterfuzzlite` actions, `step-security/harden-runner`, `release-drafter/release-drafter` in `release-drafter.yml`, the `oss-fuzz-base/base-builder` image digest, and the NSIS choco install version.
- Adds the missing `harden-runner` step to `cflite_pr.yml`'s `PR` job (CLAUDE.md requires it on every job).
- Wires up a SARIF-upload step for ClusterFuzzLite crash results in `cflite_pr.yml` so its existing `security-events: write` permission is actually used (matches Google's own reference `example_cifuzz.yml` verbatim).
- Adds a `docker` Dependabot ecosystem entry scoped to `.clusterfuzzlite/` so the newly-pinned base image digest doesn't silently go stale.

## Test plan
- [x] All pinned SHAs/digest verified against live GitHub API / container registry to match their claimed tags
- [x] New SARIF-upload condition cross-checked against Google's canonical ClusterFuzzLite example workflow
- [x] CI (`ci.yml`, `cflite_pr.yml`) runs green on this PR
- [x] Confirm the ClusterFuzzLite PR job's SARIF upload step succeeds and (if any findings) shows up under Security > Code scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin remaining CI and workflow dependencies for OpenSSF Scorecard compliance and wire ClusterFuzzLite crash results into code scanning.

New Features:
- Upload ClusterFuzzLite crash SARIF reports in the PR workflow so fuzzing findings appear in GitHub code scanning.
- Enable Dependabot monitoring for the ClusterFuzzLite base-builder Docker image to keep the pinned digest up to date.

Enhancements:
- Add harden-runner to the ClusterFuzzLite PR job and pin its version for consistent security auditing across workflows.
- Pin google/clusterfuzzlite action versions by commit SHA in the PR workflow to avoid floating refs.
- Pin the release-drafter action version by commit SHA for reproducible release automation.
- Pin the oss-fuzz base-builder image by digest in the ClusterFuzzLite Dockerfile to satisfy pinned-dependencies checks.
- Pin the NSIS Chocolatey package version in the cross-platform workflow for predictable Windows installer builds.

CI:
- Tighten CI workflows by requiring pinned SHAs/digests for key actions and images to align with OpenSSF Scorecard Pinned-Dependencies guidance.

Tests:
- Ensure fuzzing CI job outputs are integrated with GitHub code scanning via SARIF upload without altering existing fuzzing behavior.