### PR TITLE
ci: align CodeQL/fuzz PR coverage with develop

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,7 +1,7 @@
 name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'src/**'
       - 'include/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   schedule:
     - cron: '30 6 * * 1'  # weekly, Monday 06:30 UTC
 


### PR DESCRIPTION
## Summary
- Branch model is feature -> `develop` -> (auto promotion PR) -> `main`. `gitleaks.yml`, `zizmor.yml`, and `ci.yml` already trigger `pull_request` on both `main` and `develop`; `codeql.yml` and `cflite_pr.yml` triggered on `main` only.
- That meant CodeQL and PR-fuzzing only ran on the `develop -> main` promotion PR (plus CodeQL's weekly schedule) — never on the feature PRs where the code is actually reviewed.
- Went with Option A (shift-left) from the CI audit: added `develop` to `pull_request.branches` in both workflows, matching gitleaks/zizmor/ci. Cost is more Actions minutes on feature PRs (CodeQL's C++ build is the expensive one; it's already ccache-free by design so that cost was already being paid on `main`-targeted PRs).

## Test plan
- [x] `codeql.yml` and `cflite_pr.yml` both list `develop` under `pull_request.branches`
- [x] Confirm CodeQL/fuzz actually fire on the next `develop`-targeted PR (can't observe from this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Run CodeQL analysis and ClusterFuzzLite PR fuzzing on pull requests targeting both main and develop branches.

CI:
- Expand CodeQL workflow pull_request coverage to include the develop branch.
- Expand ClusterFuzzLite PR fuzzing workflow pull_request coverage to include the develop branch.