### PR TITLE
fix: correct project version and citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -38,6 +38,6 @@ keywords:
   - qt6
   - terminal-ui
 license: MIT
-version: 0.1.0
-date-released: '2026-07-04'
+version: 0.3.4
+date-released: '2026-07-09'
 doi: 10.5281/zenodo.21194876

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 project(clearCore
-        VERSION 0.1.0
+        VERSION 0.3.4
         LANGUAGES CXX C  # C may be needed by some dependencies
         DESCRIPTION "Educational MIPS CPU emulator with pipeline visualization"
 )


### PR DESCRIPTION
## Summary
- `CMakeLists.txt` (`project(clearCore VERSION ...)`) and `CITATION.cff` were still at `0.1.0` / `date-released: '2026-07-04'` while `CHANGELOG.md` had already reached `## [0.3.4] - 2026-07-09`.
- Release/cross-platform workflows override the combined `CPACK_PACKAGE_VERSION` from the git tag, so packaged tarball/installer filenames were correct — but `CPACK_PACKAGE_VERSION_MAJOR/MINOR/PATCH`, `CPACK_DMG_VOLUME_NAME`, and any in-tree `--version` string derived from `PROJECT_VERSION` directly were stale at 0.1.0.
- Bumped both files to `0.3.4` / `2026-07-09` to match the changelog.

## DOI note
`CITATION.cff`'s `doi: 10.5281/zenodo.21194876` was left **unchanged**. It resolves (via `doi.org`) to whatever the current latest-version Zenodo record is — currently v0.3.5 — which is consistent with it being the Zenodo *concept* DOI rather than a version-pinned one. I could not conclusively confirm this from the fetched page content (no explicit "concept DOI" label rendered), so per the "don't guess a DOI" guidance I left it as-is. Worth a manual check on the Zenodo dashboard.

## Long-term source of truth
Recommend option (b) from the audit: have `update-changelog.yml` (or a small release step) also bump `project(VERSION)` and `CITATION.cff` automatically, so these can't drift from `CHANGELOG.md` again. Not implemented in this PR.

## Test plan
- [x] `grep -n VERSION CMakeLists.txt` and `grep version CITATION.cff` show `0.3.4`
- [ ] `cmake --preset core-only` configures cleanly — **not verified**, `cmake` wasn't available in the environment this PR was prepared in; please confirm in CI/locally.
- [ ] If feasible, `cpack -G DEB` on a release-preset build shows the correct version in package metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align project version and citation metadata with the latest released version.

Bug Fixes:
- Correct stale project VERSION in CMake configuration so in-tree version strings match the current release.
- Update CITATION.cff release version/date to be consistent with the changelog and packaged artifacts.