### PR TITLE
fix(ci): correct cflite PR path filter

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'src/**'
       - 'include/**'
-      - 'fuzz/**'
+      - 'tests/fuzz/**'
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
## Summary
- `cflite_pr.yml`'s `paths:` filter listed `fuzz/**`, but no top-level `fuzz/` directory exists — the ClusterFuzzLite harness lives at `tests/fuzz/fuzz_hex_loader.cpp` (matches `cflite_batch.yml`'s header comment, the README, and the wiki).
- A PR touching only the fuzz harness would silently fail to trigger PR fuzzing; the bug was masked because `src/**`/`include/**` changes still fire the job in the common case.
- Changed `'fuzz/**'` to `'tests/fuzz/**'`.

## Test plan
- [x] `grep -n "tests/fuzz" .github/workflows/cflite_pr.yml` returns the path filter
- [x] No remaining bare `'fuzz/**'` in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Adjust cflite_pr workflow path filter to use tests/fuzz/** instead of the non-existent fuzz/** directory.